### PR TITLE
ZWave Heal Modifications

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveNetworkMonitor.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveNetworkMonitor.java
@@ -252,12 +252,21 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 		// The list is built multiple times since it seems that in order to
 		// fully optimize the network, this is required
 		for (ZWaveNode node : zController.getNodes()) {
-			// Ignore devices that haven't initialized yet - unless they are
+			// Ignore devices that haven't initialized yet, not listening or is the controller - unless they are
 			// DEAD.
 			if (node.isInitializationComplete() == false && node.isDead() == false) {
 				logger.debug("NODE {}: Initialisation NOT yet complete. Skipping heal.", node.getNodeId());
 				continue;
 			}
+			if (node.isListening() == false) {
+				logger.debug("NODE {}: Not listening. Skipping heal.", node.getNodeId());
+				continue;
+			}
+			if (node.getNodeId() == zController.getOwnNodeId()) {
+				logger.debug("NODE {}: Is Controller. Skipping heal.", node.getNodeId());
+				continue;
+			}
+			logger.debug("NODE {}: Attempting to heal node.", node.getNodeId());
 
 			healNode(node.getNodeId());
 		}

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeStageAdvancer.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeStageAdvancer.java
@@ -67,7 +67,7 @@ public class ZWaveNodeStageAdvancer {
 	 * stages
 	 */
 	public void advanceNodeStage(NodeStage targetStage) {
-		if (targetStage.getStage() <= this.node.getNodeStage().getStage() && targetStage != NodeStage.DONE) {
+		if (targetStage.getStage() <= this.node.getNodeStage().getStage() && targetStage != NodeStage.DONE && targetStage != NodeStage.DEAD) {
 			logger.warn(String.format("NODE %d: Already in or beyond node stage, ignoring. current = %s, requested = %s", this.node.getNodeId(),
 					this.node.getNodeStage().getLabel(), targetStage.getLabel()));
 			return;


### PR DESCRIPTION
Do not attempt to heal nodes that are marked as Dead or the Main
Controller
Added debug logging to aid troubleshooting during heal processing

Allow a Dead node to advance back to alive. Fixes a problem with some
devices not init according to sequence.