### PR TITLE
Zwave polling - make period configurable

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveActiveBinding.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveActiveBinding.java
@@ -56,6 +56,7 @@ public class ZWaveActiveBinding extends AbstractActiveBinding<ZWaveBindingProvid
 	private boolean isSUC = false;
 	private boolean softReset = false;
 	private Integer healtime = null;
+	private Integer aliveCheckPeriod = null;
 	private Integer timeout = null;
 	private volatile ZWaveController zController;
 	private volatile ZWaveConverterHandler converterHandler;
@@ -277,6 +278,9 @@ public class ZWaveActiveBinding extends AbstractActiveBinding<ZWaveBindingProvid
 			if(healtime != null) {
 				this.networkMonitor.setHealTime(healtime);
 			}
+			if(aliveCheckPeriod != null) {
+				this.networkMonitor.setPollPeriod(aliveCheckPeriod);
+			}
 			if(softReset != false) {
 				this.networkMonitor.resetOnError(softReset);
 			}
@@ -330,6 +334,15 @@ public class ZWaveActiveBinding extends AbstractActiveBinding<ZWaveBindingProvid
 			} catch (NumberFormatException e) {
 				pollingQueue = 2;
 				logger.error("Error parsing 'pollingQueue'. This must be a single number time in milliseconds.");
+			}
+		}
+		if (StringUtils.isNotBlank((String) config.get("aliveCheckPeriod"))) {
+			try {
+				aliveCheckPeriod = Integer.parseInt((String) config.get("aliveCheckPeriod"));
+				logger.info("Update config, aliveCheckPeriod = {}", aliveCheckPeriod);
+			} catch (NumberFormatException e) {
+				aliveCheckPeriod = null;
+				logger.error("Error parsing 'aliveCheckPeriod'. This must be an Integer.");
 			}
 		}
 		if (StringUtils.isNotBlank((String) config.get("timeout"))) {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveNetworkMonitor.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveNetworkMonitor.java
@@ -331,7 +331,8 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 
 			// We now have the oldest node that we've heard from - ping it!
 			// If we've actually received from this node recently, the don't bother to ping
-			if (oldestNode != null && oldestNode.getLastReceived().getTime() < System.currentTimeMillis() - pollPeriod) {
+			if (oldestNode != null && oldestNode.getLastReceived() != null &&
+					oldestNode.getLastReceived().getTime() < System.currentTimeMillis() - pollPeriod) {
 				logger.debug("NODE {}: Sending periodic PING.", oldestNode.getNodeId());
 
 				// Reset the resend count - also resets the lastUpdate timer

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveNetworkMonitor.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveNetworkMonitor.java
@@ -126,19 +126,24 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 	 *            the hour of the heal (0-23)
 	 */
 	public void setHealTime(Integer time) {
-		if (time == null)
+		if (time == null) {
 			networkHealNightlyHour = -1;
-		else
+		}
+		else {
 			networkHealNightlyHour = time;
+		}
 
 		// Sanity check
-		if (networkHealNightlyHour > 23)
+		if (networkHealNightlyHour > 23) {
 			networkHealNightlyHour = -1;
-		if (networkHealNightlyHour < 0)
+		}
+		else if (networkHealNightlyHour < 0) {
 			networkHealNightlyHour = -1;
+		}
 
-		if (initialised == false)
+		if (initialised == false) {
 			return;
+		}
 
 		// Calculate the next heal time
 		networkHealNightlyTime = calculateNextHeal();
@@ -245,10 +250,12 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 		heal.lastChange = Calendar.getInstance().getTime();
 
 		// Find out if this is a listening device
-		if (node.isListening())
+		if (node.isListening()) {
 			heal.listening = true;
-		else
+		}
+		else {
 			heal.listening = false;
+		}
 		healNodes.put(nodeId, heal);
 
 		// Start the first heal next time around the loop
@@ -277,8 +284,9 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 			healNode(node.getNodeId());
 		}
 
-		if (healNodes.size() == 0)
+		if (healNodes.size() == 0) {
 			return false;
+		}
 
 		// If we want to do a soft reset on the controller, do it now....
 		if(doSoftReset == true) {
@@ -297,7 +305,7 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 	public void execute() {
 		// Don't start the next node if there's a queue
 		if (zController.getSendQueueLength() > 1) {
-			logger.debug("Queue length is {} - deferring HEAL.", zController.getSendQueueLength());
+			logger.debug("Network Monitor: Queue length is {} - deferring network monitor functions.", zController.getSendQueueLength());
 			return;
 		}
 
@@ -331,8 +339,12 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 
 				ZWaveNoOperationCommandClass zwaveCommandClass = (ZWaveNoOperationCommandClass) oldestNode
 						.getCommandClass(CommandClass.NO_OPERATION);
-				if (zwaveCommandClass != null)
+				if (zwaveCommandClass != null) {
 					zController.sendData(zwaveCommandClass.getNoOperationMessage());
+				}
+			}
+			else {
+				logger.debug("Network Monitor: No nodes to ping!");
 			}
 
 			// To reduce congestion, we don't do anything else during this
@@ -388,9 +400,12 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 	 *            The node on which to perform the heal
 	 */
 	private void nextHealStage(HealNode healing) {
+		logger.debug("NODE {}: Heal advancing - state {}, retries {}", healing.state, healing.retryCnt);
+
 		// Don't do anything if it's failed already
-		if (healing.state == HealState.FAILED)
+		if (healing.state == HealState.FAILED) {
 			return;
+		}
 
 		healing.lastChange = Calendar.getInstance().getTime();
 
@@ -399,25 +414,34 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 		// to avoid congestion and false timeouts.
 		pingNodeTime = System.currentTimeMillis() + HEAL_TIMEOUT_PERIOD + 20000;
 
+		// Set the timeout
+		networkHealNextTime = System.currentTimeMillis() + HEAL_TIMEOUT_PERIOD;
+
 		// Handle retries
 		healing.retryCnt++;
 		if (healing.retryCnt >= HEAL_MAX_RETRIES) {
-			logger.debug("NODE {}: Network heal has exceeded maximum retries", healing.nodeId);
-			healing.failState = healing.state;
-			healing.state = HealState.FAILED;
-			networkHealNextTime = System.currentTimeMillis() + HEAL_DELAY_PERIOD;
+			logger.debug("NODE {}: Maximum retries in state {}", healing.nodeId, healing.state);
 
-			// Save the XML file. This serialises the data we've just updated
-			// (neighbors etc)
-			healing.node.setHealState(this.getNodeState(healing.node.getNodeId()));
-			
-			ZWaveNodeSerializer nodeSerializer = new ZWaveNodeSerializer();
-			nodeSerializer.SerializeNode(healing.node);
-			return;
+			// Since the GETNEIGHBORS state fails often, it seems better to
+			// continue with the heal than to abort here.
+			if (healing.state == HealState.UPDATENEIGHBORS) {
+				healing.state = healing.stateNext;
+				logger.debug("NODE {}: Heal - continuing to state {}", healing.nodeId, healing.stateNext);
+			} else {
+				logger.debug("NODE {}: Network heal has exceeded maximum retries!", healing.nodeId);
+				healing.failState = healing.state;
+				healing.state = HealState.FAILED;
+	
+				// Save the XML file. This serialises the data we've just updated
+				// (neighbors etc)
+				healing.node.setHealState(this.getNodeState(healing.node.getNodeId()));
+				
+				ZWaveNodeSerializer nodeSerializer = new ZWaveNodeSerializer();
+				nodeSerializer.SerializeNode(healing.node);
+
+				return;
+			}
 		}
-
-		// Set the timeout
-		networkHealNextTime = System.currentTimeMillis() + HEAL_TIMEOUT_PERIOD;
 
 		switch (healing.state) {
 		case WAITING:
@@ -498,8 +522,9 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 			if (healing.nodeId != zController.getOwnNodeId()) {
 				ZWaveNoOperationCommandClass zwaveCommandClass = (ZWaveNoOperationCommandClass) healing.node
 						.getCommandClass(CommandClass.NO_OPERATION);
-				if (zwaveCommandClass == null)
+				if (zwaveCommandClass == null) {
 					break;
+				}
 				zController.sendData(zwaveCommandClass.getNoOperationMessage());
 				healing.stateNext = HealState.SAVE;
 				break;
@@ -529,8 +554,9 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 	 */
 	private long calculateNextHeal() {
 		// Initialise the time for the first heal
-		if(networkHealNightlyHour == -1)
+		if(networkHealNightlyHour == -1) {
 			return Long.MAX_VALUE;
+		}
 
 		Calendar next = Calendar.getInstance();
 		next.set(Calendar.HOUR_OF_DAY, networkHealNightlyHour);
@@ -538,8 +564,9 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 		next.set(Calendar.SECOND, 0);
 		next.set(Calendar.MILLISECOND, 0);
 
-		if (next.getTimeInMillis() < System.currentTimeMillis())
+		if (next.getTimeInMillis() < System.currentTimeMillis()) {
 			return next.getTimeInMillis() + 86400000;
+		}
 		return next.getTimeInMillis();
 	}
 
@@ -559,12 +586,14 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 
 			// Get the heal class for this notification
 			HealNode node = healNodes.get(nwEvent.getNodeId());
-			if (node == null)
+			if (node == null) {
 				return;
+			}
 
 			// Is this the event we're waiting for
-			if (nwEvent.getEvent() != node.event)
+			if (nwEvent.getEvent() != node.event) {
 				return;
+			}
 
 			switch (nwEvent.getState()) {
 			case Success:
@@ -578,8 +607,9 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 
 			// If retry count is 0 and we have a list of routes, then this must have
 			// been a successful route set - remove this node
-			if (node.retryCnt == 0 && node.routeList != null && node.routeList.size() > 0)
+			if (node.retryCnt == 0 && node.routeList != null && node.routeList.size() > 0) {
 				node.routeList.remove(0);
+			}
 
 			// Continue....
 			nextHealStage(node);
@@ -587,16 +617,19 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 			SerialMessage serialMessage = ((ZWaveTransactionCompletedEvent) event).getCompletedMessage();
 
 			if (serialMessage.getMessageClass() != SerialMessageClass.SendData
-					&& serialMessage.getMessageType() != SerialMessageType.Request)
+					&& serialMessage.getMessageType() != SerialMessageType.Request) {
 				return;
+			}
 
 			byte[] payload = serialMessage.getMessagePayload();
-			if (payload.length < 3)
+			if (payload.length < 3) {
 				return;
+			}
 
 			HealNode node = healNodes.get(payload[0] & 0xFF);
-			if (node == null)
+			if (node == null) {
 				return;
+			}
 
 			// See if this node is waiting for a PING
 			if ((node.state == HealState.PING || node.state == HealState.PINGEND) && payload.length >= 3
@@ -608,18 +641,21 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 			}
 		} else if (event instanceof ZWaveWakeUpCommandClass.ZWaveWakeUpEvent) {
 			// We only care about the wake-up notification
-			if (((ZWaveWakeUpCommandClass.ZWaveWakeUpEvent) event).getEvent() != ZWaveWakeUpCommandClass.WAKE_UP_NOTIFICATION)
+			if (((ZWaveWakeUpCommandClass.ZWaveWakeUpEvent) event).getEvent() != ZWaveWakeUpCommandClass.WAKE_UP_NOTIFICATION) {
 				return;
+			}
 
 			// A wakeup event is received. Find the node in the node list
 			HealNode node = healNodes.get(event.getNodeId());
-			if (node == null)
+			if (node == null) {
 				return;
+			}
 
 			// Check to see the state of this node
 			// and only process if there's something to do
-			if (!node.state.isActive())
+			if (!node.state.isActive()) {
 				return;
+			}
 
 			logger.debug("NODE {}: Heal WakeUp EVENT {}", node.nodeId, node.state);
 			nextHealStage(node);

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveNetworkMonitor.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveNetworkMonitor.java
@@ -324,15 +324,13 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 				// This avoids the situation where we only poll a dead node if we use the received time!
 				if (oldestNode == null) {
 					oldestNode = node;
-				} else if (node.getLastSent().getTime() < oldestNode.getLastSent().getTime()) {
+				} else if (node.getLastSent() == null || node.getLastSent().getTime() < oldestNode.getLastSent().getTime()) {
 					oldestNode = node;
 				}
 			}
 
-			// We now have the oldest node that we've heard from - ping it!
-			// If we've actually received from this node recently, the don't bother to ping
-			if (oldestNode != null && oldestNode.getLastReceived() != null &&
-					oldestNode.getLastReceived().getTime() < System.currentTimeMillis() - pollPeriod) {
+			// We now have the oldest node that we've sent to - ping it!
+			if (oldestNode != null) {
 				logger.debug("NODE {}: Sending periodic PING.", oldestNode.getNodeId());
 
 				// Reset the resend count - also resets the lastUpdate timer

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveNetworkMonitor.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveNetworkMonitor.java
@@ -78,7 +78,7 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 	private long HEAL_TIMEOUT_PERIOD = 90000;
 	private long HEAL_DELAY_PERIOD = 4000;
 	private int HEAL_MAX_RETRIES = 5;
-	private long PING_PERIOD = 90000;
+	private long pollPeriod = 90000;
 
 	private int networkHealNightlyHour = -1;
 	private long networkHealNextTime = Long.MAX_VALUE;
@@ -143,6 +143,21 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 		// Calculate the next heal time
 		networkHealNightlyTime = calculateNextHeal();
 		networkHealNextTime = networkHealNightlyTime;
+	}
+	
+	/**
+	 * Sets the polling period (in milliseconds) between each network health
+	 * ping.
+	 * @param time period in seconds
+	 */
+	public void setPollPeriod(Integer time) {
+		pollPeriod = time;
+		if (pollPeriod >= 3600000) {
+			pollPeriod = 3600000;
+		}
+		else if (pollPeriod <= 15000) {
+			pollPeriod = 15000;
+		}
 	}
 	
 	/**
@@ -288,15 +303,17 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 
 		if (pingNodeTime < System.currentTimeMillis()) {
 			// Update the time and send a ping...
-			pingNodeTime = System.currentTimeMillis() + PING_PERIOD;
+			pingNodeTime = System.currentTimeMillis() + pollPeriod;
 
-			// Find the node that we haven't communicated with for the longest
-			// time
+			// Find the node that we haven't communicated with for the longest time
 			ZWaveNode oldestNode = null;
 			for (ZWaveNode node : zController.getNodes()) {
 				// Ignore the controller and nodes that aren't listening
-				if (node.getNodeId() == zController.getOwnNodeId() || node.isListening() == false)
+				if (node.getNodeId() == zController.getOwnNodeId() || node.isListening() == false) {
 					continue;
+				}
+				// Use the last sent time for comparisson.
+				// This avoids the situation where we only poll a dead node if we use the received time!
 				if (oldestNode == null) {
 					oldestNode = node;
 				} else if (node.getLastSent().getTime() < oldestNode.getLastSent().getTime()) {
@@ -305,7 +322,8 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 			}
 
 			// We now have the oldest node that we've heard from - ping it!
-			if (oldestNode != null) {
+			// If we've actually received from this node recently, the don't bother to ping
+			if (oldestNode != null && oldestNode.getLastReceived().getTime() < System.currentTimeMillis() - pollPeriod) {
 				logger.debug("NODE {}: Sending periodic PING.", oldestNode.getNodeId());
 
 				// Reset the resend count - also resets the lastUpdate timer
@@ -656,7 +674,7 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 			networkHealNextTime = networkHealNightlyTime;
 
 			// Set the next PING time
-			pingNodeTime = System.currentTimeMillis() + PING_PERIOD;
+			pingNodeTime = System.currentTimeMillis() + pollPeriod;
 		}
 	}
 


### PR DESCRIPTION
This allows the user to configure the period that the 'alive check' poll takes place. It also won't perform a poll if all nodes have been contacted within this period, thus eliminating needless traffic.