### PR TITLE
HSBType/toString: limit precision of float value

### DIFF
--- a/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/HSBType.java
+++ b/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/HSBType.java
@@ -134,7 +134,22 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
 	}
 
 	public String toString() {
-		return getHue() + "," + getSaturation() + "," + getBrightness();
+		String hue = getHue().toString();
+		try {
+			hue = hue.substring(0,6);
+		} catch (StringIndexOutOfBoundsException e) { };
+
+		String sat = getSaturation().toString();
+		try {
+			sat = sat.substring(0,6);
+		} catch (StringIndexOutOfBoundsException e) { };
+
+		String bright = getBrightness().toString();
+		try {
+			bright = bright.substring(0,6);
+		} catch (StringIndexOutOfBoundsException e) { };
+
+		return (hue + "," + sat + "," + bright);
 	}
 
 	@Override


### PR DESCRIPTION
This is needed to ensure that it can be stored in a database with a
row with a limited range of characters. E.g. errors like the following
are fixed with this patch:

0:43:17.985 ERROR o.o.p.m.i.MysqlPersistenceService[:317]- mySQL: Could not
store item 'gsAmbient' in database with statement 'INSERT INTO Item2
(TIME, VALUE) VALUES(NOW(),'217.085427135678478.0392156862745,100') ON
DUPLICATE KEYY UPDATE VALUE='217.0854271356784,78.0392156862745,100';': Data
truncation: Data too long for column 'Value' at row 1

and storing and reloading values of the Colorpicker Item works with the
MySQL backend.

Signed-off-by: Manuel Traut <manut@mecka.net>