### PR TITLE
Improve logging and handling of null values in RuleEngine

### DIFF
--- a/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/internal/engine/RuleEngine.java
+++ b/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/internal/engine/RuleEngine.java
@@ -260,11 +260,16 @@ public class RuleEngine implements EventHandler, ItemRegistryChangeListener, Sta
 						script.execute(context);
 						executedRules.add(rule);
 					} catch (ScriptExecutionException e) {
-						if(e.getCause() instanceof ItemNotFoundException || e.getCause().getMessage().contains("cannot be resolved to an item or type")) {
+						String causeMessage = getCauseMessage(e);
+						if (e.getCause() instanceof ItemNotFoundException
+								|| causeMessage.contains("cannot be resolved to an item or type")) {
+							logger.debug("Not all required items in place yet for rule {}, trying again later: {}",
+									new Object[] { rule.getName(), causeMessage });
 							// we do not seem to have all required items in place yet
 							// so we keep the rule in the list and try it again later
 						} else {
-							logger.error("Error during the execution of startup rule '{}': {}", new String[] { rule.getName(), e.getCause().getMessage() });
+							logger.error("Error during the execution of startup rule '{}': {}",
+									new Object[] { rule.getName(), causeMessage });
 							executedRules.add(rule);
 						}
 					}
@@ -273,6 +278,14 @@ public class RuleEngine implements EventHandler, ItemRegistryChangeListener, Sta
 					triggerManager.removeRule(STARTUP, rule);
 				}
 			}
+		}
+		
+		private String getCauseMessage(Throwable t) {
+			String message = "";
+			if (t.getCause() != null && t.getCause().getMessage() != null) {
+				message = t.getCause().getMessage();
+			}
+			return message;
 		}
 
 		protected synchronized void executeRule(Rule rule) {

--- a/distribution/openhabhome/configurations/rules/demo.rules
+++ b/distribution/openhabhome/configurations/rules/demo.rules
@@ -105,7 +105,7 @@ when
 then	
 	postUpdate(Weather_Temp_Max, Weather_Temperature.maximumSince(now.toDateMidnight).state)
 	postUpdate(Weather_Temp_Min, Weather_Temperature.minimumSince(now.toDateMidnight).state)
-	logInfo("Weather","Temperature evolved of " + Weather_Temperature.deltaSince(now.minusMinutes(2)).toString + " degrees.")
+	logInfo("Weather", "Temperature evolved of " + Weather_Temperature.deltaSince(now.minusMinutes(2)) + " degrees.")
 end
 
 /** shows how to use sensor values from the past */
@@ -114,7 +114,7 @@ when
 	Time cron "0 * * * * ?"
 then	
 	if(Weather_Temperature.changedSince(now.minusMinutes(1))) {
-		println("2 minutes ago, the temperature was " + Weather_Temperature.historicState(now.minusMinutes(2)) + " degrees.")		
+		logInfo("PersistenceDemo", "2 minutes ago, the temperature was " + Weather_Temperature.historicState(now.minusMinutes(2)) + " degrees.")
 	}
 end
 
@@ -127,7 +127,7 @@ when
 	Item DemoSwitch received command
 then
 	if(!DemoSwitch.changedSince(now.minusSeconds(5))) {
-		logInfo("Persistence Demo", "You did not press this button during the last 5 seconds!")
+		logInfo("PersistenceDemo2", "You did not press this button during the last 5 seconds!")
 	}
 end
 


### PR DESCRIPTION
This pull request results from the analysis of #1742:
- Improved robustness of RuleEngine against NullPointerExceptions (if ScriptExecutionException contains no cause or no cause message).
- Fix log error caused by demo.rules when no weather history exists yet. Before the fix it could happen that toString was called on a null value.