### PR TITLE
SpeechDispatcher:  Reconnect to server if connection is dropped.

### DIFF
--- a/bundles/io/org.openhab.io.multimedia.tts.speechdispatcher/src/main/java/org/openhab/io/multimedia/internal/tts/SpeechDispatcherConnection.java
+++ b/bundles/io/org.openhab.io.multimedia.tts.speechdispatcher/src/main/java/org/openhab/io/multimedia/internal/tts/SpeechDispatcherConnection.java
@@ -27,6 +27,8 @@ public class SpeechDispatcherConnection {
 	}
 
 	public void openConnection() {
+		// Close any existing connection first, if present
+		closeConnection();      
 		try {
 			speechDispatcherClient = new SSIPClient("openhab", null, null, host, port);
 		} catch (SSIPException e) {
@@ -52,7 +54,7 @@ public class SpeechDispatcherConnection {
 	 * @param voice the name of the voice to use or null, if the default voice should be used
 	 */
 	public void say(String text, String voiceName) {
-		if (speechDispatcherClient==null) {
+		if (speechDispatcherClient==null || !speechDispatcherClient.getConnection().isConnected()) {
 			openConnection();
 		}
 		if(text==null) {


### PR DESCRIPTION
Currently the SpeechDispatcher TTS plugin only connects to the speech dispatcher server once.  If that connection is dropped, it never retries to gain - just logs the following error:
`ERROR o.o.i.m.i.t.SpeechDispatcherConnection[:67]- Error sending text to SpeechDispatcher Host 127.0.0.1: not connected to server`
The only existing recovery was to restart openhab.

This simple Pull Request adds a check to see if the plugin has been disconnected from the server and reconnects automatically.