### PR TITLE
Initial version of the FrontierSilicon-Radio binding

### DIFF
--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/.classpath
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/.project
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.frontiersiliconradio</name>
+	<comment>This is the FrontierSiliconRadio binding of the open Home Automation Bus (openHAB)</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/.settings/org.eclipse.ltk.core.refactoring.prefs
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/.settings/org.eclipse.ltk.core.refactoring.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+org.eclipse.ltk.core.refactoring.enable.project.refactoring.history=false

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/META-INF/MANIFEST.MF
@@ -1,0 +1,34 @@
+Manifest-Version: 1.0
+Private-Package: org.openhab.binding.frontiersiliconradio.internal
+Ignore-Package: org.openhab.binding.frontiersiliconradio.internal
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-Name: openHAB FrontierSiliconRadio Binding
+Bundle-SymbolicName: org.openhab.binding.frontiersiliconradio
+Bundle-Vendor: openHAB.org
+Bundle-Version: 1.7.0.qualifier
+Bundle-Activator: org.openhab.binding.frontiersiliconradio.internal.FrontierSiliconRadioActivator
+Bundle-ManifestVersion: 2
+Bundle-Description: This is the FrontierSiliconRadio binding of the open Home Aut
+ omation Bus (openHAB)
+Import-Package: org.apache.commons.httpclient;version="3.1.0",
+ org.apache.commons.httpclient.methods;version="3.1.0",
+ org.apache.commons.httpclient.params;version="3.1.0",
+ org.apache.commons.io;version="2.0.1",
+ org.apache.commons.lang,
+ org.openhab.core.binding,
+ org.openhab.core.events,
+ org.openhab.core.items,
+ org.openhab.core.library.items,
+ org.openhab.core.library.types,
+ org.openhab.core.types,
+ org.openhab.model.item.binding,
+ org.osgi.framework,
+ org.osgi.service.cm,
+ org.osgi.service.component,
+ org.osgi.service.event,
+ org.slf4j
+Export-Package: org.openhab.binding.frontiersiliconradio
+Bundle-DocURL: http://www.openhab.org
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Service-Component: OSGI-INF/binding.xml, OSGI-INF/genericbindingprovider.xml
+Bundle-ClassPath: .

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/OSGI-INF/binding.xml
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/OSGI-INF/binding.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2014, openHAB.org and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" name="org.openhab.binding.frontiersiliconradio.binding">
+	<implementation class="org.openhab.binding.frontiersiliconradio.internal.FrontierSiliconRadioBinding" />
+
+	<service>
+		<provide interface="org.osgi.service.event.EventHandler" />
+		<provide interface="org.osgi.service.cm.ManagedService" />
+	</service>
+
+	<property name="event.topics" type="String" value="openhab/command/*" />
+	<property name="service.pid" type="String" value="org.openhab.frontiersiliconradio" />
+
+	<reference bind="setEventPublisher" cardinality="1..1"
+		interface="org.openhab.core.events.EventPublisher" name="EventPublisher"
+		policy="dynamic" unbind="unsetEventPublisher" />
+	<reference bind="addBindingProvider" cardinality="1..n"
+		interface="org.openhab.binding.frontiersiliconradio.FrontierSiliconRadioBindingProvider" name="FrontierSiliconRadioBindingProvider"
+		policy="dynamic" unbind="removeBindingProvider" />
+	
+</scr:component>

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/OSGI-INF/genericbindingprovider.xml
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/OSGI-INF/genericbindingprovider.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2014, openHAB.org and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.openhab.binding.frontiersiliconradio.genericbindingprovider">
+   <implementation class="org.openhab.binding.frontiersiliconradio.internal.FrontierSiliconRadioGenericBindingProvider"/>
+   
+   <service>
+      <provide interface="org.openhab.model.item.binding.BindingConfigReader"/>
+      <provide interface="org.openhab.binding.frontiersiliconradio.FrontierSiliconRadioBindingProvider"/>
+   </service>
+   
+</scr:component>

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/build.properties
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/build.properties
@@ -1,0 +1,6 @@
+source.. = src/main/java/,\
+           src/main/resources/
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/
+output.. = target/classes/

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/pom.xml
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<parent>
+		<groupId>org.openhab.bundles</groupId>
+		<artifactId>binding</artifactId>
+		<version>1.7.0-SNAPSHOT</version>
+	</parent>
+
+	<properties>
+		<bundle.symbolicName>org.openhab.binding.frontiersiliconradio</bundle.symbolicName>
+		<bundle.namespace>org.openhab.binding.frontiersiliconradio</bundle.namespace>
+		<deb.name>openhab-addon-binding-FrontierSiliconRadio</deb.name>
+		<deb.description>openhab addon binding FrontierSiliconRadio</deb.description>
+	</properties>
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.openhab.binding</groupId>
+	<artifactId>org.openhab.binding.frontiersiliconradio</artifactId>
+
+	<name>openHAB FrontierSiliconRadio Binding</name>
+
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.vafer</groupId>
+				<artifactId>jdeb</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/FrontierSiliconRadioBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/FrontierSiliconRadioBindingProvider.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2010-2014, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.frontiersiliconradio;
+
+import org.openhab.core.binding.BindingProvider;
+import org.openhab.core.items.Item;
+
+/**
+ * 
+ * Binding provider for internet radios based on frontier silicon chipset.
+ * Binding configuration is: "frontiersilicon=<deviceId>:<Property>", e.g. "frontiersilicon=kitchen:POWER"
+ * 
+ * @author Rainer Ostendorf
+ * @since 1.7.0
+ */
+public interface FrontierSiliconRadioBindingProvider extends BindingProvider {
+		
+		// return the property the item is bound to (e.g. "POWER")
+		String getProperty( String itemName );
+		
+		// get the device id of the radio (e.g. "livingroom-radio")
+		String getDeviceID( String itemName ); 
+		
+		/**
+		 * Returns the Type of the Item identified by {@code itemName}
+		 * 
+		 * @param itemName the name of the item to find the type for
+		 * @return the type of the Item identified by {@code itemName}
+		 */
+		Class<? extends Item> getItemType(String itemName);
+}

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadio.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadio.java
@@ -1,0 +1,274 @@
+/**
+ * Copyright (c) 2010-2014, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.openhab.binding.frontiersiliconradio.internal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Class representing a internet radio based on the frontier silicon chipset.
+ * Tested with "hama IR110" internet radio.
+ * 
+ * @author Rainer Ostendorf
+ * @since 1.7.0
+ */
+/**
+ * @author rainer
+ *
+ */
+/**
+ * @author rainer
+ *
+ */
+public class FrontierSiliconRadio 
+{
+	
+	private static final Logger logger = LoggerFactory.getLogger(FrontierSiliconRadioConnection.class);
+	
+	// The http connection/session used for controlling the radio
+	private FrontierSiliconRadioConnection conn;
+
+	
+	/**
+	 *  Constructor for the Radio class
+	 * 
+	 * @param hostname Hostname of the Radio adressed, e.g. "192.168.2.137"
+	 * @param port Portnumber, default: 80 (http)
+	 * @param pin Access PIN number. Must be 4 digits on hama radio. e.g. "1234"
+	 * 
+	 * @author Rainer Ostendorf
+	 * @since 1.7.0
+	 */
+	public FrontierSiliconRadio( String hostname, int port, String pin ) {
+		this.conn = new FrontierSiliconRadioConnection( hostname, port, pin );
+	}
+	
+	/**
+	 * Perform login to the radio and establish new session
+	 * 
+	 * @author Rainer Ostendorf
+	 * @since 1.7.0
+	 */
+	public void login() {
+		conn.doLogin();
+	}
+	
+	
+	/**
+	 * get the radios power state
+	 * 
+	 * @return true when radio is on, false when radio is off
+	 */
+	public Boolean getPower() {
+		try {
+			FrontierSiliconRadioApiResult result = conn.doRequest("GET/netRemote.sys.power");
+			return result.getValueU8AsBoolean();
+		}
+		catch (Exception e) {
+			logger.error("request failed");
+		}
+		
+		return false;
+	}
+	
+	/**
+	 * Turn radio on/off
+	 * 
+	 * @param powerOn true turns on the radio, false turns it off
+	 */
+	public void setPower(Boolean powerOn) {
+		try {
+			conn.doRequest("SET/netRemote.sys.power", "value="+(powerOn?"1":"0"));
+			return;
+		}
+		catch (Exception e) {
+			logger.error("request failed");
+		}
+	}
+	
+	/**
+	 * read the volume (as absolute value, 0-32)
+	 * 
+	 * @return volume: 0=muted, 32=max. volume
+	 */
+	public int getVolume() {
+		try {
+			FrontierSiliconRadioApiResult result = conn.doRequest("GET/netRemote.sys.audio.volume");
+			return result.getValueU8AsInt();
+		}
+		catch (Exception e) {
+			logger.error("request failed");
+		}
+		return 0;
+	}
+	
+	/**
+	 * Set the radios volume
+	 * 
+	 * @param volume Radio volume: 0=mute, 32=max. volume
+	 */
+	public void setVolume( int volume ) {
+		try {
+			conn.doRequest("SET/netRemote.sys.audio.volume", "value="+volume );
+			return;
+		}
+		catch (Exception e) {
+			logger.error("request failed");
+		}
+	}
+	
+	
+	/**
+	 *  Read the radios operating mode
+	 * 
+	 * @return operating mode. On hama radio: 0="Internet Radio", 1=Spotify, 2=Player, 3="AUX IN"
+	 */
+	public int getMode() {
+		try {
+			FrontierSiliconRadioApiResult result = conn.doRequest("GET/netRemote.sys.mode");
+			return result.getValueU32AsInt();
+		}
+		catch (Exception e) {
+			logger.error("request failed");
+		}
+		return 0;
+	}
+	
+	/**
+	 * Set the radio operating mode
+	 * 
+	 * @param mode On hama radio: 0="Internet Radio", 1=Spotify, 2=Player, 3="AUX IN"
+	 */
+	public void setMode( int mode ) {
+		try {
+			conn.doRequest("SET/netRemote.sys.mode", "value="+mode );
+			return;
+		}
+		catch (Exception e) {
+			logger.error("request failed");
+		}
+	}
+	
+	
+	/**
+	 * Read the Station info name, e.g. "WDR2"
+	 * 
+	 * @return the station name, e.g. "WDR2"
+	 */
+	public String getPlayInfoName() {
+		try {
+			FrontierSiliconRadioApiResult result = conn.doRequest("GET/netRemote.play.info.name");
+			return result.getValueC8ArrayAsString();
+		}
+		catch (Exception e) {
+			logger.error("request failed");
+			return "";
+		}
+	}
+	
+	/**
+	 * read the stations radio text like the song name currently playing
+	 * 
+	 * @return the radio info text, e.g. music title
+	 */
+	public String getPlayInfoText() {
+		try {
+			FrontierSiliconRadioApiResult result = conn.doRequest("GET/netRemote.play.info.text");
+			return result.getValueC8ArrayAsString();
+		}
+		catch (Exception e) {
+			logger.error("request failed");
+			return "";
+		}
+	}
+	
+	
+	/**
+	 * set a station preset. Tunes the radio to a preselected station.
+	 * 
+	 * @param presetId
+	 */
+	public void setPreset(Integer presetId) {
+		try {
+			conn.doRequest("SET/netRemote.nav.action.selectPreset", "value="+presetId.toString() );
+			return;
+		}
+		catch (Exception e) {
+			logger.error("request failed");
+			return;
+		}
+	}
+	
+	/**
+	 * read the muted state
+	 * 
+	 * @return true: radio is muted, false: radio is not muted
+	 */
+	public Boolean getMuted() {
+		try {
+			FrontierSiliconRadioApiResult result = conn.doRequest("GET/netRemote.sys.audio.mute");
+			return result.getValueU8AsBoolean();
+		}
+		catch (Exception e) {
+			logger.error("request failed");
+		}
+		
+		return false;
+	}
+	
+	
+	/** 
+	 * mute the radio volume
+	 * 
+	 * @param muted true: mute the radio, false: unmute the radio
+	 */
+	public void setMuted(Boolean muted) {
+		try {
+			conn.doRequest("SET/netRemote.sys.audio.mute", "value="+(muted?"1":"0"));
+			return;
+		}
+		catch (Exception e) {
+			logger.error("request failed");
+		}
+	}
+	
+	
+	/**
+	 * map the radio volume values to percent values
+	 * 
+	 * receiver volume 0 is 0%
+	 * receiver volume 32 is 100%
+	 * 
+	 * @param volume the receiver volume value
+	 * 
+	 */
+	public Integer convertVolumeToPercent( Integer volume )	{
+		Integer percent = Math.round( (volume*100)/32 );
+		logger.debug("converted volume '" +  volume.toString() + "' to '" + percent.toString() + "%'" );
+		return percent;
+	}
+	
+	/**
+	 * map percent values to radio volumes
+	 * 
+	 * receiver volume 0 is 0%
+	 * receiver volume 32 is 100%
+	 * 
+	 * @param volume the receiver volume value
+	 * 
+	 */
+	public Integer convertPercentToVolume( Integer percent )	{
+		Integer volume = Math.round( (percent*32)/100 );
+		logger.debug("converted " +  percent.toString() + "% to volume " + volume.toString() );
+		return volume;
+	}
+	
+}

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadio.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadio.java
@@ -219,8 +219,10 @@ public class FrontierSiliconRadio
 	 * @param presetId
 	 */
 	public void setPreset(Integer presetId) {
-		try {
+		try {		
+			conn.doRequest("SET/netRemote.nav.state", "value=1");
 			conn.doRequest("SET/netRemote.nav.action.selectPreset", "value="+presetId.toString() );
+			conn.doRequest("SET/netRemote.nav.state", "value=0");
 			return;
 		}
 		catch (Exception e) {

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadio.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadio.java
@@ -36,6 +36,8 @@ public class FrontierSiliconRadio
 	// The http connection/session used for controlling the radio
 	private FrontierSiliconRadioConnection conn;
 
+	// the volume of the radio. we cache it for fast increase/decrease
+	private int currentVolume=0;
 	
 	/**
 	 *  Constructor for the Radio class
@@ -102,7 +104,8 @@ public class FrontierSiliconRadio
 	public int getVolume() {
 		try {
 			FrontierSiliconRadioApiResult result = conn.doRequest("GET/netRemote.sys.audio.volume");
-			return result.getValueU8AsInt();
+			currentVolume = result.getValueU8AsInt();
+			return currentVolume;
 		}
 		catch (Exception e) {
 			logger.error("request failed");
@@ -118,11 +121,30 @@ public class FrontierSiliconRadio
 	public void setVolume( int volume ) {
 		try {
 			conn.doRequest("SET/netRemote.sys.audio.volume", "value="+volume );
+			currentVolume = volume;
 			return;
 		}
 		catch (Exception e) {
 			logger.error("request failed");
 		}
+	}
+	
+	/**
+	 * increase radio volume by 1 step
+	 * 
+	 */
+	public void increaseVolume() {
+		if( currentVolume < 32)
+			setVolume( currentVolume+1 );
+	}
+	
+	/**
+	 * decrease radio volume by 1 step
+	 * 
+	 */
+	public void decreaseVolume() {
+		if( currentVolume>0)
+		setVolume( currentVolume-1 );
 	}
 	
 	

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioActivator.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioActivator.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2010-2014, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.frontiersiliconradio.internal;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Extension of the default OSGi bundle activator
+ * 
+ * @author Rainer Ostendorf
+ * @since 1.7.0
+ */
+public final class FrontierSiliconRadioActivator implements BundleActivator {
+
+	private static Logger logger = LoggerFactory.getLogger(FrontierSiliconRadioActivator.class); 
+	
+	private static BundleContext context;
+	
+	/**
+	 * Called whenever the OSGi framework starts our bundle
+	 */
+	public void start(BundleContext bc) throws Exception {
+		context = bc;
+		logger.debug("FrontierSiliconRadio binding has been started.");
+	}
+
+	/**
+	 * Called whenever the OSGi framework stops our bundle
+	 */
+	public void stop(BundleContext bc) throws Exception {
+		context = null;
+		logger.debug("FrontierSiliconRadio binding has been stopped.");
+	}
+	
+	/**
+	 * Returns the bundle context of this bundle
+	 * @return the bundle context
+	 */
+	public static BundleContext getContext() {
+		return context;
+	}
+	
+}

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioApiResult.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioApiResult.java
@@ -68,7 +68,7 @@ public class FrontierSiliconRadioApiResult {
 		Element fsApiResult = (Element)xmlDoc.getElementsByTagName("fsapiResponse").item(0);
 		Element statusNode = (Element)fsApiResult.getElementsByTagName("status").item(0);
 		String status = getCharacterDataFromElement( statusNode );
-		logger.debug("status is: "+status);
+		logger.trace("status is: "+status);
 		return status;
 	}
 	
@@ -88,18 +88,12 @@ public class FrontierSiliconRadioApiResult {
 	 */
 	public Boolean getValueU8AsBoolean() {
 		try {
-			Element fsApiResult = (Element)xmlDoc.getElementsByTagName("fsapiResponse").item(0);
-			
-			Element statusNode = (Element)fsApiResult.getElementsByTagName("status").item(0);
-			String status = getCharacterDataFromElement( statusNode );
-			logger.debug("status is: "+status);
-			
-			
+			Element fsApiResult = (Element)xmlDoc.getElementsByTagName("fsapiResponse").item(0);			
 			Element valueNode = (Element) fsApiResult.getElementsByTagName("value").item(0);
 			Element u8Node = (Element) valueNode.getElementsByTagName("u8").item(0);
 			
 			String value = getCharacterDataFromElement( u8Node );
-			logger.debug("value is: "+value);
+			logger.trace("value is: "+value);
 			
 			return ("1".equals(value)?true:false);
 		}
@@ -116,18 +110,13 @@ public class FrontierSiliconRadioApiResult {
 	 */
 	public int getValueU8AsInt() {
 		try {
-			Element fsApiResult = (Element)xmlDoc.getElementsByTagName("fsapiResponse").item(0);
-			
-			Element statusNode = (Element)fsApiResult.getElementsByTagName("status").item(0);
-			String status = getCharacterDataFromElement( statusNode );
-			logger.debug("status is: "+status);
-			
-			
+			Element fsApiResult = (Element)xmlDoc.getElementsByTagName("fsapiResponse").item(0);				
 			Element valueNode = (Element) fsApiResult.getElementsByTagName("value").item(0);
 			Element u8Node = (Element) valueNode.getElementsByTagName("u8").item(0);
 			
 			String value = getCharacterDataFromElement( u8Node );
-			logger.debug("value is: "+value);
+			
+			logger.trace("value is: "+value);
 			
 			return Integer.parseInt(value);
 		}
@@ -146,17 +135,11 @@ public class FrontierSiliconRadioApiResult {
 	public int getValueU32AsInt() {
 		try {
 			Element fsApiResult = (Element)xmlDoc.getElementsByTagName("fsapiResponse").item(0);
-			
-			Element statusNode = (Element)fsApiResult.getElementsByTagName("status").item(0);
-			String status = getCharacterDataFromElement( statusNode );
-			logger.debug("status is: "+status);
-			
-			
 			Element valueNode = (Element) fsApiResult.getElementsByTagName("value").item(0);
 			Element u32Node = (Element) valueNode.getElementsByTagName("u32").item(0);
 			
 			String value = getCharacterDataFromElement( u32Node );
-			logger.debug("value is: "+value);
+			logger.trace("value is: "+value);
 			
 			return Integer.parseInt(value);
 		}
@@ -179,7 +162,7 @@ public class FrontierSiliconRadioApiResult {
 			Element c8Array = (Element) valueNode.getElementsByTagName("c8_array").item(0);
 			
 			String value = getCharacterDataFromElement( c8Array );
-			logger.debug("value is: "+value);
+			logger.trace("value is: "+value);
 			return value;
 		}
 		catch (Exception e) {
@@ -233,6 +216,4 @@ public class FrontierSiliconRadioApiResult {
 	    else
 	    	return "";
 	 }
-	
-	
 }

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioApiResult.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioApiResult.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright (c) 2010-2014, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.openhab.binding.frontiersiliconradio.internal;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.CharacterData;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * This class hold the result of a request read from the radio. 
+ * Upon a request the radio returns a XML document like this:
+ * 
+ *  <fsapiResponse>
+ *	<status>FS_OK</status>
+ *	<value><u8>1</u8></value>
+ *	</fsapiResponse>
+ * 
+ * This class parses this XML data and provides funtion for reading and casting typical fields.
+ * 
+ * @author Rainer Ostendorf
+ * @since 1.7.0
+ *
+ */
+public class FrontierSiliconRadioApiResult {
+
+	/**
+	 * XML structure holding the parsed response
+	 */
+	Document xmlDoc;
+	
+	private static final Logger logger = LoggerFactory.getLogger(FrontierSiliconRadioConnection.class);
+	
+	public FrontierSiliconRadioApiResult(String requestResultString) {
+		try {
+			this.xmlDoc = getXmlDocFromString(requestResultString);
+		}
+		catch (Exception e) {
+			logger.error("converting to XML failed: '"+requestResultString+"'");
+		}
+	}
+	
+	/**
+	 * Extract the fied "status" from the result and return it
+	 * 
+	 * @return result field as string.
+	 */
+	public String getStatus() {
+		Element fsApiResult = (Element)xmlDoc.getElementsByTagName("fsapiResponse").item(0);
+		Element statusNode = (Element)fsApiResult.getElementsByTagName("status").item(0);
+		String status = getCharacterDataFromElement( statusNode );
+		logger.debug("status is: "+status);
+		return status;
+	}
+	
+	/**
+	 * checks if the responses status code was "FS_OK"
+	 * 
+	 * @return true if status is "FS_OK", false else
+	 */
+	public Boolean isStatusOk() {
+		return ("FS_OK").equals(getStatus());
+	}
+	
+	/**
+	 * read the <value><u8> field as boolean
+	 * 
+	 * @return value.u8 field as bool
+	 */
+	public Boolean getValueU8AsBoolean() {
+		try {
+			Element fsApiResult = (Element)xmlDoc.getElementsByTagName("fsapiResponse").item(0);
+			
+			Element statusNode = (Element)fsApiResult.getElementsByTagName("status").item(0);
+			String status = getCharacterDataFromElement( statusNode );
+			logger.debug("status is: "+status);
+			
+			
+			Element valueNode = (Element) fsApiResult.getElementsByTagName("value").item(0);
+			Element u8Node = (Element) valueNode.getElementsByTagName("u8").item(0);
+			
+			String value = getCharacterDataFromElement( u8Node );
+			logger.debug("value is: "+value);
+			
+			return ("1".equals(value)?true:false);
+		}
+		catch (Exception e) {
+			logger.error( "getting Value.U8 failed");
+			return false;
+		}
+	}
+	
+	/**
+	 * read the <value><u8> field as int
+	 * 
+	 * @return value.u8 field as int
+	 */
+	public int getValueU8AsInt() {
+		try {
+			Element fsApiResult = (Element)xmlDoc.getElementsByTagName("fsapiResponse").item(0);
+			
+			Element statusNode = (Element)fsApiResult.getElementsByTagName("status").item(0);
+			String status = getCharacterDataFromElement( statusNode );
+			logger.debug("status is: "+status);
+			
+			
+			Element valueNode = (Element) fsApiResult.getElementsByTagName("value").item(0);
+			Element u8Node = (Element) valueNode.getElementsByTagName("u8").item(0);
+			
+			String value = getCharacterDataFromElement( u8Node );
+			logger.debug("value is: "+value);
+			
+			return Integer.parseInt(value);
+		}
+		catch (Exception e) {
+			logger.error( "getting Value.U8 failed");
+			e.printStackTrace();
+			return 0;
+		}
+	}
+	
+	/**
+	 * read the <value><u32> field as int
+	 * 
+	 * @return value.u32 field as int
+	 */
+	public int getValueU32AsInt() {
+		try {
+			Element fsApiResult = (Element)xmlDoc.getElementsByTagName("fsapiResponse").item(0);
+			
+			Element statusNode = (Element)fsApiResult.getElementsByTagName("status").item(0);
+			String status = getCharacterDataFromElement( statusNode );
+			logger.debug("status is: "+status);
+			
+			
+			Element valueNode = (Element) fsApiResult.getElementsByTagName("value").item(0);
+			Element u32Node = (Element) valueNode.getElementsByTagName("u32").item(0);
+			
+			String value = getCharacterDataFromElement( u32Node );
+			logger.debug("value is: "+value);
+			
+			return Integer.parseInt(value);
+		}
+		catch (Exception e) {
+			logger.error( "getting Value.U32 failed");
+			e.printStackTrace();
+			return 0;
+		}
+	}
+	
+	/**
+	 * read the <value><c8_array> field as String
+	 * 
+	 * @return value.c8_array field as String
+	 */
+	public String getValueC8ArrayAsString() {
+		try {
+			Element fsApiResult = (Element)xmlDoc.getElementsByTagName("fsapiResponse").item(0);
+			Element valueNode = (Element) fsApiResult.getElementsByTagName("value").item(0);
+			Element c8Array = (Element) valueNode.getElementsByTagName("c8_array").item(0);
+			
+			String value = getCharacterDataFromElement( c8Array );
+			logger.debug("value is: "+value);
+			return value;
+		}
+		catch (Exception e) {
+			logger.error( "getting Value.c8array failed");
+			e.printStackTrace();
+			return "";
+		}
+	}
+	
+	/**
+	 * read the <sessionId> field as String
+	 * 
+	 * @return value of sessionId field
+	 */
+	public String getSessionId() {
+		NodeList sessionIdTagList = xmlDoc.getElementsByTagName("sessionId");
+		String givenSessId = getCharacterDataFromElement( (Element)sessionIdTagList.item(0));
+		return givenSessId;
+	}
+	
+	
+	/**
+	 * converts the string we got from the radio to a parsable XML document
+	 * 
+	 * @param xmlString the XML string read from the radio
+	 * @return the parsed XML document
+	 * @throws ParserConfigurationException
+	 * @throws SAXException
+	 * @throws IOException
+	 */
+	private Document getXmlDocFromString(String xmlString) throws ParserConfigurationException, SAXException, IOException {
+	    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+	    DocumentBuilder builder = factory.newDocumentBuilder();
+	    Document xmlDocument = builder.parse( new InputSource( new StringReader(xmlString ) ) );
+		return xmlDocument;
+	}
+	
+	
+	/**
+	 *  convert the value of a given XML element to a string for further processing
+	 *  
+	 * @param e XML Element
+	 * @return the elements value converted to string
+	 */
+	private static String getCharacterDataFromElement(Element e) {
+	    Node child = e.getFirstChild();
+	    if (child instanceof CharacterData) {
+	      CharacterData cd = (CharacterData) child;
+	      return cd.getData();
+	    }
+	    else
+	    	return "";
+	 }
+	
+	
+}

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioBinding.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioBinding.java
@@ -1,0 +1,375 @@
+/**
+ * Copyright (c) 2010-2014, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.frontiersiliconradio.internal;
+
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.openhab.binding.frontiersiliconradio.internal.FrontierSiliconRadio;
+import org.openhab.binding.frontiersiliconradio.FrontierSiliconRadioBindingProvider;
+
+import org.openhab.core.binding.AbstractActiveBinding;
+import org.openhab.core.library.items.DimmerItem;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.cm.ManagedService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+	
+
+/**
+ * Implement this class if you are going create an actively polling service
+ * like querying a Website/Device.
+ * 
+ * @author Rainer Ostendorf
+ * @since 1.7.0
+ */
+public class FrontierSiliconRadioBinding extends AbstractActiveBinding<FrontierSiliconRadioBindingProvider> implements ManagedService {
+
+	private static final Logger logger = 
+		LoggerFactory.getLogger(FrontierSiliconRadioBinding.class);
+
+	
+	/** 
+	 * the refresh interval which is used to poll values from the FrontierSiliconRadio
+	 * server (optional, defaults to 1000ms)
+	 */
+	private long refreshInterval = 1000;
+	
+	/** RegEx to validate a config <code>'^(.*?)\\.(host|port|pin)$'</code> */
+	private static final Pattern EXTRACT_CONFIG_PATTERN = Pattern.compile("^(.*?)\\.(host|port|pin|refreshInterval)$");
+	
+	/**  default tcp port (http). Make this configurable cause maybe people do NAT/portforwarding. */
+	private final static int DEFAULT_PORT = 80;
+	
+	/** the default radio pin. HAMA radio was delivered with '1234' **/
+	private final static String DEFAULT_PIN = "1234";
+	
+	/** Map table to store all available radios configured by the user */
+	protected Map<String, FrontierSiliconRadioBindingConfig> deviceConfigCache = null;
+	
+	
+	public FrontierSiliconRadioBinding() {
+	}
+		
+	
+	public void activate() {
+	}
+	
+	public void deactivate() {
+		// deallocate resources here that are no longer needed and 
+		// should be reset when activating this binding again
+	}
+
+	
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	protected long getRefreshInterval() {
+		return refreshInterval;
+	}
+
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	protected String getName() {
+		return "FrontierSiliconRadio Refresh Service";
+	}
+	
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	protected void execute() {
+		// the frequently executed code (polling) goes here ...
+		logger.debug("execute() method is called!");
+		
+		for (FrontierSiliconRadioBindingProvider provider : providers) {
+			for (String itemName : provider.getItemNames() ) {
+										
+				// find the matching device config for this item				
+				String deviceId = provider.getDeviceID(itemName);
+				if( deviceId == null ) {
+					logger.error("could not find deviceId of item: "+ itemName );
+					continue;
+				}
+				else
+				{
+					FrontierSiliconRadioBindingConfig deviceConf = deviceConfigCache.get(deviceId);
+				
+					if( deviceConf != null )	{
+						
+						// get the assigned radio
+						FrontierSiliconRadio radio = deviceConf.getRadio();
+						
+						// get the assigned property of this item
+						String property = provider.getProperty(itemName);							
+						
+						// depending on the selected property, poll the property from the radio and update the item
+						switch( property )
+						{
+							case "POWER":
+								Boolean powerState = radio.getPower();
+								logger.debug("powerState is "+ powerState.toString());
+								eventPublisher.postUpdate(itemName, powerState?OnOffType.ON:OnOffType.OFF);	
+								break;
+							case "MODE":
+								Integer mode = radio.getMode();
+								eventPublisher.postUpdate(itemName, new DecimalType(mode) );
+								break;
+							case "VOLUME":
+								int volume = radio.getVolume();
+								logger.debug("volume is "+ volume );
+								if( provider.getItemType(itemName) == DimmerItem.class )
+									eventPublisher.postUpdate(itemName, new PercentType( radio.convertVolumeToPercent(volume) ) );
+								else
+									eventPublisher.postUpdate(itemName, new DecimalType( volume ) );
+								break;
+							case "PLAYINFONAME":
+								String playInfoName = radio.getPlayInfoName();
+								eventPublisher.postUpdate(itemName, new StringType(playInfoName) );
+								break;
+							case "PLAYINFOTEXT":
+								String playInfoText = radio.getPlayInfoText();
+								eventPublisher.postUpdate(itemName, new StringType(playInfoText) );
+								break;
+							case "PRESET":
+								// preset is write-only, ignore
+								break;
+							case "MUTE":
+								Boolean muteState = radio.getMuted();
+								logger.debug("mute state is "+ muteState.toString());
+								eventPublisher.postUpdate(itemName, muteState?OnOffType.ON:OnOffType.OFF);	
+								break;
+							default:
+								logger.error("unknown property: '"+ property + "'" );
+						}
+		
+					} else {
+						logger.error("deviceConf is null");								
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	protected void internalReceiveCommand(String itemName, Command command) {
+		logger.debug("internalReceiveCommand() is called!");
+		
+		for( FrontierSiliconRadioBindingProvider provider : providers )	{
+			for (String providerItemName : provider.getItemNames() ) {
+			
+				if( providerItemName.equals( itemName ) )	{
+					
+					// find the matching device config for this item
+					String deviceId = provider.getDeviceID(itemName);
+					if( deviceId == null ) {
+						logger.error("could not find deviceId of item: "+ itemName );
+						continue;
+					}
+	
+					// try to get the config of the radio from our config cache
+					FrontierSiliconRadioBindingConfig deviceConf = deviceConfigCache.get(deviceId);
+					
+					if( deviceConf != null )
+					{
+						// get the assigned radio
+						FrontierSiliconRadio radio = deviceConf.getRadio();
+							
+						// get the assigned property for this item
+						String property = provider.getProperty(itemName);
+							
+						// according the the assigned property, send the command to the assigned radio.
+						switch( property ) {
+						
+							case "POWER":
+								if (command.equals(OnOffType.ON) || command.equals(OpenClosedType.CLOSED)) {
+									radio.setPower(true);
+								} else {
+									radio.setPower(false);
+								}
+								break;
+							case "VOLUME":	
+								Integer volumeCommand = ((DecimalType) command).intValue() ;
+								if (command instanceof PercentType) {
+									Integer absoluteVolume = radio.convertPercentToVolume(volumeCommand);
+									radio.setVolume( absoluteVolume );
+								} else {
+									radio.setVolume(volumeCommand);
+								}
+								break;
+							case "MODE":
+								Integer mode = ((DecimalType) command).intValue() ;
+								radio.setMode(mode);
+								break;
+							case "PRESET":
+								Integer preset = ((DecimalType) command).intValue() ;
+								radio.setPreset(preset);
+								break;
+							case "MUTE":
+								if (command.equals(OnOffType.ON) || command.equals(OpenClosedType.CLOSED)) {
+									radio.setMuted(true);
+								} else {
+									radio.setMuted(false);
+								}
+								break;
+							default:
+								logger.error("command on unkown property: '"+property+"'. Maybe trying to set read-only property?");
+								break;
+						}
+					}
+				}
+			}
+		}	
+	}
+	
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	protected void internalReceiveUpdate(String itemName, State newState) {
+		// the code being executed when a state was sent on the openHAB
+		// event bus goes here. This method is only called if one of the 
+		// BindingProviders provide a binding for the given 'itemName'.
+		logger.debug("internalReceiveCommand() is called!");
+	}
+		
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	public void updated(Dictionary<String, ?> config) throws ConfigurationException {
+		
+		if (config != null) {
+			
+			logger.debug("Configuration updated, config {}", config != null ? true : false);
+			
+			Enumeration<String> keys = config.keys();
+			
+			if ( deviceConfigCache == null ) {
+				deviceConfigCache = new HashMap<String, FrontierSiliconRadioBindingConfig>();
+			}
+			
+			while (keys.hasMoreElements()) {
+				String key = (String) keys.nextElement();
+
+				Matcher matcher = EXTRACT_CONFIG_PATTERN.matcher(key);
+
+				if (!matcher.matches()) {
+					logger.debug("given config key '" + key
+						+ "' does not follow the expected pattern '<id>.<host|port|pin>'");
+					continue;
+				}
+
+				matcher.reset();
+				matcher.find();
+
+				String deviceId = matcher.group(1);
+
+				FrontierSiliconRadioBindingConfig deviceConfig = deviceConfigCache.get(deviceId);
+
+				if (deviceConfig == null) {
+					deviceConfig = new FrontierSiliconRadioBindingConfig(deviceId);
+					deviceConfigCache.put(deviceId, deviceConfig);
+				}
+
+				String configKey = matcher.group(2);
+				String value = (String) config.get(key);
+
+				if ("host".equals(configKey)) {
+					logger.debug("Hostname for " + deviceId + " is " + value);
+					deviceConfig.host = value;
+				} else if ("port".equals(configKey)) {
+					logger.debug("Portnumber for " + deviceId + " is " + value);
+					deviceConfig.port = Integer.valueOf(value);
+				} else if ("pin".equals(configKey)) {
+					logger.debug("PIN for " + deviceId + " is " + value);
+					deviceConfig.pin = value;
+				} else if ("refreshInterval".equals(configKey)) {
+					logger.debug("refreshInterval is " + value);
+					refreshInterval = Long.parseLong(value);
+				}
+				else {
+					throw new ConfigurationException(configKey, "the given config key '" + configKey + "' is unknown");
+				}
+			}
+			
+			// open connection to radio
+			for (String device : deviceConfigCache.keySet()) {
+				FrontierSiliconRadio radio = deviceConfigCache.get(device).getRadio();
+				if (radio != null) {
+					radio.login();
+				}
+			}
+		}
+
+		setProperlyConfigured(true);
+	}
+	
+	/**
+	 * Hold the binding configuration, consisting of:
+	 * - deviceID (e.g. "sleepingroom")
+	 * - host (e.g. "192.167.2.23" )
+	 * - portnumber (defaults to 80)
+	 * - Access PIN (e.g. 1234) 
+	 * 
+	 * @author Rainer Ostendorf
+	 *
+	 */
+	class FrontierSiliconRadioBindingConfig  {
+	
+		String deviceId; // the endpoint identifier, e.g. "RadioKitchen"
+		String host;     // hostname or ip
+		int port = DEFAULT_PORT; // TCP portnumber
+		String pin = DEFAULT_PIN; 
+		
+		FrontierSiliconRadio radio = null;
+
+		public FrontierSiliconRadioBindingConfig(String deviceId) {
+			this.deviceId = deviceId;
+		}
+
+		public String getHost(){
+			return host;
+		}
+		
+		public int getPort(){
+			return port;
+		}
+		
+		@Override
+		public String toString() {
+			return "Device [id=" + deviceId + ", host=" + host + ", port=" + port + ",  pin: "+ pin + "]";
+		}
+
+		FrontierSiliconRadio getRadio() {
+			if (radio == null) {
+				logger.debug("creating new connection to " + host + ":" + port );
+				radio = new FrontierSiliconRadio(host, port, pin);
+			}
+			return radio;
+		}
+	}
+}

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioBinding.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioBinding.java
@@ -99,8 +99,6 @@ public class FrontierSiliconRadioBinding extends AbstractActiveBinding<FrontierS
 	 */
 	@Override
 	protected void execute() {
-		// the frequently executed code (polling) goes here ...
-		logger.debug("execute() method is called!");
 		
 		for (FrontierSiliconRadioBindingProvider provider : providers) {
 			for (String itemName : provider.getItemNames() ) {
@@ -250,10 +248,7 @@ public class FrontierSiliconRadioBinding extends AbstractActiveBinding<FrontierS
 	 */
 	@Override
 	protected void internalReceiveUpdate(String itemName, State newState) {
-		// the code being executed when a state was sent on the openHAB
-		// event bus goes here. This method is only called if one of the 
-		// BindingProviders provide a binding for the given 'itemName'.
-		logger.debug("internalReceiveCommand() is called!");
+		
 	}
 		
 	/**
@@ -329,7 +324,7 @@ public class FrontierSiliconRadioBinding extends AbstractActiveBinding<FrontierS
 	}
 	
 	/**
-	 * Hold the binding configuration, consisting of:
+	 * Holds the binding configuration, consisting of:
 	 * - deviceID (e.g. "sleepingroom")
 	 * - host (e.g. "192.167.2.23" )
 	 * - portnumber (defaults to 80)

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioBinding.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioBinding.java
@@ -21,10 +21,12 @@ import org.openhab.binding.frontiersiliconradio.FrontierSiliconRadioBindingProvi
 import org.openhab.core.binding.AbstractActiveBinding;
 import org.openhab.core.library.items.DimmerItem;
 import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.types.UpDownType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.osgi.service.cm.ConfigurationException;
@@ -139,7 +141,7 @@ public class FrontierSiliconRadioBinding extends AbstractActiveBinding<FrontierS
 								if( provider.getItemType(itemName) == DimmerItem.class )
 									eventPublisher.postUpdate(itemName, new PercentType( radio.convertVolumeToPercent(volume) ) );
 								else
-									eventPublisher.postUpdate(itemName, new DecimalType( volume ) );
+									eventPublisher.postUpdate(itemName, new DecimalType( radio.convertVolumeToPercent(volume) ) );
 								break;
 							case "PLAYINFONAME":
 								String playInfoName = radio.getPlayInfoName();
@@ -162,7 +164,7 @@ public class FrontierSiliconRadioBinding extends AbstractActiveBinding<FrontierS
 						}
 		
 					} else {
-						logger.error("deviceConf is null");								
+						logger.error("deviceConf is null, no config found for deviceId: '" + deviceId +"'. Check binding config.");								
 					}
 				}
 			}
@@ -209,13 +211,23 @@ public class FrontierSiliconRadioBinding extends AbstractActiveBinding<FrontierS
 									radio.setPower(false);
 								}
 								break;
-							case "VOLUME":	
-								Integer volumeCommand = ((DecimalType) command).intValue() ;
-								if (command instanceof PercentType) {
+							case "VOLUME":
+								if (command instanceof IncreaseDecreaseType) {
+									if (command.equals(IncreaseDecreaseType.INCREASE) )
+										radio.increaseVolume();
+									else
+										radio.decreaseVolume();
+								}
+								else if (command instanceof UpDownType) {
+									if (command.equals(UpDownType.UP) )
+										radio.increaseVolume();
+									else
+										radio.decreaseVolume();
+								}
+								else {
+									Integer volumeCommand = ((DecimalType) command).intValue();
 									Integer absoluteVolume = radio.convertPercentToVolume(volumeCommand);
 									radio.setVolume( absoluteVolume );
-								} else {
-									radio.setVolume(volumeCommand);
 								}
 								break;
 							case "MODE":

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioConnection.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioConnection.java
@@ -75,7 +75,7 @@ public class FrontierSiliconRadioConnection {
 		
 		String url = "http://" + hostname + ":" + port + "/fsapi/CREATE_SESSION?pin=" + pin;
 		
-		logger.debug("Opening URL:" + url);
+		logger.trace("opening URL:" + url);
 		
 		HttpMethod method = new GetMethod( url );
         method.getParams().setSoTimeout( SOCKET_TIMEOUT );
@@ -90,14 +90,14 @@ public class FrontierSiliconRadioConnection {
 
 			String responseBody = IOUtils.toString(method.getResponseBodyAsStream());
 			if (!responseBody.isEmpty()) {
-				logger.debug("login response: " + responseBody);
+				logger.trace("login response: " + responseBody);
 			}
 			
 			try {
 				FrontierSiliconRadioApiResult result = new FrontierSiliconRadioApiResult(responseBody);
 				if( result.isStatusOk() )
 				{
-					logger.debug("login successful");
+					logger.trace("login successful");
 					sessionId = result.getSessionId();
 					isLoggedIn = true;
 				}
@@ -142,7 +142,7 @@ public class FrontierSiliconRadioConnection {
 	 */
 	public FrontierSiliconRadioApiResult doRequest( String requestString, String params) {
 		
-		int retries = 3;
+		int retries = 3; // number of retries upon failure
 		
 		while(retries>0)
 		{

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioConnection.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioConnection.java
@@ -172,6 +172,9 @@ public class FrontierSiliconRadioConnection {
 				int statusCode = httpClient.executeMethod(method);
 				if (statusCode != HttpStatus.SC_OK) {
 					logger.warn("Method failed: " + method.getStatusLine());
+					isLoggedIn = false;
+					method.releaseConnection();
+					continue;
 				}
 	
 				String responseBody = IOUtils.toString(method.getResponseBodyAsStream());
@@ -180,12 +183,17 @@ public class FrontierSiliconRadioConnection {
 				}
 				else {
 					logger.debug("got empty result" );
+					isLoggedIn = false;
+					method.releaseConnection();
+					continue;
 				}
 				
 				FrontierSiliconRadioApiResult result = new FrontierSiliconRadioApiResult(responseBody);
 				if( result.isStatusOk() )
 					return result;
 				else {
+					isLoggedIn = false;
+					method.releaseConnection();
 					continue; // try again
 				}
 			}

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioConnection.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioConnection.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2010-2013, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.openhab.binding.frontiersiliconradio.internal;
+
+import java.io.IOException;
+
+import org.apache.commons.httpclient.DefaultHttpMethodRetryHandler;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpException;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.params.HttpMethodParams;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+
+
+/**
+ * This class holds the http-connection and 
+ * session information for controlling the radio.
+ * 
+ * @author Rainer Ostendorf
+ *
+ */
+public class FrontierSiliconRadioConnection {
+	
+	private static final Logger logger = LoggerFactory.getLogger(FrontierSiliconRadioConnection.class);
+	
+	// hostname of the radio
+	private String hostname;
+	
+	// portnumber, usually 80
+	private int port;
+	
+	// access pin, passed upon login as GET parameter
+	String pin;
+	
+	// the session ID we get from the radio after logging in
+	String sessionId;
+	
+	// the timeout for HTTP requests
+	private final static int SOCKET_TIMEOUT = 5000; //ms
+	
+	// http clients, store cookies, so it is kept in connection class
+	HttpClient httpClient = null;
+	
+	// flag indicating if we are successfully logged in
+	private Boolean isLoggedIn = false;
+	
+	public FrontierSiliconRadioConnection( String hostname, int port, String pin ) {
+		this.hostname = hostname;
+		this.port = port;
+		this.pin = pin;
+	}
+	
+	/**
+	 *  Perform login/establish a new session. Uses the PIN number and when
+	 *  sucessful saves the assigned sessionID for future requests.
+	 */
+	public void doLogin() {
+		
+		if( httpClient == null ) {
+			httpClient = new HttpClient();
+		}
+		
+		String url = "http://" + hostname + ":" + port + "/fsapi/CREATE_SESSION?pin=" + pin;
+		
+		logger.debug("Opening URL:" + url);
+		
+		HttpMethod method = new GetMethod( url );
+        method.getParams().setSoTimeout( SOCKET_TIMEOUT );
+		method.getParams().setParameter(HttpMethodParams.RETRY_HANDLER, new DefaultHttpMethodRetryHandler(3, false) );
+		
+		try {
+			
+			int statusCode = httpClient.executeMethod(method);
+			if (statusCode != HttpStatus.SC_OK) {
+				logger.warn("Method failed: " + method.getStatusLine());
+			}
+
+			String responseBody = IOUtils.toString(method.getResponseBodyAsStream());
+			if (!responseBody.isEmpty()) {
+				logger.debug("login response: " + responseBody);
+			}
+			
+			try {
+				FrontierSiliconRadioApiResult result = new FrontierSiliconRadioApiResult(responseBody);
+				if( result.isStatusOk() )
+				{
+					logger.debug("login successful");
+					sessionId = result.getSessionId();
+					isLoggedIn = true;
+				}
+			}
+			catch (Exception e) {
+				logger.error("Parsing response failed");
+			}
+
+		}
+		catch (HttpException he) {
+			logger.error("Fatal protocol violation: {}", he.toString());
+		}
+		catch (IOException ioe) {
+			logger.error("Fatal transport error: {}", ioe.toString());
+		}
+		finally {
+			method.releaseConnection();
+		}
+	}
+	
+	/**
+	 * Performs a request to the radio with no further parameters.
+	 * 
+	 * Typically used for polling state info.
+	 * 
+	 * @param REST API requestString, e.g. "GET/netRemote.sys.power"
+	 * @return request result
+	 */
+	public FrontierSiliconRadioApiResult doRequest( String requestString) {
+		return doRequest(requestString, new String("") );
+	}
+	
+
+	/**
+	 * Performs a request to the radio with addition parameters.
+	 * 
+	 * Typically used for changing parameters.
+	 * 
+	 * @param REST API requestString, e.g. "SET/netRemote.sys.power"
+	 * @param params, e.g. "value=1"
+	 * @return request result
+	 */
+	public FrontierSiliconRadioApiResult doRequest( String requestString, String params) {
+		
+		int retries = 3;
+		
+		while(retries>0)
+		{
+			retries--;
+		
+			if( !isLoggedIn )
+			{
+				doLogin();
+				continue;
+			}
+			
+			String url;
+			if( params.length() > 0)
+				url = "http://" + hostname + ":" + port + "/fsapi/"+ requestString +"?pin=" + pin + "&sid=" + sessionId + "&"  + params;
+			else
+				url = "http://" + hostname + ":" + port + "/fsapi/"+ requestString +"?pin=" + pin + "&sid=" + sessionId;
+			
+			
+			logger.trace("calling url: '"+url+"'");
+			
+			HttpMethod method = new GetMethod( url );
+	        method.getParams().setSoTimeout( SOCKET_TIMEOUT );
+			method.getParams().setParameter(HttpMethodParams.RETRY_HANDLER, new DefaultHttpMethodRetryHandler(3, false) );
+			
+			try {
+				
+				int statusCode = httpClient.executeMethod(method);
+				if (statusCode != HttpStatus.SC_OK) {
+					logger.warn("Method failed: " + method.getStatusLine());
+				}
+	
+				String responseBody = IOUtils.toString(method.getResponseBodyAsStream());
+				if (!responseBody.isEmpty()) {
+					logger.trace("got result: " + responseBody );
+				}
+				else {
+					logger.debug("got empty result" );
+				}
+				
+				FrontierSiliconRadioApiResult result = new FrontierSiliconRadioApiResult(responseBody);
+				if( result.isStatusOk() )
+					return result;
+				else {
+					continue; // try again
+				}
+			}
+			catch (HttpException he) {
+				logger.error("Fatal protocol violation: {}", he.toString());
+				isLoggedIn = false;
+			}
+			catch (IOException ioe) {
+				logger.error("Fatal transport error: {}", ioe.toString());
+			}
+			finally {
+				method.releaseConnection();
+			}			
+		}
+		isLoggedIn = false; // 3 tries failed. log in again next time, maybe our session went invalid (radio restarted?)
+		return null;
+	}
+}

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioGenericBindingProvider.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2010-2014, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.frontiersiliconradio.internal;
+
+
+import org.openhab.binding.frontiersiliconradio.FrontierSiliconRadioBindingProvider;
+import org.openhab.core.binding.BindingConfig;
+import org.openhab.core.items.Item;
+import org.openhab.model.item.binding.AbstractGenericBindingProvider;
+import org.openhab.model.item.binding.BindingConfigParseException;
+
+
+/**
+ * This class is responsible for parsing the binding configuration.
+ * 
+ * @author Rainer Ostendorf
+ * @since 1.7.0
+ */
+public class FrontierSiliconRadioGenericBindingProvider extends AbstractGenericBindingProvider implements FrontierSiliconRadioBindingProvider {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public String getBindingType() {
+		return "frontiersiliconradio";
+	}
+	
+	public String getProperty( String itemName ) {
+		FrontierSiliconRadioBindingConfig config = (FrontierSiliconRadioBindingConfig) bindingConfigs.get(itemName);
+		return config != null ? config.property : null;
+	}
+	
+	public String getDeviceID( String itemName ) {
+		FrontierSiliconRadioBindingConfig config = (FrontierSiliconRadioBindingConfig) bindingConfigs.get(itemName);
+		return config != null ? config.deviceId : null;
+	}
+
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	public void validateItemType(Item item, String bindingConfig) throws BindingConfigParseException {
+		
+		
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void processBindingConfiguration(String context, Item item, String bindingConfig) throws BindingConfigParseException {
+		super.processBindingConfiguration(context, item, bindingConfig);
+		
+		FrontierSiliconRadioBindingConfig config = new FrontierSiliconRadioBindingConfig();
+		
+		String[] configParts = bindingConfig.trim().split(":");
+		if (configParts.length != 2) {
+			throw new BindingConfigParseException("FrontierSiliconRadio configuration must contain of two parts separated by a ':'");
+		}
+		
+		config.deviceId = configParts[0];
+		config.property = configParts[1];
+		config.itemType = item.getClass();
+		
+		addBindingConfig(item, config);		
+	}
+	
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	public Class<? extends Item> getItemType(String itemName) {
+		FrontierSiliconRadioBindingConfig config = (FrontierSiliconRadioBindingConfig) bindingConfigs.get(itemName);
+		return config != null ? config.itemType : null;
+	}
+	
+	
+	class FrontierSiliconRadioBindingConfig implements BindingConfig {
+		// device id, identifying the radio, e.g. "RadioSleepingroom"
+		String deviceId;
+		
+		// Parameter, e.g. "Power", "Mute" or "Volume"
+		String property; 
+		
+		// item type
+		Class<? extends Item> itemType;
+	}
+}

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/resources/readme.txt
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/resources/readme.txt
@@ -1,0 +1,1 @@
+Bundle resources go in here!

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1586,3 +1586,14 @@ tcp:refreshinterval=250
 #weather:location.<locationId2>.provider=
 #weather:location.<locationId2>.language=
 #weather:location.<locationId2>.updateInterval=
+
+############################### Silicon Frontier Radio Binding ###################################
+#
+# Hostname/IP of the radio to control
+frontiersiliconradio:radio.host=192.168.2.137
+
+# PIN access code of the radio (default: 1234)
+frontiersiliconradio:radio.pin=1234
+
+# Portnumber of the radio to control (optional, defaults to 80)
+#siliconfrontierradio:radio.port=80


### PR DESCRIPTION
This binding can be used for controlling internet/mp3 radios based on a
frontier silicon radio chipset.
Tested with a Hama IR110 internet radio.

Disclaimer: I am not a Java developer ... :)