### PR TITLE
fixed cut&paste mistake in binding archetype

### DIFF
--- a/bundles/archetype/org.openhab.archetype.binding/src/main/resources/archetype-resources/src/main/java/internal/__binding-name__Binding.java
+++ b/bundles/archetype/org.openhab.archetype.binding/src/main/resources/archetype-resources/src/main/java/internal/__binding-name__Binding.java
@@ -102,7 +102,7 @@ public class ${binding-name}Binding extends AbstractActiveBinding<${binding-name
 		// the code being executed when a state was sent on the openHAB
 		// event bus goes here. This method is only called if one of the 
 		// BindingProviders provide a binding for the given 'itemName'.
-		logger.debug("internalReceiveCommand() is called!");
+		logger.debug("internalReceiveUpdate() is called!");
 	}
 		
 	/**


### PR DESCRIPTION
nothing big, just a wrong debug message in the binding archetype. I didn't check if it is there in the bindings.