### PR TITLE
Zwave: Update products.xml: typo

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -1155,7 +1155,7 @@
 			</Reference>
 			<Model>WALLC-S</Model>
 			<Label lang="en">Wall Controller</Label>
-			<ConfigFile>zwaveme/zme_wallc.xml</ConfigFile>
+			<ConfigFile>zwaveme/zme_wallcs.xml</ConfigFile>
 		</Product>
 		<Product>
 			<Reference>


### PR DESCRIPTION
Chris,

there is a typo in the products.xml for the newly added zwave.me WALLC-S device.

Regards,
Matt