### PR TITLE
changed log level of fatal errors in charts

### DIFF
--- a/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/chart/ChartServlet.java
+++ b/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/chart/ChartServlet.java
@@ -246,9 +246,9 @@ public class ChartServlet extends HttpServlet implements ManagedService {
 					req.getParameter("items"), req.getParameter("groups"));
 			ImageIO.write(chart, provider.getChartType().toString(), res.getOutputStream());
 		} catch (ItemNotFoundException e) {
-			logger.error("Item not found error while generating chart.", e);
+			logger.info("Item not found error while generating chart: " + e.getMessage());
 		} catch (IllegalArgumentException e) {
-			logger.error("Illegal argument in chart", e);
+			logger.info("Illegal argument in chart: " + e.getMessage());
 		}
 	}
 

--- a/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/chart/ChartServlet.java
+++ b/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/chart/ChartServlet.java
@@ -246,9 +246,9 @@ public class ChartServlet extends HttpServlet implements ManagedService {
 					req.getParameter("items"), req.getParameter("groups"));
 			ImageIO.write(chart, provider.getChartType().toString(), res.getOutputStream());
 		} catch (ItemNotFoundException e) {
-			logger.debug("Item not found error while generating chart.");
+			logger.error("Item not found error while generating chart.", e);
 		} catch (IllegalArgumentException e) {
-			logger.debug("Illegal argument in chart: {}", e);
+			logger.error("Illegal argument in chart", e);
 		}
 	}
 

--- a/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/chart/ChartServlet.java
+++ b/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/chart/ChartServlet.java
@@ -246,9 +246,9 @@ public class ChartServlet extends HttpServlet implements ManagedService {
 					req.getParameter("items"), req.getParameter("groups"));
 			ImageIO.write(chart, provider.getChartType().toString(), res.getOutputStream());
 		} catch (ItemNotFoundException e) {
-			logger.info("Item not found error while generating chart: " + e.getMessage());
+			logger.info("Item not found error while generating chart: {}", e);
 		} catch (IllegalArgumentException e) {
-			logger.info("Illegal argument in chart: " + e.getMessage());
+			logger.info("Illegal argument in chart: {}", e);
 		}
 	}
 


### PR DESCRIPTION
The log level DEBUG makes it quite hard to find a problem with wrong
parameters in charts. (Particularly as even logback_debug.xml sets the
level of messages from everything below org.openhab.ui to INFO.)

I am not completely sure if ERROR is the right level to use here, perhaps
WARNING (or even INFO) could be enough. But DEBUG is definitely too
low IMHO.