### PR TITLE
Max binding cul config

### DIFF
--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/CULHandler.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/CULHandler.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.io.transport.cul;
 
+import java.util.Map;
+
 /**
  * An interface representing a culfw based device. Can only be obtained via
  * CULManager and has to be closed via CULManager. Classes implementing this
@@ -57,4 +59,12 @@ public interface CULHandler {
 	 * @return number of 10ms transmit credits remaining
 	 */
 	public int getCredit10ms();
+
+
+	/**
+	 * Checks if all properties which are used by the CULHandler implementation are equal
+	 *
+	 * @return true if all are equal
+	 */
+	public boolean arePropertiesEqual(Map<String, ?> properties);
 }

--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/CULManager.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/CULManager.java
@@ -77,7 +77,7 @@ public class CULManager {
 
 			if (openDevices.containsKey(deviceName)) {
 				CULHandler handler = openDevices.get(deviceName);
-				if (handler.getCULMode() == mode) {
+				if ((handler.getCULMode() == mode)  && (handler.arePropertiesEqual(properties))){
 					logger.debug("Device " + deviceName + " is already open in mode " + mode.toString()
 							+ ", returning already openend handler");
 					return handler;

--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/AbstractCULHandler.java
@@ -13,6 +13,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
@@ -26,7 +27,6 @@ import org.openhab.io.transport.cul.CULMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Abstract base class for all CULHandler which brings some convenience
  * regarding registering listeners and detecting forbidden messages.
@@ -34,9 +34,11 @@ import org.slf4j.LoggerFactory;
  * @author Till Klocke
  * @since 1.4.0
  */
-public abstract class AbstractCULHandler implements CULHandler, CULHandlerInternal {
+public abstract class AbstractCULHandler implements CULHandler,
+		CULHandlerInternal {
 
-	private final static Logger log = LoggerFactory.getLogger(AbstractCULHandler.class);
+	private final static Logger log = LoggerFactory
+			.getLogger(AbstractCULHandler.class);
 
 	/**
 	 * Thread which sends all queued commands to the CUL.
@@ -125,6 +127,9 @@ public abstract class AbstractCULHandler implements CULHandler, CULHandlerIntern
 	}
 
 	@Override
+	public abstract boolean arePropertiesEqual(Map<String, ?> properties);
+
+	@Override
 	public void registerListener(CULListener listener) {
 		if (listener != null) {
 			listeners.add(listener);
@@ -175,10 +180,10 @@ public abstract class AbstractCULHandler implements CULHandler, CULHandlerIntern
 	}
 
 	@Override
-	public void sendWithoutCheck(String message) throws CULCommunicationException {
+	public void sendWithoutCheck(String message)
+			throws CULCommunicationException {
 		sendQueue.add(message);
 	}
-
 
 	/**
 	 * Checks if the message would alter the RF mode of this device.
@@ -204,7 +209,8 @@ public abstract class AbstractCULHandler implements CULHandler, CULHandlerIntern
 	 */
 	protected void notifyDataReceived(String data) {
 		for (final CULListener listener : listeners) {
-			receiveExecutor.execute(new NotifyDataReceivedRunner(listener, data));
+			receiveExecutor
+					.execute(new NotifyDataReceivedRunner(listener, data));
 		}
 	}
 
@@ -214,20 +220,21 @@ public abstract class AbstractCULHandler implements CULHandler, CULHandlerIntern
 		}
 	}
 
-	
 	/**
 	 * read and process next line from underlying transport.
-	 * @throws CULCommunicationException if 
+	 *
+	 * @throws CULCommunicationException
+	 *             if
 	 */
-	protected void processNextLine() throws CULCommunicationException  {
+	protected void processNextLine() throws CULCommunicationException {
 		try {
 			String data = br.readLine();
-			if(data==null){
-				String msg="EOF encountered for "+deviceName;
+			if (data == null) {
+				String msg = "EOF encountered for " + deviceName;
 				log.error(msg);
 				throw new CULCommunicationException(msg);
 			}
-			
+
 			log.debug("Received raw message from CUL: " + data);
 			if ("EOB".equals(data)) {
 				log.warn("(EOB) End of Buffer. Last message lost. Try sending less messages per time slot to the CUL");
@@ -235,38 +242,38 @@ public abstract class AbstractCULHandler implements CULHandler, CULHandlerIntern
 			} else if ("LOVF".equals(data)) {
 				log.warn("(LOVF) Limit Overflow: Last message lost. You are using more than 1% transmitting time. Reduce the number of rf messages");
 				return;
-			} else if (data.matches("^\\d+\\s+\\d+"))
-			{					
+			} else if (data.matches("^\\d+\\s+\\d+")) {
 				processCreditReport(data);
 				return;
 			}
 			notifyDataReceived(data);
 			requestCreditReport();
-						
+
 		} catch (IOException e) {
-			log.error("Exception while reading from CUL port "+deviceName, e);
+			log.error("Exception while reading from CUL port " + deviceName, e);
 			notifyError(e);
-			
+
 			throw new CULCommunicationException(e);
-		}				
+		}
 	}
 
 	/**
 	 * process data received from credit report
+	 *
 	 * @param data
 	 */
 	private void processCreditReport(String data) {
 		// Credit report received
-		String[] report = data.split(" ");					
-		credit10ms = Integer.parseInt(report[report.length-1]);
-		log.debug("credit10ms = "+credit10ms);
+		String[] report = data.split(" ");
+		credit10ms = Integer.parseInt(report[report.length - 1]);
+		log.debug("credit10ms = " + credit10ms);
 	}
-	
 
 	/**
-	 * get the remaining send time on channel as seen at the last send/receive event.
+	 * get the remaining send time on channel as seen at the last send/receive
+	 * event.
 	 * 
-	 * @return  remaining send time in 10ms units
+	 * @return remaining send time in 10ms units
 	 */
 	public int getCredit10ms() {
 		return credit10ms;
@@ -292,8 +299,9 @@ public abstract class AbstractCULHandler implements CULHandler, CULHandlerIntern
 	 * @param message
 	 * @throws CULCommunicationException
 	 */
-	private  void writeMessage(String message) throws CULCommunicationException {
-		log.debug("Sending raw message to CUL "+deviceName+":  '"+ message+"'");
+	private void writeMessage(String message) throws CULCommunicationException {
+		log.debug("Sending raw message to CUL " + deviceName + ":  '" + message
+				+ "'");
 		if (bw == null) {
 			log.error("Can't write message, BufferedWriter is NULL");
 		}
@@ -302,11 +310,11 @@ public abstract class AbstractCULHandler implements CULHandler, CULHandlerIntern
 				bw.write(message);
 				bw.flush();
 			} catch (IOException e) {
-				log.error("Can't write to CUL "+deviceName, e);
+				log.error("Can't write to CUL " + deviceName, e);
 			}
-			
+
 			requestCreditReport();
 		}
-	
+
 	}
 }

--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/CULNetworkHandlerImpl.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/CULNetworkHandlerImpl.java
@@ -26,7 +26,6 @@ import org.openhab.io.transport.cul.CULMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Implementation for culfw based devices which communicate via network port
  * (CUN for example).
@@ -37,6 +36,7 @@ import org.slf4j.LoggerFactory;
 public class CULNetworkHandlerImpl extends AbstractCULHandler {
 
 	private static final int CUN_DEFAULT_PORT = 2323;
+
 	/**
 	 * Thread which receives all data from the CUL.
 	 * 
@@ -46,15 +46,16 @@ public class CULNetworkHandlerImpl extends AbstractCULHandler {
 	 */
 	private class ReceiveThread extends Thread {
 
-		private final Logger logger = LoggerFactory.getLogger(ReceiveThread.class);
+		private final Logger logger = LoggerFactory
+				.getLogger(ReceiveThread.class);
 
 		/**
 		 * Mark this thread
 		 */
-		ReceiveThread(){
+		ReceiveThread() {
 			super("CUL ReceiveThread");
 		}
-		
+
 		@Override
 		public void run() {
 
@@ -70,64 +71,70 @@ public class CULNetworkHandlerImpl extends AbstractCULHandler {
 				}
 				logger.debug("ReceiveThread exiting.");
 			} catch (CULCommunicationException e) {
-				log.error("Connection to CUL broken, terminating receive thread for " + deviceName);
+				log.error("Connection to CUL broken, terminating receive thread for "
+						+ deviceName);
 			}
 		}
 
 	}
-	
-	final static Logger log = LoggerFactory.getLogger(CULNetworkHandlerImpl.class);
+
+	final static Logger log = LoggerFactory
+			.getLogger(CULNetworkHandlerImpl.class);
 
 	private ReceiveThread receiveThread;
-	
+
 	private Socket socket;
 	private InputStream is;
 	private OutputStream os;
-	
-	
+
 	public CULNetworkHandlerImpl(String deviceName, CULMode mode) {
-		super(deviceName, mode);
+		this(deviceName, mode, null);
 	}
 
 	/**
-	 * Constructor including property map for specific configuration. Just for compatibility with CulSerialHandlerImpl
+	 * Constructor including property map for specific configuration. Just for
+	 * compatibility with CulSerialHandlerImpl
+	 *
 	 * @param deviceName
-	 * 			String representing the device.
+	 *            String representing the device.
 	 * @param mode
-	 * 			The RF mode for which the device will be configured.
+	 *            The RF mode for which the device will be configured.
 	 * @param properties
-	 * 			Properties are ignored
+	 *            Properties are ignored
 	 */
-	public CULNetworkHandlerImpl(String deviceName, CULMode mode, Map<String, ?> properties){
-		super(deviceName, mode);		
+	public CULNetworkHandlerImpl(String deviceName, CULMode mode,
+			Map<String, ?> properties) {
+		super(deviceName, mode);
 	}
-	
+
 	@Override
 	protected void openHardware() throws CULDeviceException {
 		log.debug("Opening network CUL connection for " + deviceName);
 		try {
-			 URI uri = new URI("cul://" + deviceName);
-			  String host = uri.getHost();
-			  int port = uri.getPort()==-1?CUN_DEFAULT_PORT:uri.getPort();
+			URI uri = new URI("cul://" + deviceName);
+			String host = uri.getHost();
+			int port = uri.getPort() == -1 ? CUN_DEFAULT_PORT : uri.getPort();
 
-			  if (uri.getHost() == null || uri.getPort() == -1) {
-					throw new CULDeviceException("Could not parse host:port from "+deviceName);
-			  }
-			log.debug("Opening network CUL connection to " + host+":"+port);
-			socket=new Socket(host, port);
-			log.info("Connected network CUL connection to " + host+":"+port);
+			if (uri.getHost() == null || uri.getPort() == -1) {
+				throw new CULDeviceException("Could not parse host:port from "
+						+ deviceName);
+			}
+			log.debug("Opening network CUL connection to " + host + ":" + port);
+			socket = new Socket(host, port);
+			log.info("Connected network CUL connection to " + host + ":" + port);
 			is = socket.getInputStream();
 			os = socket.getOutputStream();
 			br = new BufferedReader(new InputStreamReader(is));
 			bw = new BufferedWriter(new OutputStreamWriter(os));
 
 			log.debug("Starting network listener Thread");
-			receiveThread=new ReceiveThread();
+			receiveThread = new ReceiveThread();
 			receiveThread.start();
 		} catch (IOException e) {
 			throw new CULDeviceException(e);
 		} catch (URISyntaxException e) {
-			throw new CULDeviceException("Could not parse host:port from "+deviceName, e);
+			throw new CULDeviceException("Could not parse host:port from "
+					+ deviceName, e);
 		}
 
 	}
@@ -135,9 +142,9 @@ public class CULNetworkHandlerImpl extends AbstractCULHandler {
 	@Override
 	protected void closeHardware() {
 		receiveThread.interrupt();
-		
+
 		log.debug("Closing network device " + deviceName);
-		
+
 		try {
 			if (br != null) {
 				br.close();
@@ -156,5 +163,14 @@ public class CULNetworkHandlerImpl extends AbstractCULHandler {
 				}
 			}
 		}
-	}	
+	}
+
+	/**
+	 * Returns always true, because connection properties are ignored for a
+	 * network connection.
+	 */
+	@Override
+	public boolean arePropertiesEqual(Map<String, ?> properties) {
+		return true;
+	}
 }

--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/CULSerialHandlerImpl.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/internal/CULSerialHandlerImpl.java
@@ -24,15 +24,22 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.TooManyListenersException;
 
+import org.apache.commons.lang.StringUtils;
 import org.openhab.io.transport.cul.CULCommunicationException;
 import org.openhab.io.transport.cul.CULDeviceException;
 import org.openhab.io.transport.cul.CULMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * Implementation for culfw based devices which communicate via serial port
@@ -42,55 +49,155 @@ import org.slf4j.LoggerFactory;
  * @author Till Klocke
  * @since 1.4.0
  */
-public class CULSerialHandlerImpl extends AbstractCULHandler implements SerialPortEventListener {
+public class CULSerialHandlerImpl extends AbstractCULHandler implements
+		SerialPortEventListener {
 
-	final static Logger log = LoggerFactory.getLogger(CULSerialHandlerImpl.class);
+	private static final Map<String, Integer> validParitiesMap;
+	static {
+		Map<String, Integer> parities = new HashMap<String, Integer>();
+		parities.put("EVEN", SerialPort.PARITY_EVEN);
+		parities.put("ODD", SerialPort.PARITY_ODD);
+		parities.put("MARK", SerialPort.PARITY_MARK);
+		parities.put("NONE", SerialPort.PARITY_NONE);
+		parities.put("SPACE", SerialPort.PARITY_SPACE);
+		validParitiesMap = Collections.unmodifiableMap(parities);
+	}
+
+	private static final List<Integer> validBaudrateMap;
+	static {
+		Integer baudrates[] = {75, 110, 300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200};
+		validBaudrateMap = Collections.unmodifiableList(Arrays.asList(baudrates));
+	}
+
+	private final static Logger log = LoggerFactory
+			.getLogger(CULSerialHandlerImpl.class);
+
+	private final static String KEY_BAUDRATE = "baudrate";
+	private final static String KEY_PARITY = "parity";
 
 	private SerialPort serialPort;
 	private Integer baudRate = 9600;
 	private Integer parityMode = SerialPort.PARITY_EVEN;
 	private InputStream is;
 	private OutputStream os;
+
 	/**
 	 * Default Constructor
+	 *
 	 * @param deviceName
-	 * 			String representing the device.
+	 *            String representing the device.
 	 * @param mode
-	 * 			The RF mode for which the device will be configured.
+	 *            The RF mode for which the device will be configured.
 	 */
 	public CULSerialHandlerImpl(String deviceName, CULMode mode) {
-		super(deviceName, mode);
+		this(deviceName, mode, null);
 	}
-	
-	
+
 	/**
 	 * Constructor including property map for specific configuration.
+	 *
 	 * @param deviceName
-	 * 			String representing the device.
+	 *            String representing the device.
 	 * @param mode
-	 * 			The RF mode for which the device will be configured.
+	 *            The RF mode for which the device will be configured.
 	 * @param properties
-	 * 			Property Map containing specific configuration for serial device connection.
-	 * 			<ul>
-	 * 				<li>"baudrate" (Integer) Setup baudrate</li>
-	 * 				<li>"parity" (Integer) Setup parity bit handling. (http://show.docjava.com/book/cgij/code/data/j4pDoc/constant-values.html#serialPort.rxtx.SerialPortInterface.PARITY_NONE)
-	 * 			</ul>
+	 *            Property Map containing specific configuration for serial
+	 *            device connection.
+	 *            <ul>
+	 *            <li>"baudrate" (Integer) Setup baudrate</li>
+	 *            <li>"parity" (Integer) Setup parity bit handling.
+	 *            (http://show.
+	 *            docjava.com/book/cgij/code/data/j4pDoc/constant-values
+	 *            .html#serialPort.rxtx.SerialPortInterface.PARITY_NONE)
+	 *            </ul>
 	 */
-	public CULSerialHandlerImpl(String deviceName, CULMode mode, Map<String, ?> properties){
+	public CULSerialHandlerImpl(String deviceName, CULMode mode,
+			Map<String, ?> properties) {
 		super(deviceName, mode);
-		
-		if(properties.get("baudrate") != null){
-			baudRate = (Integer) properties.get("baudrate");
-			log.debug("Set baudrate to " + baudRate);
+
+		final String configuredBaudRate = (String) properties.get(KEY_BAUDRATE);
+		if (StringUtils.isNotBlank(configuredBaudRate)) {
+			try {
+				int tmpBaudRate = Integer.parseInt(configuredBaudRate);
+				if(validBaudrateMap.contains(tmpBaudRate)) {
+					baudRate = tmpBaudRate;
+				} else {
+					log.error(
+							"Error parsing config parameter '{}'. Value = {} is not a valid baudrate. Value must be in [75, 110, 300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200]",
+							KEY_BAUDRATE, tmpBaudRate);
+				}
+				log.info("Update config, {} = {}", KEY_BAUDRATE, baudRate);
+			} catch (NumberFormatException e) {
+				log.error(
+						"Error parsing config parameter '{}' to integer. Value = {}",
+						KEY_BAUDRATE, configuredBaudRate);
+			}
 		}
-		
-		if(properties.get("parity") != null){
-			parityMode = (Integer) properties.get("parity");
-			log.debug("Set parity to " + parityMode);
+
+		final String configuredParity = (String) properties.get(KEY_PARITY);
+		if (StringUtils.isNotBlank(configuredParity)) {
+			try {
+				if (isValidParity(configuredParity)) {
+					parityMode = validParitiesMap.get(configuredParity
+							.toUpperCase());
+				} else {
+					int parsedParityNumber = Integer.parseInt(configuredParity);
+					if (isValidParity(parsedParityNumber)) {
+						parityMode = parsedParityNumber;
+					} else {
+						log.error(
+								"The configured '{}' value is invalid. The value '{}' has to be one of {}.",
+								KEY_PARITY, parsedParityNumber,
+								validParitiesMap.keySet());
+					}
+				}
+				log.info("Update config, {} = {} ({})", KEY_PARITY,
+						convertParityModeToString(parityMode), parityMode);
+			} catch (NumberFormatException e) {
+				log.error("Error parsing config key '{}'. Use one of {}.",
+						KEY_PARITY, validParitiesMap.keySet());
+			}
 		}
-		
+
 	}
-	
+
+	/**
+	 * Checks if mode is a valid input for 'SerialPort' - class
+	 *
+	 * @param mode
+	 * @return true if valid
+	 */
+	private boolean isValidParity(int mode) {
+		return validParitiesMap.containsValue(mode);
+	}
+
+	/**
+	 * Checks if mode is a valid input for 'SerialPort' - class
+	 *
+	 * @param mode
+	 * @return true if valid
+	 */
+	private boolean isValidParity(String mode) {
+		return validParitiesMap.containsKey(mode.toUpperCase());
+	}
+
+	/**
+	 * converts modes integer representation into a readable sting
+	 *
+	 * @param mode
+	 * @return text if mode was valid, otherwise "invalid mode"
+	 */
+	private String convertParityModeToString(int mode) {
+		if (validParitiesMap.containsValue(mode)) {
+			for (Entry<String, Integer> parity : validParitiesMap.entrySet()) {
+				if (parity.getValue().equals(mode)) {
+					return parity.getKey();
+				}
+			}
+		}
+		return "invalid mode";
+	}
+
 	@Override
 	public void serialEvent(SerialPortEvent event) {
 		if (event.getEventType() == SerialPortEvent.DATA_AVAILABLE) {
@@ -106,17 +213,23 @@ public class CULSerialHandlerImpl extends AbstractCULHandler implements SerialPo
 	protected void openHardware() throws CULDeviceException {
 		log.debug("Opening serial CUL connection for " + deviceName);
 		try {
-			CommPortIdentifier portIdentifier = CommPortIdentifier.getPortIdentifier(deviceName);
+			CommPortIdentifier portIdentifier = CommPortIdentifier
+					.getPortIdentifier(deviceName);
 			if (portIdentifier.isCurrentlyOwned()) {
-				throw new CULDeviceException("The port " + deviceName + " is currenty used by "
+				throw new CULDeviceException("The port " + deviceName
+						+ " is currenty used by "
 						+ portIdentifier.getCurrentOwner());
 			}
-			CommPort port = portIdentifier.open(this.getClass().getName(), 2000);
+			CommPort port = portIdentifier
+					.open(this.getClass().getName(), 2000);
 			if (!(port instanceof SerialPort)) {
-				throw new CULDeviceException("The device " + deviceName + " is not a serial port");
+				throw new CULDeviceException("The device " + deviceName
+						+ " is not a serial port");
 			}
 			serialPort = (SerialPort) port;
-			serialPort.setSerialPortParams(baudRate, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, parityMode);
+
+			serialPort.setSerialPortParams(baudRate, SerialPort.DATABITS_8,
+					SerialPort.STOPBITS_1, parityMode);
 			is = serialPort.getInputStream();
 			os = serialPort.getOutputStream();
 			br = new BufferedReader(new InputStreamReader(is));
@@ -160,5 +273,49 @@ public class CULSerialHandlerImpl extends AbstractCULHandler implements SerialPo
 			}
 		}
 
+	}
+
+	/**
+	 * Compares KEY_BAUDRATE and KEY_PARITY to equality in properties map. The
+	 * values are not required, so if they're not present, they're handled as
+	 * equal, too!
+	 */
+	@Override
+	public boolean arePropertiesEqual(Map<String, ?> properties) {
+
+		if (properties == null) {
+			return false;
+		}
+
+		boolean baudRateEquals = mapContainsEqualValueByKey(properties,
+				KEY_BAUDRATE, baudRate);
+		boolean parityEquals = mapContainsEqualValueByKey(properties,
+				KEY_PARITY, parityMode);
+
+		return baudRateEquals && parityEquals;
+	}
+
+	/**
+	 * Check if a key in a map is present and in that case check equality of the
+	 * value to {value}.
+	 *
+	 * @param properties
+	 * @param key
+	 *            The key of the given properties
+	 * @param value
+	 *            Has to equal the properties value of key
+	 */
+	private boolean mapContainsEqualValueByKey(Map<String, ?> properties,
+			String key, Integer value) {
+		boolean result = true;
+		if (properties.containsKey(key)) {
+			try {
+				int mapValue = Integer.parseInt((String) properties.get(key));
+				result = (value == mapValue);
+			} catch (NumberFormatException e) {
+				result = false;
+			}
+		}
+		return result;
 	}
 }


### PR DESCRIPTION
Current CUL binding only supports only Cul-Devices with 9600 8E1.
At http://busware.de/ there are several more devices basing on the same firmware (culfw) bu using different configurations. e.g. SCC which is used with the Rasberry PI uses different serial settings (36400 8N1).

So I made some changes to be able to setup the serialport in the CUL-Binding configuration.
The properties baudrate and parity are now forwarded from the org.openhab.binding.maxcul config to the org.openhab.io.transport.cul module.

In the org.openhab.binding.maxcul there was a problem converting the parameters "baudrate" to integer.
Added parse method instead of cast operation.

All changes are backward compatible (if there is no property in config-file, the defaults (which are unchanged) are taken)

What is the prefered workflow for updating the documentation?