### PR TITLE
Add support for second wlan AP in fritzbox binding

### DIFF
--- a/bundles/binding/org.openhab.binding.fritzbox/src/main/java/org/openhab/binding/fritzbox/FritzboxBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.fritzbox/src/main/java/org/openhab/binding/fritzbox/FritzboxBindingProvider.java
@@ -34,6 +34,9 @@ public interface FritzboxBindingProvider extends BindingProvider {
 
 	/** binds wlan state to an item */
 	static final public String TYPE_WLAN = "wlan";
+	
+	/** binds second wlan state to an item */
+	static final public String TYPE_WLAN_SCND = "wlan2";
 
 	/** binds dect state to an item */
 	static final public String TYPE_DECT = "dect";
@@ -48,7 +51,7 @@ public interface FritzboxBindingProvider extends BindingProvider {
 	static final public String TYPE_COMMAND = "cmd";
 
 	static final public String[] TYPES = { TYPE_INBOUND, TYPE_OUTBOUND,
-			TYPE_ACTIVE, TYPE_WLAN, TYPE_DECT, TYPE_TAM, TYPE_QUERY,
+			TYPE_ACTIVE, TYPE_WLAN, TYPE_WLAN_SCND, TYPE_DECT, TYPE_TAM, TYPE_QUERY,
 			TYPE_COMMAND };
 
 	/**

--- a/bundles/binding/org.openhab.binding.fritzbox/src/main/java/org/openhab/binding/fritzbox/internal/FritzboxBinding.java
+++ b/bundles/binding/org.openhab.binding.fritzbox/src/main/java/org/openhab/binding/fritzbox/internal/FritzboxBinding.java
@@ -77,11 +77,15 @@ public class FritzboxBinding extends
 				"ctlmgr_ctl w dect settings/enabled");
 		commandMap.put(FritzboxBindingProvider.TYPE_WLAN,
 				"ctlmgr_ctl w wlan settings/ap_enabled");
+		commandMap.put(FritzboxBindingProvider.TYPE_WLAN_SCND,
+				"ctlmgr_ctl w wlan settings/ap_enabled_scnd");
 
 		queryMap.put(FritzboxBindingProvider.TYPE_DECT,
 				"ctlmgr_ctl r dect settings/enabled");
 		queryMap.put(FritzboxBindingProvider.TYPE_WLAN,
 				"ctlmgr_ctl r wlan settings/ap_enabled");
+		queryMap.put(FritzboxBindingProvider.TYPE_WLAN_SCND,
+				"ctlmgr_ctl r wlan settings/ap_enabled_scnd");
 	}
 
 	@Override


### PR DESCRIPTION
Hi

This is my first try with both github and openhab... The changes are not tested, but intend to add support for the second wlan ap in a FritzBox, such as the 7490.

Thanks for considering.

Best,
Chris