### PR TITLE
Ignore invalid actual temperature reading

### DIFF
--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/Device.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/Device.java
@@ -164,8 +164,11 @@ public abstract class Device {
 					logger.debug ("No temperature reading in {} mode", heatingThermostat.getMode()) ;
 				}
 			}
-			logger.debug ("Actual Temperature : {}",  (double)actualTemp / 10);
-			heatingThermostat.setTemperatureActual((double)actualTemp / 10);
+			
+			if (actualTemp != 0) {
+				logger.debug ("Actual Temperature : {}",  (double)actualTemp / 10);
+				heatingThermostat.setTemperatureActual((double)actualTemp / 10);
+			}
 			break;
 		case EcoSwitch:
 			String eCoSwitchData = Utils.toHex(raw[3] & 0xFF, raw[4] & 0xFF, raw[5] & 0xFF);


### PR DESCRIPTION
If actualTemp cannot be extracted (because of vacation or boost mode or if message is invalid/empty), don't publish an invalid actual temperature of 0 °C. This can happen if a window state is changed and the setpoint temperature of a thermostat is set to a new value.