### PR TITLE
use uppercase strings to compare two hex-value strings

### DIFF
--- a/bundles/binding/org.openhab.binding.fs20/src/main/java/org/openhab/binding/fs20/internal/FS20Command.java
+++ b/bundles/binding/org.openhab.binding.fs20/src/main/java/org/openhab/binding/fs20/internal/FS20Command.java
@@ -28,7 +28,8 @@ public enum FS20Command {
 	private final static Map<String, FS20Command> hexValueToCommand = new LinkedHashMap<String, FS20Command>();
 	static {
 		for (FS20Command c : FS20Command.values()) {
-			hexValueToCommand.put(c.getHexValue(), c);
+			String upperHexValue = c.getHexValue() == null ? null : c.getHexValue().toUpperCase();
+			hexValueToCommand.put(upperHexValue, c);
 		}
 	}
 
@@ -43,7 +44,8 @@ public enum FS20Command {
 	}
 
 	public static FS20Command getFromHexValue(String hexValue) {
-		FS20Command command = hexValueToCommand.get(hexValue);
+		if (hexValue == null) return UNKOWN;
+		FS20Command command = hexValueToCommand.get(hexValue.toUpperCase());
 		return command != null ? command : UNKOWN;
 	}
 }

--- a/bundles/binding/org.openhab.binding.fs20/src/test/java/org/openhab/binding/fs20/internal/FS20CommandHelperTest.java
+++ b/bundles/binding/org.openhab.binding.fs20/src/test/java/org/openhab/binding/fs20/internal/FS20CommandHelperTest.java
@@ -1,0 +1,23 @@
+package org.openhab.binding.fs20.internal;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.types.Command;
+
+public class FS20CommandHelperTest {
+	@Test
+	public void testConvertHABCommandToFS20Command() {
+		Command command = new PercentType(80);
+		FS20Command fs20Command = FS20CommandHelper.convertHABCommandToFS20Command(command);
+		
+		// Test for issue: FS20 - Converting Value to raw-message fails #1635
+		// see: https://github.com/openhab/openhab/issues/1635
+		assertNotEquals(fs20Command, FS20Command.UNKOWN);
+		assertNotEquals(fs20Command.toString(), null);
+		
+		// excepted value:
+		assertEquals(fs20Command, FS20Command.DIM_12);
+	}
+}


### PR DESCRIPTION
fixes issue: FS20 - Converting Value to raw-message fails #1635
openhab/openhab#1635