### PR TITLE
Add a test for parsing exec binding IN config

### DIFF
--- a/bundles/binding/org.openhab.binding.exec.test/src/test/java/org/openhab/binding/exec/internal/ExecGenericBindingProviderTest.java
+++ b/bundles/binding/org.openhab.binding.exec.test/src/test/java/org/openhab/binding/exec/internal/ExecGenericBindingProviderTest.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.exec.internal;
 
+import java.util.List;
 import junit.framework.Assert;
 
 import org.junit.Before;
@@ -46,4 +47,23 @@ public class ExecGenericBindingProviderTest {
 		Assert.assertEquals("and a fallback", config.get(StringType.valueOf("*")).commandLine);
 	}
 
+	@Test
+	public void testParseBindingConfigIn() throws BindingConfigParseException {
+		String     cmdLine = "/usr/bin/uptime";
+		String     itemName = "Switch";
+		SwitchItem item = new SwitchItem(itemName);
+		String     bindingConfig = "<[" + cmdLine + ":60000:]";
+
+		provider.processBindingConfiguration("New", item, bindingConfig);
+
+		Assert.assertTrue(provider.providesBinding());
+		Assert.assertTrue(provider.providesBindingFor(itemName));
+		Assert.assertEquals(cmdLine, provider.getCommandLine(itemName));
+
+		Assert.assertEquals(60000, provider.getRefreshInterval(itemName));
+		Assert.assertEquals("", provider.getTransformation(itemName));
+
+		List<String> itemNames = provider.getInBindingItemNames();
+		Assert.assertEquals(itemName, itemNames.get(0));
+	}
 }


### PR DESCRIPTION
Add a simple test to verify the correct parsing of an input exec
configuration.

Signed-off-by: domidimi