### PR TITLE
Bugfix #1980: anel-binding caused 100% cpu usage

### DIFF
--- a/bundles/binding/org.openhab.binding.anel/src/main/java/org/openhab/binding/anel/internal/AnelBinding.java
+++ b/bundles/binding/org.openhab.binding.anel/src/main/java/org/openhab/binding/anel/internal/AnelBinding.java
@@ -75,7 +75,7 @@ public class AnelBinding extends AbstractActiveBinding<AnelBindingProvider> impl
 	}
 
 	/** The refresh interval which is used to poll values from the Anel server. */
-	private long refreshInterval;
+	private long refreshInterval = AnelConfigReader.DEFAULT_REFRESH_INTERVAL;
 
 	/** Threads to communicate with Anel devices */
 	private final Map<String, AnelConnectorThread> connectorThreads = new HashMap<String, AnelConnectorThread>();
@@ -232,7 +232,7 @@ public class AnelBinding extends AbstractActiveBinding<AnelBindingProvider> impl
 
 		// clear map of previous threads because config changed
 		connectorThreads.clear();
-		refreshInterval = 0;
+		refreshInterval = AnelConfigReader.DEFAULT_REFRESH_INTERVAL;
 
 		// read new config
 		try {

--- a/bundles/binding/org.openhab.binding.anel/src/main/java/org/openhab/binding/anel/internal/AnelConfigReader.java
+++ b/bundles/binding/org.openhab.binding.anel/src/main/java/org/openhab/binding/anel/internal/AnelConfigReader.java
@@ -29,7 +29,7 @@ public class AnelConfigReader {
 	/**
 	 * Refresh rate with which the state is regularly updated.
 	 */
-	private final static long DEFAULT_REFRESH_INTERVAL = 60000;
+	final static long DEFAULT_REFRESH_INTERVAL = 60000;
 
 	/**
 	 * If cache period is set to a positive integer, then this specifies the
@@ -68,7 +68,7 @@ public class AnelConfigReader {
 	static long readConfig(Dictionary<String, ?> config, Map<String, AnelConnectorThread> threads,
 			IInternalAnelBinding bindingFacade) throws ConfigurationException {
 		if (config == null || config.isEmpty())
-			return 0;
+			return DEFAULT_REFRESH_INTERVAL;
 
 		long cachePeriod = DEFAULT_CACHE_PERIOD;
 		long refresh = DEFAULT_REFRESH_INTERVAL;


### PR DESCRIPTION
If refresh rate is not set in anel-configuration, the default rate for refresh thread (60s) was not read properly, so it used 0s instead. This caused the refresh rate to call 'execute()' every 0s which results in 100% cpu usage.