### PR TITLE
Fix for http binding not responding to wildcard outgoing commands

### DIFF
--- a/bundles/binding/org.openhab.binding.http.test/src/test/java/org/openhab/binding/http/internal/HttpGenericBindingProviderTest.java
+++ b/bundles/binding/org.openhab.binding.http.test/src/test/java/org/openhab/binding/http/internal/HttpGenericBindingProviderTest.java
@@ -200,8 +200,23 @@ public class HttpGenericBindingProviderTest {
 		Assert.assertEquals("http://localhost:42111/valuepost.html?id=4-SWITCHMULTILEVEL-user-byte-1-0&v=39", config.get(HttpGenericBindingProvider.CHANGED_COMMAND_KEY).url);
 	}
 	
+	@Test
+	public void testParseBindingWilcard() throws BindingConfigParseException {
+		String bindingConfig = ">[*:GET:http://192.168.0.2/RGB/%2$s] >[TWINKLE:PUT:http://192.168.0.2/PROGRAM/TWINKLE]";
+		
+		testItem = new StringTestItem("StringTestItem");
+		
+		provider.processBindingConfiguration("test", testItem, bindingConfig);
 
-	
+		Assert.assertEquals(provider.getUrl("StringTestItem", new StringType("0000FF")), "http://192.168.0.2/RGB/%2$s");
+		Assert.assertEquals(provider.getHttpMethod("StringTestItem", new StringType("0000FF")), "GET");
+		
+		Assert.assertEquals(provider.getUrl("StringTestItem", new StringType("TWINKLE")), "http://192.168.0.2/PROGRAM/TWINKLE");
+		Assert.assertEquals(provider.getHttpMethod("StringTestItem", new StringType("TWINKLE")), "PUT");
+		
+		Assert.assertEquals(provider.getUrl("StringTestItem", StringType.valueOf("CHANGED")), null);
+	}
+		
 	class StringTestItem extends GenericItem {
 		
 		public StringTestItem() {

--- a/bundles/binding/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/HttpGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/HttpGenericBindingProvider.java
@@ -305,7 +305,7 @@ public class HttpGenericBindingProvider extends AbstractGenericBindingProvider i
 	 */
 	public String getHttpMethod(String itemName, Command command) {
 		HttpBindingConfig config = (HttpBindingConfig) bindingConfigs.get(itemName);
-		return config != null && config.get(command) != null ? config.get(command).httpMethod : null;
+		return config != null && getConfigElement(config, command) != null ? getConfigElement(config, command).httpMethod : null;
 	}
 
 	/**
@@ -313,7 +313,7 @@ public class HttpGenericBindingProvider extends AbstractGenericBindingProvider i
 	 */
 	public String getUrl(String itemName, Command command) {
 		HttpBindingConfig config = (HttpBindingConfig) bindingConfigs.get(itemName);
-		return config != null && config.get(command) != null ? config.get(command).url : null;
+		return config != null && getConfigElement(config, command) != null ? getConfigElement(config, command).url : null;
 	}
 	
 	/**
@@ -321,7 +321,7 @@ public class HttpGenericBindingProvider extends AbstractGenericBindingProvider i
 	 */
 	public Properties getHttpHeaders(String itemName, Command command){
 		HttpBindingConfig config = (HttpBindingConfig) bindingConfigs.get(itemName);
-		return config != null && config.get(command) != null ? config.get(command).headers : null;
+		return config != null && getConfigElement(config, command) != null ? getConfigElement(config, command).headers : null;
 	}
 	
 	/**
@@ -371,7 +371,18 @@ public class HttpGenericBindingProvider extends AbstractGenericBindingProvider i
 		}
 		return inBindings;
 	}
-
+	
+	private HttpBindingConfigElement getConfigElement(HttpBindingConfig config, Command command) {
+		if (config.get(command) != null) {
+			return config.get(command);
+		}
+		
+		if (!CHANGED_COMMAND_KEY.equals(command)) {
+			return config.get(WILDCARD_COMMAND_KEY);
+		}
+		
+		return null;
+ 	}
 	
 	/**
 	 * This is an internal data structure to map commands to 


### PR DESCRIPTION
This fixes [this issue](https://groups.google.com/forum/#!searchin/openhab/string$20http$20not/openhab/SRLsk-A0Mnc/gcU6mk0DGSkJ) where wildcard outgoing commands are never triggered in the http binding. Seems the wildcard command was not considered when the actual command was not directly bound. 