### PR TITLE
Add additional blinds types

### DIFF
--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1Message.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComBlinds1Message.java
@@ -71,6 +71,9 @@ public class RFXComBlinds1Message extends RFXComBaseMessage {
 		AC114(3),
 		YR1326(4),		//Additional commands.
 		MEDIAMOUNT(5),	//MEDIA MOUNT have different direction commands then the rest!! needs to bee fixed.
+		DC106(6),
+		FOREST(7),
+		CS4330(8),		// Chamberlain CS4330
 		
 		UNKNOWN(255);
 


### PR DESCRIPTION
Added 3 more blind types, as found in RFXmgr. Was interested in T8, but others must be working as well.

To be forward ported to master as well.