### PR TITLE
MiOS Add initial Action/Rule support for the MiOS Bridge Binding.

### DIFF
--- a/bundles/action/org.openhab.action.mios/.classpath
+++ b/bundles/action/org.openhab.action.mios/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/action/org.openhab.action.mios/.project
+++ b/bundles/action/org.openhab.action.mios/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.action.mios</name>
+	<comment>This is the ${binding-name} binding of the open Home Automation Bus (openHAB)</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/action/org.openhab.action.mios/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.mios/META-INF/MANIFEST.MF
@@ -1,0 +1,28 @@
+Manifest-Version: 1.0
+Private-Package: org.openhab.action.mios.internal
+Ignore-Package: org.openhab.action.mios.internal
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-Name: openHAB MiOS Action
+Bundle-SymbolicName: org.openhab.action.mios
+Bundle-Vendor: openHAB.org
+Bundle-Version: 1.7.0.qualifier
+Bundle-Activator: org.openhab.action.mios.internal.MiosActivator
+Bundle-ManifestVersion: 2
+Bundle-Description: This is the MiOS action of the open Home Aut
+ omation Bus (openHAB)
+Import-Package: org.openhab.core.items,
+ org.openhab.core.library.items,
+ org.openhab.core.library.types,
+ org.openhab.core.scriptengine.action,
+ org.openhab.core.types,
+ org.eclipse.xtext.xbase.lib,
+ org.osgi.framework,
+ org.osgi.service.cm,
+ org.osgi.service.component,
+ org.slf4j
+Bundle-DocURL: http://www.openhab.org
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Service-Component: OSGI-INF/action.xml
+Bundle-ClassPath: .
+Bundle-ActivationPolicy: lazy
+Require-Bundle: org.openhab.binding.mios;bundle-version="1.7.0"

--- a/bundles/action/org.openhab.action.mios/OSGI-INF/action.xml
+++ b/bundles/action/org.openhab.action.mios/OSGI-INF/action.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2015, openHAB.org and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" immediate="true" name="org.openhab.action.mios.action">
+	<implementation class="org.openhab.action.mios.internal.MiosActionService" />
+
+	<service>
+		<provide interface="org.openhab.core.scriptengine.action.ActionService" />
+		<provide interface="org.osgi.service.cm.ManagedService" />
+	</service>
+
+	<property name="service.pid" type="String" value="org.openhab.mios.action" />
+
+ 	<reference bind="setMiosActionProvider" cardinality="1..1" interface="org.openhab.binding.mios.MiosActionProvider" name="MiosActionProvider" policy="static" unbind="unsetMiosActionProvider"/>
+</scr:component>

--- a/bundles/action/org.openhab.action.mios/README.md
+++ b/bundles/action/org.openhab.action.mios/README.md
@@ -1,0 +1,65 @@
+Documentation for the MiOS Action Binding.
+
+# Introduction
+This binding exposes openHAB Rule extensions to be used with the [MiOS Bridge Binding](https://github.com/openhab/openhab/wiki/MiOS-Binding).
+
+It exposes the ability to do the following things in the MiOS HA Controller from within [openHAB Rules](https://github.com/openhab/openhab/wiki/Rules):
+
+* `Device Actions` - Asynchronously invoke MiOS Device Actions involving 0, 1 or more parameters.
+* `Scenes Invocation` - Asynchronously invoke MiOS Scenes
+
+The MiOS Action Binding depends upon the installation of the MiOS Bridge Binding, and need only be installed if the target deployment uses MiOS Action extensions in it's Rules.
+
+# Releases
+
+* 1.7.0 - First release
+
+# Configuration
+
+The MiOS Action Binding relies upon the MiOS Bridge Binding being installed and configured, and the installation of the MiOS Action Binding Bundle (JAR) file.  Once these are done, you're ready to use the Rule extensions this bundle provides.
+
+# Extensions
+
+Add-on Actions - MiOS Action
+
+* `sendMiosAction(Item item, String action)` - requests the _parameterless_ Device Action, specified through `action`, be invoked on the MiOS Device bound to `item`.
+* `sendMiosAction(Item item, String action, List<<String,Object>> params)` - as above, but for parameterized Device Actions.
+* `sendMiosScene(Item scene)` - requests the scene associated with the `scene` parameter be invoked on the MiOS Unit.
+
+The `action` string, of the `sendMiosAction` extension, is a string of the form:
+
+    <ServiceURN>/<ServiceAction>
+
+or
+
+    <ServiceAlias>/<ServiceAction>
+
+where _ServiceURN_, _ServiceAlias_ and _ServiceAction_ have the same form as decribed in [MiOS Bridge Binding](https://github.com/openhab/openhab/wiki/MiOS-Binding) commands.
+
+You can use the MiOS `invoke` URL to discover the _Actions_, and _Action-parameters_, your particular MiOS Device supports:
+ 
+    http://<mios:host>:49451/data_request?id=invoke
+ 
+## Examples
+
+* Invoking a Device Action and calling a Scene to turn off the AV.
+```
+    rule "Test action rules Off"
+        when 
+            Time cron "0 45 23 * * ?"
+        then
+            sendMiosAction(FamilyMainLightsId, "Dimmer/SetLoadLevelTarget", newArrayList('newLoadlevelTarget' -> 0))
+            sendMiosScene(SceneGoodNight)
+    end
+```
+
+* Invoking a Sonos Device on MiOS to _say_ something
+```
+    rule "Test action say"
+        when
+            Item HallGarageDoorZoneTripped changed to OPEN
+        then
+            sendMios(OfficeSonosId, "Sonos/Say", newArrayList('Text' -> 'Warning! Garage door opened', 'Volume' -> 50))
+    end
+```
+

--- a/bundles/action/org.openhab.action.mios/build.properties
+++ b/bundles/action/org.openhab.action.mios/build.properties
@@ -1,0 +1,6 @@
+source.. = src/main/java/,\
+           src/main/resources/
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/
+output.. = target/classes/

--- a/bundles/action/org.openhab.action.mios/pom.xml
+++ b/bundles/action/org.openhab.action.mios/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<parent>
+		<groupId>org.openhab.bundles</groupId>
+		<artifactId>action</artifactId>
+		<version>1.7.0-SNAPSHOT</version>
+	</parent>
+
+	<properties>
+		<bundle.symbolicName>org.openhab.action.mios</bundle.symbolicName>
+		<bundle.namespace>org.openhab.action.mios</bundle.namespace>
+		<deb.name>openhab-addon-action-mios</deb.name>
+		<deb.description>openHAB Action addon for MiOS</deb.description>
+	</properties>
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.openhab.action</groupId>
+	<artifactId>org.openhab.action.mios</artifactId>
+
+	<name>openHAB MiOS Action</name>
+
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.vafer</groupId>
+				<artifactId>jdeb</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/bundles/action/org.openhab.action.mios/src/main/java/org/openhab/action/mios/internal/MiosAction.java
+++ b/bundles/action/org.openhab.action.mios/src/main/java/org/openhab/action/mios/internal/MiosAction.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.action.mios.internal;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+
+import org.eclipse.xtext.xbase.lib.Pair;
+import org.openhab.binding.mios.MiosActionProvider;
+import org.openhab.core.items.Item;
+import org.openhab.core.scriptengine.action.ActionDoc;
+import org.openhab.core.scriptengine.action.ParamDoc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class provides static methods, for invocation of MiOS Action and Scene requests, for use in automation rules.
+ * 
+ * @author Mark Clark
+ * @since 1.7.0
+ */
+public class MiosAction {
+
+	private static final Logger logger = LoggerFactory.getLogger(MiosAction.class);
+
+	/**
+	 * Sends an Action invocation to a Device at a MiOS Unit, without parameters.
+	 */
+	@ActionDoc(text = "Sends an Action invocation to a Device at a MiOS Unit, without parameters.")
+	public static boolean sendMiosAction(
+			@ParamDoc(name = "item", text = "The Item used to determine the MiOS Unit Address information for sending the Action call.") Item item,
+			@ParamDoc(name = "action", text = "The Action string to be remotely invoked on the MiOS Unit.") String actionName) {
+
+		return sendMiosActionInternal(item.getName(), actionName, null);
+	}
+
+	/**
+	 * Sends an Action invocation to a Device at a MiOS Unit, with parameters.
+	 */
+	@ActionDoc(text = "Sends an Action invocation to a Device at a MiOS Unit, with parameters.")
+	public static boolean sendMiosAction(
+			@ParamDoc(name = "item", text = "The Item used to determine the MiOS Unit Address information for sending the Action call.") Item item,
+			@ParamDoc(name = "actionName", text = "The Action string to be remotely invoked on the MiOS Unit.") String actionName,
+			@ParamDoc(name = "params", text = "The list of Action Parameters.") List<Pair> params) {
+
+		return sendMiosActionInternal(item.getName(), actionName, params);
+	}
+
+	/**
+	 * Sends a Scene invocation to a MiOS Unit.
+	 */
+	@ActionDoc(text = "Sends a Scene invocation to a MiOS Unit.")
+	public static boolean sendMiosScene(
+			@ParamDoc(name = "item", text = "The Item used to determine the MiOS Unit Address information for sending the Action call.") Item item) {
+
+		return sendMiosSceneInternal(item.getName());
+	}
+
+	private static MiosActionProvider getActionProviderInternal(String itemName) throws Exception {
+		MiosActionService service = MiosActionService.getMiosActionService();
+		if (service == null) {
+			throw new Exception(String.format("MiOS Service is not configured, Action for Item %1$s not queued.",
+					itemName));
+		}
+
+		MiosActionProvider actionProvider = service.getMiosActionProvider();
+		if (actionProvider == null) {
+			throw new Exception(String.format(
+					"MiOS Action Provider is not configured, Action for Item %1$s not queued.", itemName));
+		}
+
+		return actionProvider;
+	}
+
+	private static boolean sendMiosActionInternal(String itemName, String actionName, List<Pair> params) {
+		try {
+			logger.debug("Attempting to invoke MiOS Action {} using Item {} and {} Parameters", new Object[] {
+					actionName, itemName, (params == null) ? 0 : params.size() });
+			ArrayList<Entry<String, Object>> paramList;
+
+			// Convert from XText to the form needed to invoke MiOS.
+			if (params != null) {
+				paramList = new ArrayList<Entry<String, Object>>(params.size());
+
+				for (Pair<String, String> p : params) {
+					logger.trace("Type of parameter key={} value={}", p.getKey(), p.getValue());
+					paramList.add(new AbstractMap.SimpleImmutableEntry<String, Object>(p.getKey(), p.getValue()));
+				}
+			} else {
+				paramList = null;
+			}
+
+			MiosActionProvider actionProvider = getActionProviderInternal(itemName);
+
+			return actionProvider.invokeMiosAction(itemName, actionName, paramList);
+		} catch (Exception ex) {
+			logger.error(ex.getMessage(), ex);
+			return false;
+		}
+	}
+
+	private static boolean sendMiosSceneInternal(String itemName) {
+		try {
+			logger.debug("Attempting to invoke MiOS Scene using Item {}", itemName);
+
+			MiosActionProvider actionProvider = getActionProviderInternal(itemName);
+
+			return actionProvider.invokeMiosScene(itemName);
+		} catch (Exception ex) {
+			logger.error(ex.getMessage(), ex);
+			return false;
+		}
+	}
+}

--- a/bundles/action/org.openhab.action.mios/src/main/java/org/openhab/action/mios/internal/MiosActionService.java
+++ b/bundles/action/org.openhab.action.mios/src/main/java/org/openhab/action/mios/internal/MiosActionService.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.action.mios.internal;
+
+import java.util.Dictionary;
+
+import org.openhab.binding.mios.MiosActionProvider;
+import org.openhab.core.scriptengine.action.ActionService;
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.cm.ManagedService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class registers an OSGi service for the MiOS Action.
+ * 
+ * @author Mark Clark
+ * @since 1.7.0
+ */
+public class MiosActionService implements ActionService, ManagedService {
+
+	private static final Logger logger = LoggerFactory.getLogger(MiosActionService.class);
+
+	private MiosActionProvider actionProvider;
+	private static MiosActionService service;
+
+	public static MiosActionService getMiosActionService() {
+		return service;
+	}
+
+	public void activate() {
+		logger.debug("MiOS action service activated");
+		service = this;
+	}
+
+	public void deactivate() {
+		logger.debug("MiOS action service activated");
+		service = null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getActionClassName() {
+		return getActionClass().getCanonicalName();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Class<?> getActionClass() {
+		return MiosAction.class;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void updated(Dictionary<String, ?> properties) throws ConfigurationException {
+	}
+
+	/**
+	 * Setter for use by OSGi injection.
+	 * 
+	 * @param actionProvider the MiOS Action Provider (provided by the MiOS Binding).
+	 */
+	public void setMiosActionProvider(MiosActionProvider actionProvider) {
+		this.actionProvider = actionProvider;
+		logger.debug("MiOS setMiosActionProvider called");
+	}
+
+	/**
+	 * Unsetter for use by OSGi injection.
+	 * 
+	 * @param actionProvider MiOS Action Provider to remove.
+	 */
+	public void unsetMiosActionProvider(MiosActionProvider actionProvider) {
+		this.actionProvider = null;
+		logger.debug("MiOS unsetMiosActionProvider called");
+	}
+
+	/**
+	 * Get the MiosActionProvider instance injected by OSGi.
+	 * 
+	 * @return the MiOS Action Provider associated with this Action Service.
+	 */
+	public MiosActionProvider getMiosActionProvider() {
+		return this.actionProvider;
+	}
+}

--- a/bundles/action/org.openhab.action.mios/src/main/java/org/openhab/action/mios/internal/MiosActivator.java
+++ b/bundles/action/org.openhab.action.mios/src/main/java/org/openhab/action/mios/internal/MiosActivator.java
@@ -6,7 +6,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.openhab.binding.mios.internal;
+package org.openhab.action.mios.internal;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  * Extension of the default OSGi bundle activator.
  * 
  * @author Mark Clark
- * @since 1.6.0
+ * @since 1.7.0
  */
 public final class MiosActivator implements BundleActivator {
 
@@ -27,34 +27,24 @@ public final class MiosActivator implements BundleActivator {
 
 	/**
 	 * Called whenever the OSGi framework starts our bundle.
-	 * 
-	 * @param bc
-	 *            the OSGi BundleContext associated with our openHAB Binding.
 	 */
 	public void start(BundleContext bc) throws Exception {
 		context = bc;
-		logger.debug("MiOS binding has been started");
+		logger.debug("MiOS Action has been started.");
 	}
 
 	/**
 	 * Called whenever the OSGi framework stops our bundle.
-	 * 
-	 * @param bc
-	 *            the OSGi BundleContext associated with our openHAB Binding.
 	 */
 	public void stop(BundleContext bc) throws Exception {
 		context = null;
-		logger.debug("MiOS binding has been stopped");
+		logger.debug("MiOS Action has been stopped.");
 	}
 
 	/**
-	 * Returns the OSGi BundleContext of this bundle.
+	 * Returns the bundle context of this bundle.
 	 * 
-	 * The OSGi BundleContext is needed to talk with other services running under OSGi.
-	 * <p>
-	 * eg. openHAB's {@code TransformationService}.
-	 * 
-	 * @return the bundle context
+	 * @return the bundle context.
 	 */
 	public static BundleContext getContext() {
 		return context;

--- a/bundles/action/org.openhab.action.mios/src/main/resources/readme.txt
+++ b/bundles/action/org.openhab.action.mios/src/main/resources/readme.txt
@@ -1,0 +1,1 @@
+Bundle resources go in here!

--- a/bundles/action/pom.xml
+++ b/bundles/action/pom.xml
@@ -28,6 +28,7 @@
     <module>org.openhab.action.homematic</module>
     <module>org.openhab.action.openwebif</module>
     <module>org.openhab.action.weather</module>
+    <module>org.openhab.action.mios</module>
     <module>org.openhab.action.astro</module>
   </modules>
 

--- a/bundles/binding/org.openhab.binding.mios/OSGI-INF/activebinding.xml
+++ b/bundles/binding/org.openhab.binding.mios/OSGI-INF/activebinding.xml
@@ -15,6 +15,7 @@
 	<service>
 		<provide interface="org.osgi.service.event.EventHandler" />
 		<provide interface="org.osgi.service.cm.ManagedService" />
+		<provide interface="org.openhab.binding.mios.MiosActionProvider" />
 	</service>
 
 	<property name="event.topics" type="String" value="openhab/*" />

--- a/bundles/binding/org.openhab.binding.mios/OSGI-INF/genericbindingprovider.xml
+++ b/bundles/binding/org.openhab.binding.mios/OSGI-INF/genericbindingprovider.xml
@@ -10,11 +10,12 @@
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.openhab.binding.mios.genericbindingprovider">
-   <implementation class="org.openhab.binding.mios.internal.MiosBindingProviderImpl"/>
+	<implementation class="org.openhab.binding.mios.internal.MiosBindingProviderImpl" />
    
-   <service>
-      <provide interface="org.openhab.model.item.binding.BindingConfigReader"/>
-      <provide interface="org.openhab.binding.mios.MiosBindingProvider"/>
-   </service>
-   <reference bind="setItemRegistry" cardinality="1..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry"/>
+	<service>
+		<provide interface="org.openhab.model.item.binding.BindingConfigReader" />
+		<provide interface="org.openhab.binding.mios.MiosBindingProvider" />
+	</service>
+
+	<reference bind="setItemRegistry" cardinality="1..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry" />
 </scr:component>

--- a/bundles/binding/org.openhab.binding.mios/README.md
+++ b/bundles/binding/org.openhab.binding.mios/README.md
@@ -1,11 +1,50 @@
+Documentation for the MiOS Bridge Binding.
+
+# Introduction
+This binding exposes read, and read-command, access to Devices controlled by a MiOS Home Automation controller, such as those seen at http://getvera.com.
+
+It exposes the ability to do the following things in the MiOS HA Controller
+
+* `Devices` - Read State Variables & Device Attributes, and invoke (single parameter) UPnP Commands to control the Device.
+* `Scenes` - Read the current execution state of a Scene, and invoke those Scenes within the remote HA Controller
+* `System` - Read System-level Attributes.
+It uses the remote control interfaces (aka "UI Simple" JSON Calls, and HTTP Long-polling) of the MiOS HA Controller to keep the _bound_ openHAB Items in sync with their counterparts in the MiOS HA Controller.
+
+The binding uses the openHAB _Transformation Service_ extensively to "map" the Data & Commands between the two systems. A set of example MAP transform files is provided in the `examples/transform` directory of the Binding, but these can readily be augmented without needing to tweak the code.
+
+Original code was used from the XBMC Binding, and then heavily modified. Snippets included from the HTTP Binding for the various datatype mapping functions.
+
 # Releases
 
-This code is not currently in release-ready form.  Changes are expected, especially as feedback is received.
-
-## 1.6.0
-  * TBD
+* 1.6 - First release
+* 1.6.2 - #1889 Only change Item state during incremental updates from MiOS Unit, use UTF-8 for JSON responses for i18n.
+* 1.6.2 - #1824 datetime handling made more automatic for MiOS style "epoch" dates.
+* 1.6.2 - #1909 Add missing aliases for common UPnP ServiceId's.
+* 1.7.0 - #???? Add MiOS Action Binding support for calling Device Actions and invoking Scenes.
 
 # Configuration
+ * [MiOS Unit configuration](MiOS-Binding#mios-unit-configuration)
+ * [Transformations](MiOS-Binding#mios-transformations)
+ * [Actions](MiOS-Binding#mios-action-addon)
+ * [Logger](MiOS-Binding#mios-logger)
+ * [Item configuration (Reading)](MiOS-Binding#mios-item-configuration)
+    * [MiOS - Device Binding](MiOS-Binding#item--mios-device-binding---values-reading)
+    * [MiOS - Scene Binding](MiOS-Binding#item--mios-scene-binding---values-reading)
+    * [MiOS - System Binding](MiOS-Binding#item--mios-system-binding)
+    * [Transformations (Use)](MiOS-Binding#transformations)
+ * [Item Commands (Reacting)](MiOS-Binding#item-commands-reacting)
+     * [MiOS - Device Binding - Commands (Reacting)] (MiOS-Binding#item--mios-device-binding---commands-reacting)
+        * [Device Command Binding Examples (Parameterless)] (MiOS-Binding#device-command-binding-examples-parameterless)
+            * [A Switch ...](MiOS-Binding#a-switch)
+            * [An Armed Sensor ...](MiOS-Binding#an-armed-sensor)
+            * [A Lock ...] (MiOS-Binding#a-lock)
+        * [Device Command Binding Examples (Parameterized)](MiOS-Binding#device-command-binding-examples-parameterized)
+            * [A Dimmer, Volume Control, Speed controlled Fan ...](MiOS-Binding#a-dimmer-volume-control-speed-controlled-fan)
+            * [A Thermostat ...] (MiOS-Binding#a-thermostat)
+     * [MiOS Scene Binding - Commands (Reacting)] (MiOS-Binding#item--mios-scene-binding---commands-reacting)
+        * [Scene Command Binding Examples] (MiOS-Binding#scene-command-binding-examples)
+
+***
 
 ## MiOS Unit configuration
 
@@ -39,6 +78,8 @@ You can also declare multiple MiOS Units, as illustrated in this example.
 
 **NOTE**: The MiOS Unit name is case-sensitive, and may only contain AlphaNumeric characters.  The leading character must be an [ASCII] alpha.
 
+[Back to Table of Contents](MiOS-Binding#configuration)
+
 ## MiOS Transformations
 
 Internally, the MiOS Binding uses the openHAB _Transformation Service_.  The MiOS Binding supplies a number of pre-configured MAP Transformation for the common use-cases.
@@ -52,6 +93,67 @@ and placed into your openHAB installation under the directory:
     {openHAB Home}/configurations/transform/
 
 **NOTE**: These transformations can be readily extended by the user, for any use-cases that aren't covered by those pre-configured & shipped with the Binding.
+
+[Back to Table of Contents](MiOS-Binding#configuration)
+
+## MiOS Action Addon
+
+The MiOS Binding automatically synchronizes data between openHAB Items, and their bound Device Variables on the MiOS Unit.
+For more advanced integration, the MiOS Action bundle can be installed.  This bundle extends openHAB's Rule language to include support for calling MiOS Device Actions, as well as invoking MiOS Scenes.
+Installation of the MiOS Action bundle is optional and only required if your deployment needs the MiOS Rule language extensions.
+
+[Back to Table of Contents](MiOS-Binding#configuration)
+
+## MiOS Logger
+Especially during setup of the binding the log information can provide you valuable information. Therefore it is recommended to configure logging to use a dedicated file for MiOS logging.
+
+There are two configuration files to configure the log subsystem of openHAB:
+ * {openHAB Home}/configurations/logback.xml
+ * {openHAB Home}/configurations/logback_debug.xml (if you start in debug mode)
+
+To simplify analysis and to keep things structured we'll use a dedicated logfile for this demo configuration.
+
+```xml
+    <!-- log appender to be used for MIOS binding -->
+    <appender 
+       name  = "MIOSFILE" 
+       class = "ch.qos.logback.core.rolling.RollingFileAppender">
+       <!-- target file -->
+        <file>logs/mios.log</file>
+        <!-- settings how to archive old logs and how long to retain them [days] -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/mios-%d{yyyy-ww}.log.zip</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <!-- encoder rule (how to format the messages in the log file ) -->
+        <encoder>
+           <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%-30.30logger{36}] - %msg%n</pattern>
+        </encoder>
+    </appender>
+```
+Next we configure the actual logger:
+```xml
+    <!-- valid log levels: OFF | ERROR | INFO | DEBUG | TRACE -->
+    <logger 
+      name       = "org.openhab.binding.mios"
+      level      = "TRACE" 
+      additivity = "FALSE">
+      <appender-ref ref="MIOSFILE"  />
+    </logger>
+```
+
+Below how it should look if the configuration is correct (TRACE):
+```
+...
+2015-01-18 16:37:18.971 [DEBUG] [.o.b.mios.internal.MiosBinding] - internalPropertyUpdate: BOUND {mios="unit:vera,device:1/service/urn:micasaverde-com:serviceId:ZWaveNetwork1/Role"}, value=Master SIS:NO PRI:YES, bound 1 time(s)
+2015-01-18 16:37:18.971 [TRACE] [.o.b.mios.internal.MiosBinding] - internalPropertyUpdate: NOT BOUND {mios="unit:vera,device:1/service/urn:micasaverde-com:serviceId:ZWaveNetwork1/LastDongleBackup"}, value=2015-01-14T23:30:57
+2015-01-18 16:37:18.971 [TRACE] [.o.b.mios.internal.MiosBinding] - internalPropertyUpdate: NOT BOUND {mios="unit:vera,device:1/service/urn:micasaverde-com:serviceId:ZWaveNetwork1/LastError"}, value=Poll failed
+2015-01-18 16:37:18.971 [TRACE] [.o.b.mios.internal.MiosBinding] - internalPropertyUpdate: NOT BOUND {mios="unit:vera,device:1/service/urn:micasaverde-com:serviceId:ZWaveNetwork1/LastHeal"}, value=2015-01-14T05:16:26
+2015-01-18 16:37:18.971 [TRACE] [.o.b.mios.internal.MiosBinding] - internalPropertyUpdate: NOT BOUND {mios="unit:vera,device:1/service/urn:micasaverde-com:serviceId:ZWaveNetwork1/LastRouteFailure"}, value=2015-01-14T04:11:33
+...
+```
+
+[Back to Table of Contents](MiOS-Binding#configuration)
 
 ## MiOS Item configuration
 
@@ -73,6 +175,7 @@ In many cases, only a subset of these parameters need to be specified/used, with
 
 The sections below describe the types of things that can be bound, in addition to the transformations that are permitted, and any default transformations that may be applied for you.
 
+[Back to Table of Contents](MiOS-Binding#configuration)
 
 ### Item : MiOS Device Binding - Values (Reading)
 
@@ -174,6 +277,7 @@ The _serviceAliases_ are built into the MiOS Binding and may be expanded over ti
 |`urn:macrho-com:serviceId:LiftMasterOpener1`|`LiftMasterOpener1`,`LiftMaster`|
 |`urn:directv-com:serviceId:DVR1`|`DirecTVDVR1`,`DirecTV`|
 
+[Back to Table of Contents](MiOS-Binding#configuration)
 
 ### Item : MiOS Scene Binding - Values (Reading)
 
@@ -186,7 +290,9 @@ With examples like:
     Number   SceneGarageOpenId         (GScene) {mios="unit:house,scene:109/id"}
     Number   SceneGarageOpenStatus     (GScene) {mios="unit:house,scene:109/status"}
     String   SceneGarageOpenActive     (GScene) {mios="unit:house,scene:109/active"}
-       
+ 
+[Back to Table of Contents](MiOS-Binding#configuration)
+      
 ### Item : MiOS System Binding
 
 System Bindings are read-only, with data flowing from the MiOS Unit _into_ openHAB.  System Bindings have the form:
@@ -202,6 +308,8 @@ With examples like:
     Number   SystemDataVersion         "[%d]"  (GSystem) {mios="unit:house,system:/DataVersion"} 
     String   SystemLoadTime            "[%s]"  (GSystem) {mios="unit:house,system:/LoadTime"} 
       
+[Back to Table of Contents](MiOS-Binding#configuration)
+
 ### Transformations
 
 Sometimes the value presented by the binding isn't in the format that you require for your Item.  For these cases, the binding provides access to the standard openHAB _Transformation Service_.
@@ -273,6 +381,7 @@ For users wanting more advanced configurations, the openHAB _Transformation Serv
 
 More reading on these is available in the openHAB Wiki.
 
+[Back to Table of Contents](MiOS-Binding#configuration)
 
 ## Item Commands (Reacting)
 
@@ -289,6 +398,7 @@ MiOS Units don't natively handle these Commands so a mapping step must occur bef
 
 The `command:` Binding parameter is used to specify that we want data to flow back to the MiOS unit as well as how to perform the required mapping.  For most Items bound using the MiOS Binding, internal defaults will take care of the correct `command:`, `in:` and `out:` parameters.  These need only be specified if you have something not handled by the internal defaults, or wish to override them with custom behavior.
 
+[Back to Table of Contents](MiOS-Binding#configuration)
 
 ### Item : MiOS Device Binding - Commands (Reacting)
 
@@ -316,9 +426,13 @@ _&lt;openHABTransform>_ is `MAP`, `XSLT`, `EXEC`, `XPATH`, etc<br>
 
 _&lt;BoundValue>_ is `?`, `??`, `?++`, `?--`
 
+[Back to Table of Contents](MiOS-Binding#configuration)
+
 #### Device Command Binding Examples (Parameterless)
 
 In practice, when discrete commands are being sent by openHAB, the map is fairly simple.  In the examples listed below, the `*.map` files are provided in the `examples/transform` directory of the MiOS binding.
+
+[Back to Table of Contents](MiOS-Binding#configuration)
 
 ##### A Switch...
 
@@ -334,6 +448,7 @@ or, *more simply*, use the internal defaults altogether:
 
     Switch   FamilyTheatreLightsStatus "Family Theatre Lights" (GSwitch) {mios="unit:house,device:13/service/SwitchPower1/Status"}
 
+[Back to Table of Contents](MiOS-Binding#configuration)
 
 ##### An Armed Sensor...
 
@@ -345,6 +460,7 @@ or the fully spelled out version:
 
     Switch   LivingRoomZoneArmed "Zone Armed [%s]" {mios="unit:house,device:117/service/SecuritySensor1/Armed,command:MAP(miosArmedCommand.map),in:MAP(miosSwitchIn.map)"}
 
+[Back to Table of Contents](MiOS-Binding#configuration)
 
 ##### A Lock...
 
@@ -356,6 +472,7 @@ or the full version:
 
     Switch   GarageDeadboltDStatus "Garage Deadbolt" (GLock,GSwitch) {mios="unit:house,device:189/service/DoorLock1/Status,command:MAP(miosLockCommand.map),in:MAP(miosSwitchIn.map)"}
 
+[Back to Table of Contents](MiOS-Binding#configuration)
 
 #### Device Command Binding Examples (Parameterized)
 
@@ -370,6 +487,7 @@ To do this, we introduce the _&lt;BoundValue>_ parameter that, when present in t
 
 Additionally, since _&lt;PCTNumber>_ is just a value, it won't match any of the entries in our Mapping file, so we introduce a magic key `_defaultCommand`.  We first attempt to do a literal mapping and, if that doesn't find a match, we go look for this magic key and use it's entry.
 
+[Back to Table of Contents](MiOS-Binding#configuration)
 
 ##### A Dimmer, Volume Control, Speed controlled Fan...
 
@@ -390,6 +508,7 @@ The `examples/transform/miosDimmerCommand.map` file has a definition that handle
     DECREASE=urn:upnp-org:serviceId:Dimming1/SetLoadLevelTarget(newLoadlevelTarget=?--)
     _defaultCommand=urn:upnp-org:serviceId:Dimming1/SetLoadLevelTarget(newLoadlevelTarget=??)
 
+[Back to Table of Contents](MiOS-Binding#configuration)
 
 ##### A Thermostat...
 
@@ -425,6 +544,7 @@ and these need to be paired with similar items in the `*.sitemap` file:
         Text     item=ThermostatUpstairsBatteryDate
     }
 
+[Back to Table of Contents](MiOS-Binding#configuration)
 
 ### Item : MiOS Scene Binding - Commands (Reacting)
 
@@ -443,6 +563,8 @@ _&lt;openHABCommand>_ is `ON`, `OFF`, `INCREASE`, `DECREASE`, `TOGGLE` etc
 
 _&lt;SceneAttribute>_ is `status` | `active`
 
+[Back to Table of Contents](MiOS-Binding#configuration)
+
 #### Scene Command Binding Examples
 
 In general Scenes tend to look like:
@@ -455,3 +577,5 @@ Or if you want the Scene executed upon receipt of `ON` or `TOGGLE` Commands:
 
 
 **NOTE**: Here we've added an additional configuration to the binding declaration, `autoupdate="false"`, to ensure the Switch no longer has the `ON` and `OFF` States automatically managed.  In openHAB, this declaration ensures that the UI rendition appears like a Button.
+
+[Back to Table of Contents](MiOS-Binding#configuration)

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/MiosActionProvider.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/MiosActionProvider.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.mios;
+
+import java.util.List;
+import java.util.Map.Entry;
+
+/**
+ * openHAB Action Provider interface for MiOS Devices.
+ * 
+ * Defines how to get properties from a MiOS-specific binding configuration.
+ * 
+ * @author Mark Clark
+ * @since 1.7.0
+ */
+public interface MiosActionProvider {
+	/**
+	 * Invoke the named MiOS Scene.
+	 * 
+	 * Requests the named MiOS Scene, associated with the [Scene] Item be invoked. The invocation itself is
+	 * asynchronous, and may fail. The return status of this call is whether we were successful in queuing the Scene
+	 * request.
+	 * 
+	 * @param itemName
+	 *            the name of of the openHAB Item to which the Scene invocation should be delivered.
+	 * @return true if the Scene request was sent.
+	 */
+	public boolean invokeMiosScene(String itemName);
+
+	/**
+	 * Invoke the named MiOS Action.
+	 * 
+	 * Requests the named MiOS Action, associated with the [Device] Item be invoked. Callers can pass an Action to be
+	 * invoked, in the form: <serviceName>/<actionName> OR; <serviceAlias>/<actionName>
+	 * 
+	 * The invocation itself is asynchronous, and may fail. The return status of this call is whether we were successful
+	 * in queuing the Action request.
+	 * 
+	 * @param itemName
+	 *            the name of of the openHAB Item to which the Action invocation should be delivered.
+	 * @param actionName
+	 *            the name of the Action to request upon the specified ItemName.
+	 * @param params
+	 *            a list of String name/value pairs to be used as the Parameter list for the Action call
+	 * @return true if the Action request was sent.
+	 */
+	public boolean invokeMiosAction(String itemName, String actionName, List<Entry<String, Object>> params);
+}

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/MiosBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/MiosBindingProvider.java
@@ -11,7 +11,6 @@ package org.openhab.binding.mios;
 import java.util.List;
 
 import org.openhab.core.binding.BindingProvider;
-import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemRegistry;
 
 /**
@@ -29,8 +28,7 @@ public interface MiosBindingProvider extends BindingProvider {
 	 * @param itemName
 	 *            the name of the Item.
 	 * 
-	 * @return the name of the MiOS Unit associated with the the Item
-	 *         {@code itemName}
+	 * @return the name of the MiOS Unit associated with the the Item {@code itemName}
 	 */
 	String getMiosUnitName(String itemName);
 
@@ -40,8 +38,7 @@ public interface MiosBindingProvider extends BindingProvider {
 	 * @param itemName
 	 *            the name of the Item.
 	 * 
-	 * @return the property string component for the Binding on the Item
-	 *         {@code itemName}
+	 * @return the property string component for the Binding on the Item {@code itemName}
 	 */
 	String getProperty(String itemName);
 
@@ -50,10 +47,8 @@ public interface MiosBindingProvider extends BindingProvider {
 	/**
 	 * Gets the ItemRegistry (catalog) used by this BindingProvider.
 	 * 
-	 * The {@code ItemRegistry} is injected into the {@code MiosBindingProvider}
-	 * through OSGi configuration. This method provider read-only access to the
-	 * {@code ItemRegistry}, which is the catalog of Items in use by this
-	 * system.
+	 * The {@code ItemRegistry} is injected into the {@code MiosBindingProvider} through OSGi configuration. This method
+	 * provider read-only access to the {@code ItemRegistry}, which is the catalog of Items in use by this system.
 	 * 
 	 * @return the ItemRegistry associated with this BindingProvider.
 	 */

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosBinding.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosBinding.java
@@ -12,10 +12,15 @@ import java.util.Calendar;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
+import org.openhab.binding.mios.MiosActionProvider;
 import org.openhab.binding.mios.MiosBindingProvider;
+import org.openhab.binding.mios.internal.config.DeviceBindingConfig;
 import org.openhab.binding.mios.internal.config.MiosBindingConfig;
+import org.openhab.binding.mios.internal.config.SceneBindingConfig;
 import org.openhab.core.binding.AbstractBinding;
 import org.openhab.core.binding.BindingProvider;
 import org.openhab.core.items.Item;
@@ -33,15 +38,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The MiOS Binding is responsible for coordinating changes to openHAB Items
- * from the corresponding/bound information from each configured MiOS Unit.
+ * The MiOS Binding is responsible for coordinating changes to openHAB Items from the corresponding/bound information
+ * from each configured MiOS Unit.
  * 
- * The Binding allows information from a MiOS Unit to be bound to openHAB Items,
- * as well a allowing openHAB Commands to be propagated back to the MiOS Unit
- * under control.
+ * The Binding allows information from a MiOS Unit to be bound to openHAB Items, as well a allowing openHAB Commands to
+ * be propagated back to the MiOS Unit under control.
  * 
- * The following types of information from a MiOS Unit can be bound to openHAB
- * Items:
+ * The following types of information from a MiOS Unit can be bound to openHAB Items:
  * <p>
  * 
  * <ul>
@@ -51,48 +54,40 @@ import org.slf4j.LoggerFactory;
  * </ul>
  * <p>
  * 
- * Similarly, through a configurable set of openHAB Transformations, any
- * Commands sent to these Items can be proxied back to the corresponding MiOS
- * Unit.
+ * Similarly, through a configurable set of openHAB Transformations, any Commands sent to these Items can be proxied
+ * back to the corresponding MiOS Unit.
  * <p>
  * 
- * Data flowing between the MiOS Unit and openHAB can be transformed as it flows
- * between the two systems. This transformation is configurable, and is
- * expressed in the Item Binding using standard openHAB
+ * Data flowing between the MiOS Unit and openHAB can be transformed as it flows between the two systems. This
+ * transformation is configurable, and is expressed in the Item Binding using standard openHAB
  * {@code TransformationService} expressions.
  * <p>
  * 
- * Example MAP-based Transformation files are provided for commonly required
- * transformations. <br>
- * eg. For Switch Data flowing into openHAB {@code MAP(miosSwitchIn.map)}, and
- * for Switch Commands flowing in to MiOS {@code MAP(miosSwitchOut.map)}
+ * Example MAP-based Transformation files are provided for commonly required transformations. <br>
+ * eg. For Switch Data flowing into openHAB {@code MAP(miosSwitchIn.map)}, and for Switch Commands flowing in to MiOS
+ * {@code MAP(miosSwitchOut.map)}
  * <p>
  * 
  * The Binding follows the general interaction principals outlined in the MiOS
- * {@link <a href="http://wiki.micasaverde.com/index.php/UI_Simple">UI Simple</a>}
- * documentation.
+ * {@link <a href="http://wiki.micasaverde.com/index.php/UI_Simple">UI Simple</a>} documentation.
  * <p>
  * 
- * In effect, the binding behaves like a "remote control" to one or more
- * configured MiOS Units, utilizing a HTTP-based Long-poll to receive updates
- * occurring within each Unit, and transforming them into corresponding updates
- * to the openHAB Items that have been bound.
+ * In effect, the binding behaves like a "remote control" to one or more configured MiOS Units, utilizing a HTTP-based
+ * Long-poll to receive updates occurring within each Unit, and transforming them into corresponding updates to the
+ * openHAB Items that have been bound.
  * <p>
  * 
- * All updates are received asynchronously from the MiOS Units. This interaction
- * is managed by a per MiOS Unit {@link MiosUnitConnector} Polling Thread object
- * that utilizes a {@link MiosUnit MiOS Unit} configuration object to determine
- * the location of the MiOS Unit.
+ * All updates are received asynchronously from the MiOS Units. This interaction is managed by a per MiOS Unit
+ * {@link MiosUnitConnector} Polling Thread object that utilizes a {@link MiosUnit MiOS Unit} configuration object to
+ * determine the location of the MiOS Unit.
  * <p>
  * 
  * @author Mark Clark
  * @since 1.6.0
  */
-public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
-		ManagedService {
+public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements ManagedService, MiosActionProvider {
 
-	private static final Logger logger = LoggerFactory
-			.getLogger(MiosBinding.class);
+	private static final Logger logger = LoggerFactory.getLogger(MiosBinding.class);
 
 	private Map<String, MiosUnitConnector> connectors = new HashMap<String, MiosUnitConnector>();
 	private Map<String, MiosUnit> nameUnitMapper = null;
@@ -102,8 +97,7 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 	}
 
 	/**
-	 * Invoked by OSGi Framework, once per instance, during the Binding
-	 * activation process.
+	 * Invoked by OSGi Framework, once per instance, during the Binding activation process.
 	 * 
 	 * OSGi is configured to do this in OSGI-INF/activebinding.xml
 	 */
@@ -113,11 +107,9 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 	}
 
 	/**
-	 * Invoked by the OSGi Framework, once per instance, during the Binding
-	 * deactivation process.
+	 * Invoked by the OSGi Framework, once per instance, during the Binding deactivation process.
 	 * 
-	 * Internally this is used to close out any resources used by the MiOS
-	 * Binding.
+	 * Internally this is used to close out any resources used by the MiOS Binding.
 	 * 
 	 * OSGi is configured to do this in OSGI-INF/activebinding.xml
 	 */
@@ -137,8 +129,7 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 	 */
 	@Override
 	public void bindingChanged(BindingProvider provider, String itemName) {
-		logger.debug("bindingChanged: start provider '{}', itemName '{}'",
-				provider, itemName);
+		logger.debug("bindingChanged: start provider '{}', itemName '{}'", provider, itemName);
 
 		if (provider instanceof MiosBindingProvider) {
 			registerWatch((MiosBindingProvider) provider, itemName);
@@ -165,8 +156,7 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 		logger.debug("registerAllWatches: start");
 
 		for (BindingProvider provider : providers) {
-			logger.debug("registerAllWatches: provider '{}'",
-					provider.getClass());
+			logger.debug("registerAllWatches: provider '{}'", provider.getClass());
 
 			if (provider instanceof MiosBindingProvider) {
 				MiosBindingProvider miosProvider = (MiosBindingProvider) provider;
@@ -179,8 +169,7 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 	}
 
 	private void registerWatch(MiosBindingProvider miosProvider, String itemName) {
-		logger.debug("registerWatch: start miosProvider '{}', itemName '{}'",
-				miosProvider, itemName);
+		logger.debug("registerWatch: start miosProvider '{}', itemName '{}'", miosProvider, itemName);
 
 		String unitName = miosProvider.getMiosUnitName(itemName);
 
@@ -199,8 +188,7 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 		for (BindingProvider provider : providers) {
 			if (provider instanceof MiosBindingProvider) {
 				if (provider.getItemNames().contains(itemName)) {
-					return ((MiosBindingProvider) provider)
-							.getMiosUnitName(itemName);
+					return ((MiosBindingProvider) provider).getMiosUnitName(itemName);
 				}
 			}
 		}
@@ -227,8 +215,7 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 		// check if we have been initialized yet - can't process
 		// named units until we have read the binding config.
 		if (nameUnitMapper == null) {
-			logger.trace(
-					"Attempting to access the named MiOS Unit '{}' before the binding config has been loaded",
+			logger.trace("Attempting to access the named MiOS Unit '{}' before the binding config has been loaded",
 					unitName);
 			return null;
 		}
@@ -237,15 +224,12 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 
 		// Check this Unit name exists in our config
 		if (miosUnit == null) {
-			logger.error(
-					"Named MiOS Unit '{}' does not exist in the binding config",
-					unitName);
+			logger.error("Named MiOS Unit '{}' does not exist in the binding config", unitName);
 			return null;
 		}
 
 		// create a new connection handler
-		logger.debug("Creating new MiosConnector for '{}' on {}", unitName,
-				miosUnit.getHostname());
+		logger.debug("Creating new MiosConnector for '{}' on {}", unitName, miosUnit.getHostname());
 		connector = new MiosUnitConnector(miosUnit, this);
 		connectors.put(unitName, connector);
 
@@ -253,8 +237,7 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 		try {
 			connector.open();
 		} catch (Exception e) {
-			logger.error("Connection failed for '{}' on {}", unitName,
-					miosUnit.getHostname());
+			logger.error("Connection failed for '{}' on {}", unitName, miosUnit.getHostname());
 		}
 
 		return connector;
@@ -266,16 +249,14 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 	@Override
 	protected void internalReceiveCommand(String itemName, Command command) {
 		try {
-			logger.debug("internalReceiveCommand: itemName '{}', command '{}'",
-					itemName, command);
+			logger.debug("internalReceiveCommand: itemName '{}', command '{}'", itemName, command);
 
 			// Lookup the MiOS Unit name and property for this item
 			String unitName = getMiosUnitName(itemName);
 
 			MiosUnitConnector connector = getMiosConnector(unitName);
 			if (connector == null) {
-				logger.warn(
-						"Received command ({}) for item '{}' but no connector found for MiOS Unit '{}', ignoring",
+				logger.warn("Received command ({}) for item '{}' but no connector found for MiOS Unit '{}', ignoring",
 						new Object[] { command.toString(), itemName, unitName });
 				return;
 			}
@@ -290,8 +271,7 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 			for (BindingProvider provider : providers) {
 				if (provider instanceof MiosBindingProvider) {
 					MiosBindingProviderImpl miosProvider = (MiosBindingProviderImpl) provider;
-					MiosBindingConfig config = miosProvider
-							.getMiosBindingConfig(itemName);
+					MiosBindingConfig config = miosProvider.getMiosBindingConfig(itemName);
 
 					if (config != null) {
 						ItemRegistry reg = miosProvider.getItemRegistry();
@@ -301,13 +281,11 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 							State state = item.getState();
 							connector.invokeCommand(config, command, state);
 						} else {
-							logger.warn(
-									"internalReceiveCommand: Missing ItemRegistry for item '{}' command '{}'",
+							logger.warn("internalReceiveCommand: Missing ItemRegistry for item '{}' command '{}'",
 									itemName, command);
 						}
 					} else {
-						logger.trace(
-								"internalReceiveCommand: Missing BindingConfig for item '{}' command '{}'",
+						logger.trace("internalReceiveCommand: Missing BindingConfig for item '{}' command '{}'",
 								itemName, command);
 					}
 				}
@@ -323,9 +301,8 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 	 */
 	@Override
 	protected void internalReceiveUpdate(String itemName, State newState) {
-		logger.trace(
-				"internalReceiveUpdate: itemName '{}', newState '{}', class '{}'",
-				new Object[] { itemName, newState, newState.getClass() });
+		logger.trace("internalReceiveUpdate: itemName '{}', newState '{}', class '{}'", new Object[] { itemName,
+				newState, newState.getClass() });
 
 		// No need to implement this for MiOS Bridge Binding since anything
 		// that needs to be sent back to the MiOS System will be done via a
@@ -339,8 +316,7 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void updated(Dictionary<String, ?> properties)
-			throws ConfigurationException {
+	public void updated(Dictionary<String, ?> properties) throws ConfigurationException {
 		logger.trace(getName() + " updated()");
 
 		Map<String, MiosUnit> units = new HashMap<String, MiosUnit>();
@@ -373,8 +349,7 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 			}
 
 			boolean created = false;
-			String hackUnitName = (unitName == null) ? MiosUnit.CONFIG_DEFAULT_UNIT
-					: unitName;
+			String hackUnitName = (unitName == null) ? MiosUnit.CONFIG_DEFAULT_UNIT : unitName;
 			MiosUnit unit = units.get(hackUnitName);
 
 			if (unit == null) {
@@ -412,11 +387,10 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 	}
 
 	/**
-	 * Push a value into all openHAB Items that match a given MiOS Property name
-	 * (from the Item Binding declaration).
+	 * Push a value into all openHAB Items that match a given MiOS Property name (from the Item Binding declaration).
 	 * <p>
-	 * In the process, this routine will perform Datatype conversions from Java
-	 * types to openHAB's type system. These conversions are as follows:
+	 * In the process, this routine will perform Datatype conversions from Java types to openHAB's type system. These
+	 * conversions are as follows:
 	 * <p>
 	 * <ul>
 	 * <li>{@code String} -> {@code StringType}
@@ -433,39 +407,29 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 	 * @exception IllegalArgumentException
 	 *                thrown if the value isn't one of the supported types.
 	 */
-	public void postPropertyUpdate(String property, Object value,
-			boolean incremental) throws Exception {
+	public void postPropertyUpdate(String property, Object value, boolean incremental) throws Exception {
 		if (value instanceof String) {
-			internalPropertyUpdate(property, new StringType(value == null ? ""
-					: (String) value), incremental);
+			internalPropertyUpdate(property, new StringType(value == null ? "" : (String) value), incremental);
 		} else if (value instanceof Integer) {
-			internalPropertyUpdate(property, new DecimalType((Integer) value),
-					incremental);
+			internalPropertyUpdate(property, new DecimalType((Integer) value), incremental);
 		} else if (value instanceof Calendar) {
-			internalPropertyUpdate(property,
-					new DateTimeType((Calendar) value), incremental);
+			internalPropertyUpdate(property, new DateTimeType((Calendar) value), incremental);
 		} else if (value instanceof Double) {
-			internalPropertyUpdate(property, new DecimalType((Double) value),
-					incremental);
+			internalPropertyUpdate(property, new DecimalType((Double) value), incremental);
 		} else if (value instanceof Boolean) {
 			postPropertyUpdate(property,
-					((Boolean) value).booleanValue() ? OnOffType.ON.toString()
-							: OnOffType.OFF.toString(), incremental);
+					((Boolean) value).booleanValue() ? OnOffType.ON.toString() : OnOffType.OFF.toString(), incremental);
 		} else {
-			throw new IllegalArgumentException(String.format(
-					"Unexpected Datatype, property=%s datatype=%s", property,
+			throw new IllegalArgumentException(String.format("Unexpected Datatype, property=%s datatype=%s", property,
 					value.getClass().toString()));
 		}
 	}
 
-	private void internalPropertyUpdate(String property, State value,
-			boolean incremental) throws Exception {
+	private void internalPropertyUpdate(String property, State value, boolean incremental) throws Exception {
 		int bound = 0;
 
 		if (value == null) {
-			logger.trace(
-					"internalPropertyUpdate: Value is null for Property '{}', ignored.",
-					property);
+			logger.trace("internalPropertyUpdate: Value is null for Property '{}', ignored.", property);
 			return;
 		}
 
@@ -473,11 +437,9 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 			if (provider instanceof MiosBindingProvider) {
 				MiosBindingProviderImpl miosProvider = (MiosBindingProviderImpl) provider;
 
-				for (String itemName : miosProvider
-						.getItemNamesForProperty(property)) {
+				for (String itemName : miosProvider.getItemNamesForProperty(property)) {
 
-					MiosBindingConfig config = miosProvider
-							.getMiosBindingConfig(itemName);
+					MiosBindingConfig config = miosProvider.getMiosBindingConfig(itemName);
 
 					if (config != null) {
 						// Transform whatever value we have, based upon the
@@ -487,9 +449,8 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 						State newValue = config.transformIn(value);
 
 						if (newValue != value) {
-							logger.trace(
-									"internalPropertyUpdate: transformation performed, from '{}' to '{}'",
-									value, newValue);
+							logger.trace("internalPropertyUpdate: transformation performed, from '{}' to '{}'", value,
+									newValue);
 
 							value = newValue;
 						}
@@ -517,26 +478,22 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 							State oldValue = reg.getItem(itemName).getState();
 
 							if ((oldValue == null && value != null)
-									|| (UnDefType.UNDEF.equals(oldValue) && !UnDefType.UNDEF
-											.equals(value))
+									|| (UnDefType.UNDEF.equals(oldValue) && !UnDefType.UNDEF.equals(value))
 									|| !oldValue.equals(value)) {
 								logger.debug(
 										"internalPropertyUpdate: Updating (Full) itemName '{}' with value '{}', oldValue '{}'",
-										new Object[] { itemName, value,
-												oldValue });
+										new Object[] { itemName, value, oldValue });
 
 								eventPublisher.postUpdate(itemName, value);
 							} else {
 								logger.trace(
 										"internalPropertyUpdate: Ignoring (Full) itemName '{}' with value '{}', oldValue '{}'",
-										new Object[] { itemName, value,
-												oldValue });
+										new Object[] { itemName, value, oldValue });
 							}
 						}
 						bound++;
 					} else {
-						logger.trace(
-								"internalPropertyUpdate: Found null BindingConfig for item '{}' property '{}'",
+						logger.trace("internalPropertyUpdate: Found null BindingConfig for item '{}' property '{}'",
 								itemName, property);
 					}
 				}
@@ -544,13 +501,112 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 		}
 
 		if (bound == 0) {
-			logger.trace(
-					"internalPropertyUpdate: NOT BOUND {mios=\"{}\"}, value={}",
-					property, value);
+			logger.trace("internalPropertyUpdate: NOT BOUND {mios=\"{}\"}, value={}", property, value);
 		} else {
-			logger.debug(
-					"internalPropertyUpdate: BOUND {mios=\"{}\"}, value={}, bound {} time(s)",
-					new Object[] { property, value, bound });
+			logger.debug("internalPropertyUpdate: BOUND {mios=\"{}\"}, value={}, bound {} time(s)", new Object[] {
+					property, value, bound });
 		}
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public boolean invokeMiosScene(String itemName) {
+		try {
+			logger.debug("invokeMiosScene item {}", itemName);
+
+			boolean sent = false;
+
+			// Lookup the MiOS Unit name and property for this item
+			String unitName = getMiosUnitName(itemName);
+
+			MiosUnitConnector connector = getMiosConnector(unitName);
+			if (connector == null) {
+				logger.warn(
+						"invokeMiosScene: Scene call for item '{}' but no connector found for MiOS Unit '{}', ignoring",
+						itemName, unitName);
+				return false;
+			}
+
+			if (!connector.isConnected()) {
+				logger.warn(
+						"invokeMiosScene: Scene call for item '{}' but the connection to the MiOS Unit '{}' is down, ignoring",
+						itemName, unitName);
+				return false;
+			}
+
+			for (BindingProvider provider : providers) {
+				if (provider instanceof MiosBindingProvider) {
+					MiosBindingProviderImpl miosProvider = (MiosBindingProviderImpl) provider;
+					MiosBindingConfig config = miosProvider.getMiosBindingConfig(itemName);
+
+					if ((config != null) && (config instanceof SceneBindingConfig)) {
+						connector.invokeScene((SceneBindingConfig) config);
+						sent = true;
+					} else {
+						logger.error(
+								"invokeMiosScene: Missing BindingConfig for item '{}', or not bound to a MiOS Scene.",
+								itemName);
+					}
+				}
+			}
+
+			return sent;
+		} catch (Exception e) {
+			logger.error("invokeMiosScene: Error handling command", e);
+			return false;
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public boolean invokeMiosAction(String itemName, String actionName, List<Entry<String, Object>> params) {
+		try {
+			logger.debug("invokeMiosAction item {}, action {}, params {}",
+					new Object[] { itemName, actionName, Integer.valueOf((params == null) ? 0 : params.size()) });
+
+			boolean sent = false;
+
+			// Lookup the MiOS Unit name and property for this item
+			String unitName = getMiosUnitName(itemName);
+
+			MiosUnitConnector connector = getMiosConnector(unitName);
+			if (connector == null) {
+				logger.warn(
+						"invokeMiosAction: Action call for item '{}' but no connector found for MiOS Unit '{}', ignoring",
+						itemName, unitName);
+				return false;
+			}
+
+			if (!connector.isConnected()) {
+				logger.warn(
+						"invokeMiosAction: Action call for item '{}' but the connection to the MiOS Unit '{}' is down, ignoring",
+						itemName, unitName);
+				return false;
+			}
+
+			for (BindingProvider provider : providers) {
+				if (provider instanceof MiosBindingProvider) {
+					MiosBindingProviderImpl miosProvider = (MiosBindingProviderImpl) provider;
+					MiosBindingConfig config = miosProvider.getMiosBindingConfig(itemName);
+
+					if ((config != null) && (config instanceof DeviceBindingConfig)) {
+						connector.invokeAction((DeviceBindingConfig) config, actionName, params);
+						sent = true;
+					} else {
+						logger.error(
+								"invokeMiosAction: Missing BindingConfig for item '{}', or not bound to a MiOS Device.",
+								itemName);
+					}
+				}
+			}
+
+			return sent;
+		} catch (Exception e) {
+			logger.error("invokeMiosScene: Error handling command", e);
+			return false;
+		}
+	}
+
 }

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosBindingProviderImpl.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosBindingProviderImpl.java
@@ -31,29 +31,24 @@ import org.slf4j.LoggerFactory;
 /**
  * This class is responsible for parsing the binding configuration.
  * 
- * Each MiOS Binding declaration consists of a comma-separated list of elements,
- * of the form <name>:<value>, that are expressed in a specific order.
+ * Each MiOS Binding declaration consists of a comma-separated list of elements, of the form <name>:<value>, that are
+ * expressed in a specific order.
  * <p>
  * 
  * The order is:
  * <ul>
- * <li>{@code unit:<name>} - the name of the MiOS Unit, declared in the openHAB
- * configuration. The value is a case-sensitive MiOS Unit name [alphaNumeric]
- * String.
+ * <li>{@code unit:<name>} - the name of the MiOS Unit, declared in the openHAB configuration. The value is a
+ * case-sensitive MiOS Unit name [alphaNumeric] String.
  * 
- * <li>{@code <type>:<id>} - the type of entity bound at the MiOS Unit. The
- * value is a MiOS-specific identifier Integer. Type names include "
- * {@code device}", " {@code scene}", and "{@code system}" and the corresponding
- * {@code id} used within the MiOS Unit.
+ * <li>{@code <type>:<id>} - the type of entity bound at the MiOS Unit. The value is a MiOS-specific identifier Integer.
+ * Type names include " {@code device}", " {@code scene}", and "{@code system}" and the corresponding {@code id} used
+ * within the MiOS Unit.
  * 
- * <li>{@code command:<transform>} - a Transformation expression to map openHAB
- * Command data to MiOS UPnP calls.
+ * <li>{@code command:<transform>} - a Transformation expression to map openHAB Command data to MiOS UPnP calls.
  * 
- * <li>{@code in:<transform>} - a Transformation expression for inbound data
- * from the MiOS Unit for openHAB.
+ * <li>{@code in:<transform>} - a Transformation expression for inbound data from the MiOS Unit for openHAB.
  * 
- * <li>{@code out:<transform>} - a Transformation expression for outbound data
- * from openHAB for the MiOS Unit.
+ * <li>{@code out:<transform>} - a Transformation expression for outbound data from openHAB for the MiOS Unit.
  * </ul>
  * <p>
  * Example MiOS binding expressions look like the following:
@@ -62,32 +57,26 @@ import org.slf4j.LoggerFactory;
  * A read-only, binding expression with no mappings applied<br>
  * {@code mios="unit:house,device:228/service/AlarmPartition2/DetailedArmMode"}
  * <li>
- * A read-write, binding expression with input & output value and command
- * transformations<br>
+ * A read-write, binding expression with input & output value and command transformations<br>
  * {@code mios="unit:house,device:6/service/SwitchPower1/Status,command:ON|OFF,in:MAP(miosSwitchIn.map),out:MAP(miosSwitchOut.map)"}
  * </ul>
  * 
  * @author Mark Clark
  * @since 1.6.0
  */
-public class MiosBindingProviderImpl extends AbstractGenericBindingProvider
-		implements MiosBindingProvider {
+public class MiosBindingProviderImpl extends AbstractGenericBindingProvider implements MiosBindingProvider {
 
 	// TODO: Fix parsing for system to be tighter. We "opened" the parsing for
-	// the others to permit no "id" field, but that's not value
-	private static final Pattern BINDING_PATTERN = Pattern
-			.compile("(unit:(?<unit>[a-zA-Z]+[a-zA-Z0-9]*),)"
-					+ "(?<inThing>[^,]+)"
-					+ "(,command:(?<command>[^,]*))?"
-					+ "(,in:(?<inTransform>[a-zA-Z]+[a-zA-Z0-9]*\\([^,]*\\)))?"
-					+ "(,out:(?<outTransform>[a-zA-Z]+[a-zA-Z0-9]*\\([^,]*\\)))?");
+	// the others to permit no "id" field, but that's not valid
+	private static final Pattern BINDING_PATTERN = Pattern.compile("(unit:(?<unit>[a-zA-Z]+[a-zA-Z0-9]*),)"
+			+ "(?<inThing>[^,]+)" + "(,command:(?<command>[^,]*))?"
+			+ "(,in:(?<inTransform>[a-zA-Z]+[a-zA-Z0-9]*\\([^,]*\\)))?"
+			+ "(,out:(?<outTransform>[a-zA-Z]+[a-zA-Z0-9]*\\([^,]*\\)))?");
 
-	private static final Pattern IN_CONFIG_PATTERN = Pattern
-			.compile("((?<inType>device|scene|system|room):" + "(?<id>[0-9]*))"
-					+ "(/(?<inStuff>.+))?");
+	private static final Pattern IN_CONFIG_PATTERN = Pattern.compile("((?<inType>device|scene|system|room):"
+			+ "(?<id>[0-9]*))" + "(/(?<inStuff>.+))?");
 
-	private static final Logger logger = LoggerFactory
-			.getLogger(MiosBindingProviderImpl.class);
+	private static final Logger logger = LoggerFactory.getLogger(MiosBindingProviderImpl.class);
 
 	// Injected by the OSGi Container through the setItemRegistry and
 	// unsetItemRegistry methods.
@@ -96,9 +85,8 @@ public class MiosBindingProviderImpl extends AbstractGenericBindingProvider
 	/**
 	 * Invoked by the OSGi Framework.
 	 * 
-	 * This method is invoked by OSGi during the initialization of the
-	 * MiOSBinding, so we have subsequent access to the ItemRegistry (needed to
-	 * get values from Items in openHAB)
+	 * This method is invoked by OSGi during the initialization of the MiOSBinding, so we have subsequent access to the
+	 * ItemRegistry (needed to get values from Items in openHAB)
 	 */
 	public void setItemRegistry(ItemRegistry itemRegistry) {
 		logger.debug("setItemRegistry: called");
@@ -108,9 +96,8 @@ public class MiosBindingProviderImpl extends AbstractGenericBindingProvider
 	/**
 	 * Invoked by the OSGi Framework.
 	 * 
-	 * This method is invoked by OSGi during the initialization of the
-	 * MiOSBinding, so we have subsequent access to the ItemRegistry (needed to
-	 * get values from Items in openHAB)
+	 * This method is invoked by OSGi during the initialization of the MiOSBinding, so we have subsequent access to the
+	 * ItemRegistry (needed to get values from Items in openHAB)
 	 */
 	public void unsetItemRegistry(ItemRegistry itemRegistry) {
 		logger.debug("unsetItemRegistry: called");
@@ -132,8 +119,7 @@ public class MiosBindingProviderImpl extends AbstractGenericBindingProvider
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void validateItemType(Item item, String bindingConfig)
-			throws BindingConfigParseException {
+	public void validateItemType(Item item, String bindingConfig) throws BindingConfigParseException {
 		// Validation is done at the BindingConfig level, just after parsing the
 		// bindingConfig String inside processBindingConfiguration.
 	}
@@ -142,17 +128,15 @@ public class MiosBindingProviderImpl extends AbstractGenericBindingProvider
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void processBindingConfiguration(String context, Item item,
-			String bindingConfig) throws BindingConfigParseException {
+	public void processBindingConfiguration(String context, Item item, String bindingConfig)
+			throws BindingConfigParseException {
 		super.processBindingConfiguration(context, item, bindingConfig);
 
 		try {
-			MiosBindingConfig config = parseBindingConfig(context, item,
-					bindingConfig);
+			MiosBindingConfig config = parseBindingConfig(context, item, bindingConfig);
 			config.validateItemType(item);
 
-			logger.debug(
-					"processBindingConfiguration: Adding Item '{}' Binding '{}', from '{}'",
+			logger.debug("processBindingConfiguration: Adding Item '{}' Binding '{}', from '{}'",
 					new Object[] { item.getName(), config, context });
 			addBindingConfig(item, config);
 		} catch (BindingConfigParseException bcpe) {
@@ -164,16 +148,15 @@ public class MiosBindingProviderImpl extends AbstractGenericBindingProvider
 		}
 	}
 
-	private MiosBindingConfig parseBindingConfig(String context, Item item,
-			String bindingConfig) throws BindingConfigParseException {
+	private MiosBindingConfig parseBindingConfig(String context, Item item, String bindingConfig)
+			throws BindingConfigParseException {
 		Matcher matcher;
 
 		matcher = BINDING_PATTERN.matcher(bindingConfig);
 		if (!matcher.matches()) {
-			throw new BindingConfigParseException(
-					String.format(
-							"Config for item '%s' could not be parsed.  Bad general format '%s'",
-							item.getName(), bindingConfig.toString()));
+			throw new BindingConfigParseException(String.format(
+					"Config for item '%s' could not be parsed.  Bad general format '%s'", item.getName(),
+					bindingConfig.toString()));
 		}
 
 		String unitName = matcher.group("unit");
@@ -184,47 +167,39 @@ public class MiosBindingProviderImpl extends AbstractGenericBindingProvider
 		String inTrans = matcher.group("inTransform");
 		String outTrans = matcher.group("outTransform");
 
-		logger.trace(
-				"parseBindingConfig: unit '{}' thing '{}' inTrans '{}' outTrans '{}'",
-				new Object[] { unitName, inThing, inTrans, outTrans });
+		logger.trace("parseBindingConfig: unit '{}' thing '{}' inTrans '{}' outTrans '{}'", new Object[] { unitName,
+				inThing, inTrans, outTrans });
 
 		// The inbound pattern is mandatory, and enforced by the
 		// pattern-matcher.
 		matcher = IN_CONFIG_PATTERN.matcher(inThing);
 		if (!matcher.matches())
-			throw new BindingConfigParseException(
-					String.format(
-							"Config for item '%s' could not be parsed.  Bad thing format '%s'",
-							item.getName(), bindingConfig));
+			throw new BindingConfigParseException(String.format(
+					"Config for item '%s' could not be parsed.  Bad thing format '%s'", item.getName(), bindingConfig));
 
 		String inType = matcher.group("inType");
 		String inId = matcher.group("id");
 		String inStuff = matcher.group("inStuff");
 
-		logger.trace(
-				"parseBindingConfig: in: (Type '{}' id '{}' Stuff '{}'), command: ('{}')",
-				new Object[] { inType, inId, inStuff, commandThing });
+		logger.trace("parseBindingConfig: in: (Type '{}' id '{}' Stuff '{}'), command: ('{}')", new Object[] { inType,
+				inId, inStuff, commandThing });
 
 		// FIXME: Inline a factory for now...
 		if (inType.equals("device")) {
-			return DeviceBindingConfig.create(context, item.getName(),
-					unitName, Integer.parseInt(inId), inStuff, item.getClass(),
-					commandThing, inTrans, outTrans);
+			return DeviceBindingConfig.create(context, item.getName(), unitName, Integer.parseInt(inId), inStuff,
+					item.getClass(), commandThing, inTrans, outTrans);
 		} else if (inType.equals("scene")) {
-			return SceneBindingConfig.create(context, item.getName(), unitName,
-					Integer.parseInt(inId), inStuff, item.getClass(),
-					commandThing, inTrans, outTrans);
+			return SceneBindingConfig.create(context, item.getName(), unitName, Integer.parseInt(inId), inStuff,
+					item.getClass(), commandThing, inTrans, outTrans);
 		} else if (inType.equals("system")) {
-			return SystemBindingConfig.create(context, item.getName(),
-					unitName, inStuff, item.getClass(), inTrans, outTrans);
-		} else if (inType.equals("room")) {
-			return RoomBindingConfig.create(context, item.getName(), unitName,
-					Integer.parseInt(inId), inStuff, item.getClass(), inTrans,
+			return SystemBindingConfig.create(context, item.getName(), unitName, inStuff, item.getClass(), inTrans,
 					outTrans);
+		} else if (inType.equals("room")) {
+			return RoomBindingConfig.create(context, item.getName(), unitName, Integer.parseInt(inId), inStuff,
+					item.getClass(), inTrans, outTrans);
 		} else
 			throw new BindingConfigParseException(String.format(
-					"Invalid binding type received for Item %s, bad type (%s)",
-					item.getName(), inType));
+					"Invalid binding type received for Item %s, bad type (%s)", item.getName(), inType));
 	}
 
 	public MiosBindingConfig getMiosBindingConfig(String itemName) {
@@ -258,15 +233,12 @@ public class MiosBindingProviderImpl extends AbstractGenericBindingProvider
 
 		// TODO: Make a reverse map somewhere, and keep it around as this is
 		// going to get a lot of calls, and a lot of garbage along the way!!
-		for (Entry<String, BindingConfig> bindingConfigEntry : bindingConfigs
-				.entrySet()) {
+		for (Entry<String, BindingConfig> bindingConfigEntry : bindingConfigs.entrySet()) {
 			if (bindingConfigEntry.getValue() instanceof MiosBindingConfig) {
-				String p = ((MiosBindingConfig) bindingConfigEntry.getValue())
-						.toProperty();
+				String p = ((MiosBindingConfig) bindingConfigEntry.getValue()).toProperty();
 
 				if (p.equals(property)) {
-					logger.trace(
-							"getItemNamesForProperty: MATCH property '{}' against BindingConfig.toProperty '{}'",
+					logger.trace("getItemNamesForProperty: MATCH property '{}' against BindingConfig.toProperty '{}'",
 							property, p);
 
 					String itemName = bindingConfigEntry.getKey();

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosUnit.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosUnit.java
@@ -14,19 +14,16 @@ import org.slf4j.LoggerFactory;
 /**
  * Connection properties for an MiOS Unit.
  * 
- * Class used internally to contain the configuration of a <i>named</i> MiOS
- * Unit, after it's been materialized from openHAB's configuration components.
+ * Class used internally to contain the configuration of a <i>named</i> MiOS Unit, after it's been materialized from
+ * openHAB's configuration components.
  * 
- * The MiOS Unit is a <i>named</i> set of attributes that the MiOS Binding uses
- * to determine where communications need to be established:
+ * The MiOS Unit is a <i>named</i> set of attributes that the MiOS Binding uses to determine where communications need
+ * to be established:
  * <p>
  * <ul>
- * <li><code>Hostname</code> - the name, or IP Address of the host that's
- * running the MiOS Unit.
- * <li><code>Port</code> - the (numeric) TCP port of the host that's running the
- * MiOS Unit (default: <code>3480</code>)
- * <li><code>Timeout</code> - the Timeout to use for HTTP connections to the
- * MiOS Unit (default: <code>60000</code> ms)
+ * <li><code>Hostname</code> - the name, or IP Address of the host that's running the MiOS Unit.
+ * <li><code>Port</code> - the (numeric) TCP port of the host that's running the MiOS Unit (default: <code>3480</code>)
+ * <li><code>Timeout</code> - the Timeout to use for HTTP connections to the MiOS Unit (default: <code>60000</code> ms)
  * </ul>
  * <p>
  * 
@@ -38,9 +35,8 @@ public class MiosUnit {
 	public static final String CONFIG_DEFAULT_UNIT = "default";
 
 	/**
-	 * The minimal permissible timeout to be specified in the Unit
-	 * configuration. This allows us some headroom to tell the MiOS unit that we
-	 * want to long-poll for less than this amount of time.
+	 * The minimal permissible timeout to be specified in the Unit configuration. This allows us some headroom to tell
+	 * the MiOS unit that we want to long-poll for less than this amount of time.
 	 */
 	private static final int CONFIG_MIN_TIMEOUT = 5000;
 	private static final int CONFIG_DEFAULT_TIMEOUT = 60000;
@@ -66,12 +62,10 @@ public class MiosUnit {
 	private int refreshCount = CONFIG_DEFAULT_REFRESH_COUNT;
 	private int errorCount = CONFIG_DEFAULT_ERROR_COUNT;
 
-	private static final Logger logger = LoggerFactory
-			.getLogger(MiosUnit.class);
+	private static final Logger logger = LoggerFactory.getLogger(MiosUnit.class);
 
 	/**
-	 * All MiOS unit's have a name, that must be specified as the configuration
-	 * is being loaded.
+	 * All MiOS unit's have a name, that must be specified as the configuration is being loaded.
 	 */
 	public MiosUnit(String name) {
 		this.name = name;
@@ -89,8 +83,7 @@ public class MiosUnit {
 	/**
 	 * Get the Port setting for the MiOS unit configuration.
 	 * 
-	 * The default Port for a MiOS Unit is 3480, but this can be overridden in
-	 * config as needed.
+	 * The default Port for a MiOS Unit is 3480, but this can be overridden in config as needed.
 	 * 
 	 * @return the Port associated with the MiOS Unit.
 	 */
@@ -110,14 +103,11 @@ public class MiosUnit {
 	}
 
 	/**
-	 * Get the Minimum time, in ms, that the MiOS Unit should wait/delay in
-	 * order to "bundle" changes in their response.
+	 * Get the Minimum time, in ms, that the MiOS Unit should wait/delay in order to "bundle" changes in their response.
 	 * 
-	 * If this configuration is not specified, then it will default to 0ms, or
-	 * no-delay.
+	 * If this configuration is not specified, then it will default to 0ms, or no-delay.
 	 * 
-	 * @return the Minimum Delay for dealing with the MiOS Unit, in
-	 *         milliseconds.
+	 * @return the Minimum Delay for dealing with the MiOS Unit, in milliseconds.
 	 */
 	public int getMinimumDelay() {
 		return minimumDelay;
@@ -126,15 +116,13 @@ public class MiosUnit {
 	/**
 	 * Get the Refresh Count setting for the MiOS Unit configuration.
 	 * 
-	 * This setting is used to control how often (loop cycles) should be
-	 * performed loading incremental data, before a full-refresh of data should
-	 * be performed from the MiOS Unit under control.
+	 * This setting is used to control how often (loop cycles) should be performed loading incremental data, before a
+	 * full-refresh of data should be performed from the MiOS Unit under control.
 	 * 
-	 * If this setting is not specified, it will default to never performing the
-	 * full-refresh on the MiOS Unit (internally, a 0 value).
+	 * If this setting is not specified, it will default to never performing the full-refresh on the MiOS Unit
+	 * (internally, a 0 value).
 	 * 
-	 * @return the Full Refresh cycle count. A value of 0 will disable the Full
-	 *         Refresh from occurring.
+	 * @return the Full Refresh cycle count. A value of 0 will disable the Full Refresh from occurring.
 	 */
 	public int getRefreshCount() {
 		return refreshCount;
@@ -143,17 +131,14 @@ public class MiosUnit {
 	/**
 	 * Get the Error Count setting for the MiOS Unit configuration.
 	 * 
-	 * This setting is used to control how many errors are permitted, in
-	 * attempting to retrieve data from the MiOS Unit, prior to forcing a
-	 * full-refresh. By default, this logic is disabled (a 0 value), but it can
-	 * be reset so that errors in the retrieval will trigger a full data-set to
-	 * be fetched.
+	 * This setting is used to control how many errors are permitted, in attempting to retrieve data from the MiOS Unit,
+	 * prior to forcing a full-refresh. By default, this logic is disabled (a 0 value), but it can be reset so that
+	 * errors in the retrieval will trigger a full data-set to be fetched.
 	 * 
-	 * If this setting is not specified, it will default to never performing the
-	 * full-refresh on the MiOS Unit (internally, a 0 value).
+	 * If this setting is not specified, it will default to never performing the full-refresh on the MiOS Unit
+	 * (internally, a 0 value).
 	 * 
-	 * @return the Error count. A value of 0 will disable the Full Refresh from
-	 *         occurring upon errors.
+	 * @return the Error count. A value of 0 will disable the Full Refresh from occurring upon errors.
 	 */
 	public int getErrorCount() {
 		return errorCount;
@@ -183,13 +168,11 @@ public class MiosUnit {
 	 * Set the Timeout of the MiOS Unit configuration.
 	 * 
 	 * @param timeout
-	 *            the timeout to set for any connections associated with this
-	 *            MiOS Unit.
+	 *            the timeout to set for any connections associated with this MiOS Unit.
 	 */
 	public void setTimeout(int timeout) {
 		if (timeout < CONFIG_MIN_TIMEOUT) {
-			logger.warn("Timeout of {} below minimum permitted, {} used.",
-					timeout, CONFIG_MIN_TIMEOUT);
+			logger.warn("Timeout of {} below minimum permitted, {} used.", timeout, CONFIG_MIN_TIMEOUT);
 			timeout = CONFIG_MIN_TIMEOUT;
 		}
 		this.timeout = timeout;
@@ -199,14 +182,11 @@ public class MiosUnit {
 	 * Set the Minimum Delay of the MiOS Unit configuration.
 	 * 
 	 * @param delay
-	 *            the minimum delay, in ms, to use for any connections
-	 *            associated with this MiOS Unit.
+	 *            the minimum delay, in ms, to use for any connections associated with this MiOS Unit.
 	 */
 	public void setMinimumDelay(int delay) {
 		if (delay < CONFIG_MIN_MINIMUM_DELAY) {
-			logger.warn(
-					"Minimum Delay of {} below minimum permitted, {] used.",
-					minimumDelay, CONFIG_MIN_MINIMUM_DELAY);
+			logger.warn("Minimum Delay of {} below minimum permitted, {] used.", minimumDelay, CONFIG_MIN_MINIMUM_DELAY);
 			delay = CONFIG_MIN_MINIMUM_DELAY;
 		}
 		this.minimumDelay = delay;
@@ -216,14 +196,12 @@ public class MiosUnit {
 	 * Set the Refresh Count of the MiOS Unit configuration.
 	 * 
 	 * @param count
-	 *            the number of loop/cycles before a Full-data refresh is
-	 *            performed from the MiOS Unit. A value of 0 disables the
-	 *            refresh processing.
+	 *            the number of loop/cycles before a Full-data refresh is performed from the MiOS Unit. A value of 0
+	 *            disables the refresh processing.
 	 */
 	public void setRefreshCount(int count) {
 		if (count < 0) {
-			logger.warn("RefreshCount {} below minimum permitted, {} used.",
-					count, CONFIG_DISABLE_REFRESH_COUNT);
+			logger.warn("RefreshCount {} below minimum permitted, {} used.", count, CONFIG_DISABLE_REFRESH_COUNT);
 			count = CONFIG_DISABLE_REFRESH_COUNT;
 		}
 		this.refreshCount = count;
@@ -233,14 +211,12 @@ public class MiosUnit {
 	 * Set the Error Count of the MiOS Unit configuration.
 	 * 
 	 * @param errors
-	 *            the number of error loop/cycles before a Full-data refresh is
-	 *            performed from the MiOS Unit. A value of 0 disables the
-	 *            processing.
+	 *            the number of error loop/cycles before a Full-data refresh is performed from the MiOS Unit. A value of
+	 *            0 disables the processing.
 	 */
 	public void setErrorCount(int errors) {
 		if (errors < 0) {
-			logger.warn("RefreshCount {} below minimum permitted, {} used.",
-					errors, CONFIG_DISABLE_ERROR_COUNT);
+			logger.warn("RefreshCount {} below minimum permitted, {} used.", errors, CONFIG_DISABLE_ERROR_COUNT);
 			errors = CONFIG_DISABLE_ERROR_COUNT;
 		}
 		this.errorCount = errors;
@@ -249,8 +225,8 @@ public class MiosUnit {
 	/**
 	 * Get the name of the MiOS Unit configuration.
 	 * 
-	 * Each MiOS Unit has a name within the configuration properties. If it's
-	 * not named, then the "default" name is "default".
+	 * Each MiOS Unit has a name within the configuration properties. If it's not named, then the "default" name is
+	 * "default".
 	 * <p>
 	 * 
 	 * Otherwise, the name is that specified in the openHAB configuration.
@@ -270,13 +246,12 @@ public class MiosUnit {
 	/**
 	 * Provide any unit-specific prefix to a given property name.
 	 * 
-	 * Internally this method is used to augment a "MiOS Unit neutral" property
-	 * string with the name of <i>this<i/> MiOS Unit.
+	 * Internally this method is used to augment a "MiOS Unit neutral" property string with the name of <i>this<i/> MiOS
+	 * Unit.
 	 * <p>
 	 * 
-	 * In many cases, the code that builds the property string isn't aware of
-	 * the MiOS Unit that it's part of, and the MiOS Unit needs to be added on
-	 * later.
+	 * In many cases, the code that builds the property string isn't aware of the MiOS Unit that it's part of, and the
+	 * MiOS Unit needs to be added on later.
 	 * 
 	 * @param property
 	 *            an unformatted property name.

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosUnitConnector.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosUnitConnector.java
@@ -9,7 +9,6 @@
 package org.openhab.binding.mios.internal;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -18,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Properties;
+import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.regex.Matcher;
@@ -48,15 +47,11 @@ import com.ning.http.client.providers.jdk.JDKAsyncHttpProvider;
  * This code has two functions to perform:
  * <ul>
  * <li>Inbound <i>changes</i> from the MiOS Unit.<br>
- * Manages an internal thread to periodically poll the configured MiOS Unit and
- * timeout at the specified interval. All changes are internally transformed
- * from their original (JSON) form, and dispatched to the relevant parts of
- * openHAB.
+ * Manages an internal thread to periodically poll the configured MiOS Unit and timeout at the specified interval. All
+ * changes are internally transformed from their original (JSON) form, and dispatched to the relevant parts of openHAB.
  * <li>Outbound <i>commands</i> to the MiOS Unit.<br>
- * Exposes a method to transform & transmit openHAB Commands to the configured
- * MiOS Unit, in a non-blocking manner.<br>
- * Callers wishing to utilize this functionality use the
- * <code>invokeCommand</code> method.
+ * Exposes a method to transform & transmit openHAB Commands to the configured MiOS Unit, in a non-blocking manner.<br>
+ * Callers wishing to utilize this functionality use the <code>invokeCommand</code> method.
  * </ul>
  * 
  * @author Mark Clark
@@ -64,8 +59,7 @@ import com.ning.http.client.providers.jdk.JDKAsyncHttpProvider;
  */
 public class MiosUnitConnector {
 
-	private static final Logger logger = LoggerFactory
-			.getLogger(MiosUnitConnector.class);
+	private static final Logger logger = LoggerFactory.getLogger(MiosUnitConnector.class);
 
 	private static final String ENCODING_CHARSET = "utf-8";
 
@@ -79,10 +73,10 @@ public class MiosUnitConnector {
 	private static final String DEVICE_URL = "http://%s:%d/data_request?id=action&DeviceNum=%d&serviceId=%s&action=%s";
 	private static final String DEVICE_URL_PARAMS = DEVICE_URL + "&%s";
 
-	private static final Pattern DEVICE_PATTERN = Pattern
-			.compile("(?<serviceName>.+)/"
-					+ "(?<serviceAction>.+)"
-					+ "\\(((?<serviceParam>[a-zA-Z]+[a-zA-Z0-9]*)(=(?<serviceValue>.+))?)?\\)");
+	private static final Pattern DEVICE_PATTERN = Pattern.compile("(?<serviceName>.+)/" + "(?<serviceAction>.+)"
+			+ "\\(((?<serviceParam>[a-zA-Z]+[a-zA-Z0-9]*)(=(?<serviceValue>.+))?)?\\)");
+
+	private static final Pattern ACTION_PATTERN = Pattern.compile("(?<serviceName>.+)/" + "(?<serviceAction>.+)");
 
 	// the MiOS instance and openHAB event publisher handles
 	private final MiosUnit unit;
@@ -95,8 +89,7 @@ public class MiosUnitConnector {
 
 	/**
 	 * @param unit
-	 *            The host to connect to. Give a reachable hostname or IP
-	 *            address, without protocol or port
+	 *            The host to connect to. Give a reachable hostname or IP address, without protocol or port
 	 */
 	public MiosUnitConnector(MiosUnit unit, MiosBinding binding) {
 		logger.debug("Constructor: unit '{}', binding '{}'", unit, binding);
@@ -110,8 +103,7 @@ public class MiosUnitConnector {
 		// Use the JDK Provider for now, we're not looking for server-level
 		// scalability, and we'd like to lighten the load for folks wanting to
 		// run atop RPi units.
-		this.client = new AsyncHttpClient(new JDKAsyncHttpProvider(
-				builder.build()));
+		this.client = new AsyncHttpClient(new JDKAsyncHttpProvider(builder.build()));
 
 		pollCall = new LongPoll();
 		pollThread = new Thread(pollCall);
@@ -120,23 +112,20 @@ public class MiosUnitConnector {
 	/***
 	 * Check if the connection to the MiOS instance is active
 	 * 
-	 * @return true if an active connection to the MiOS instance exists, false
-	 *         otherwise
+	 * @return true if an active connection to the MiOS instance exists, false otherwise
 	 */
 	public boolean isConnected() {
 		return isRunning() && pollCall.isConnected();
 	}
 
 	/**
-	 * Attempts to create a connection to the MiOS host and begin listening for
-	 * updates over the async HTTP connection.
+	 * Attempts to create a connection to the MiOS host and begin listening for updates over the async HTTP connection.
 	 * 
 	 * @throws ExecutionException
 	 * @throws InterruptedException
 	 * @throws IOException
 	 */
-	public void open() throws IOException, InterruptedException,
-			ExecutionException {
+	public void open() throws IOException, InterruptedException, ExecutionException {
 		running = true;
 		pollThread.start();
 	}
@@ -181,24 +170,19 @@ public class MiosUnitConnector {
 		}
 	}
 
-	private void callDevice(DeviceBindingConfig config, Command command,
-			State state) throws TransformationException {
+	private void invokeDevice(DeviceBindingConfig config, Command command, State state) throws TransformationException {
 
-		logger.debug(
-				"callDevice: Need to remote-invoke Device '{}' action '{}' and current state '{}')",
+		logger.debug("invokeDevice: Need to remote-invoke Device '{}' action '{}' and current state '{}')",
 				new Object[] { config.toProperty(), command, state });
 
 		String newCommand = config.transformCommand(command);
 		if (newCommand == null) {
-			logger.warn(
-					"callDevice: Command '{}' not supported, or missing command: mapping, for Item '{}'",
+			logger.warn("invokeDevice: Command '{}' not supported, or missing command: mapping, for Item '{}'",
 					command.toString(), config.getItemName());
 			return;
 		} else if (newCommand.equals("")) {
-			logger.trace(
-					"callDevice: Item '{}' has disabled the use of Command '{}' via it's configuration '{}'",
-					new Object[] { config.getItemName(), command.toString(),
-							config.toProperty() });
+			logger.trace("invokeDevice: Item '{}' has disabled the use of Command '{}' via it's configuration '{}'",
+					new Object[] { config.getItemName(), command.toString(), config.toProperty() });
 			return;
 		}
 
@@ -208,15 +192,14 @@ public class MiosUnitConnector {
 			try {
 				MiosUnit u = getMiosUnit();
 
-				String serviceName = matcher.group("serviceName");
+				String serviceName = DeviceBindingConfig.mapServiceAlias(matcher.group("serviceName"));
 				String serviceAction = matcher.group("serviceAction");
 				String serviceParam = matcher.group("serviceParam");
 				String serviceValue = matcher.group("serviceValue");
 
 				logger.debug(
-						"callDevice: decoded as serviceName '{}' serviceAction '{}' serviceParam '{}' serviceValue '{}'",
-						new Object[] { serviceName, serviceAction,
-								serviceParam, serviceValue });
+						"invokeDevice: decoded as serviceName '{}' serviceAction '{}' serviceParam '{}' serviceValue '{}'",
+						new Object[] { serviceName, serviceAction, serviceParam, serviceValue });
 
 				// Perform any necessary bind-variable style transformations on
 				// the value, before we put it into the URL.
@@ -226,52 +209,37 @@ public class MiosUnitConnector {
 				// build the parameter section of the URL, encoding parameter
 				// names and values... trust no-one 8)
 				if (serviceParam != null) {
-					String p = URLEncoder
-							.encode(serviceParam, ENCODING_CHARSET)
-							+ '='
+					String p = URLEncoder.encode(serviceParam, ENCODING_CHARSET) + '='
 							+ URLEncoder.encode(serviceValue, ENCODING_CHARSET);
-					callMios(String.format(DEVICE_URL_PARAMS, u.getHostname(),
-							u.getPort(), config.getMiosId(),
+					callMios(String.format(DEVICE_URL_PARAMS, u.getHostname(), u.getPort(), config.getMiosId(),
 							URLEncoder.encode(serviceName, ENCODING_CHARSET),
-							URLEncoder.encode(serviceAction, ENCODING_CHARSET),
-							p));
+							URLEncoder.encode(serviceAction, ENCODING_CHARSET), p));
 				} else {
-					callMios(String.format(DEVICE_URL, u.getHostname(),
-							u.getPort(), config.getMiosId(),
+					callMios(String.format(DEVICE_URL, u.getHostname(), u.getPort(), config.getMiosId(),
 							URLEncoder.encode(serviceName, ENCODING_CHARSET),
 							URLEncoder.encode(serviceAction, ENCODING_CHARSET)));
 				}
 
 			} catch (UnsupportedEncodingException uee) {
-				logger.debug(
-						"Really, trust me, this won't happen ;)   exception='{}'",
-						uee);
+				logger.debug("Really, trust me, this won't happen ;)   exception='{}'", uee);
 			}
 		} else {
-			logger.error(
-					"callDevice: The parameter is in the wrong format.  BindingConfig '{}', UPnP Action '{}'",
+			logger.error("invokeDevice: The parameter is in the wrong format.  BindingConfig '{}', UPnP Action '{}'",
 					config, newCommand);
 		}
 
 	}
 
-	private void callScene(SceneBindingConfig config, Command command,
-			State state) throws TransformationException {
-		logger.debug("callScene: Need to remote-invoke Scene '{}'",
-				config.toProperty());
+	private void invokeScene(SceneBindingConfig config, Command command) throws TransformationException {
 
 		String newCommand = config.transformCommand(command);
 
 		if (newCommand != null) {
-			MiosUnit u = getMiosUnit();
-			callMios(String.format(SCENE_URL, u.getHostname(), u.getPort(),
-					config.getMiosId()));
+			invokeScene(config);
 		} else {
-			logger.warn(
-					"callScene: Command '{}' not supported, or missing command: declaration, for Item '{}'",
+			logger.warn("invokeScene: Command '{}' not supported, or missing command: declaration, for Item '{}'",
 					command.toString(), config.getItemName());
 		}
-
 	}
 
 	private void callMios(String url) {
@@ -286,35 +254,92 @@ public class MiosUnitConnector {
 			// success/fail of the call, log details (etc) so things can be
 			// diagnosed.
 		} catch (Exception e) {
-			logger.debug(
-					"callMios: Exception Error occurred fetching content: {}",
-					e.getMessage(), e);
+			logger.debug("callMios: Exception Error occurred fetching content: {}", e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * Request that a MiOS Scene be triggered.
+	 * 
+	 * Used by openHAB Action code, this method fires off the MiOS Scene associated with the Scene Item.
+	 * 
+	 * @param config
+	 *            A Scene [Item] Binding Configuration.
+	 */
+	public void invokeScene(SceneBindingConfig config) {
+
+		logger.debug("invokeScene: Invoking remote Scene '{}'", config.toProperty());
+
+		MiosUnit u = getMiosUnit();
+		callMios(String.format(SCENE_URL, u.getHostname(), u.getPort(), config.getMiosId()));
+	}
+
+	/**
+	 * Request that a MiOS Device Action be triggered.
+	 * 
+	 * Used by openHAB Action code, this method fires off the MiOS Action associated with the Device Item.
+	 * 
+	 * @param config
+	 *            A Device [Item] Binding Configuration.
+	 * @param actionName
+	 *            a UPnP-style Action to fire off on the remote MiOS Unit.
+	 * @param params
+	 *            a NV-Pair style list of parameters to be used by the Action call.
+	 */
+	public void invokeAction(DeviceBindingConfig config, String actionName, List<Entry<String, Object>> params) {
+		Matcher matcher = ACTION_PATTERN.matcher(actionName);
+		if (matcher.matches()) {
+			try {
+				MiosUnit u = getMiosUnit();
+
+				String serviceName = DeviceBindingConfig.mapServiceAlias(matcher.group("serviceName"));
+				String serviceAction = matcher.group("serviceAction");
+
+				if (params != null) {
+					String p = "";
+
+					for (Entry<String, Object> entry : params) {
+						if (p.length() != 0) {
+							p += '&';
+						}
+
+						p += URLEncoder.encode(entry.getKey(), ENCODING_CHARSET) + '='
+								+ URLEncoder.encode(entry.getValue().toString(), ENCODING_CHARSET);
+					}
+
+					callMios(String.format(DEVICE_URL_PARAMS, u.getHostname(), u.getPort(), config.getMiosId(),
+							URLEncoder.encode(serviceName, ENCODING_CHARSET),
+							URLEncoder.encode(serviceAction, ENCODING_CHARSET), p));
+				} else {
+					callMios(String.format(DEVICE_URL, u.getHostname(), u.getPort(), config.getMiosId(),
+							URLEncoder.encode(serviceName, ENCODING_CHARSET),
+							URLEncoder.encode(serviceAction, ENCODING_CHARSET)));
+				}
+
+			} catch (UnsupportedEncodingException uee) {
+				logger.debug("Really, trust me, this won't happen ;)   exception='{}'", uee);
+			}
 		}
 	}
 
 	/**
 	 * Request a Command be delivered to the MiOS Unit under control.
 	 * <p>
-	 * The MiOS Binding uses this call to deliver "single valued" openHAB
-	 * Commands to the target MiOS Unit.
+	 * The MiOS Binding uses this call to deliver "single valued" openHAB Commands to the target MiOS Unit.
 	 * <p>
-	 * Configurable transformations, defined at the BindingConfig level, are
-	 * used to transform this openHAB Command into the specific form required by
-	 * the MiOS Unit.
+	 * Configurable transformations, defined at the BindingConfig level, are used to transform this openHAB Command into
+	 * the specific form required by the MiOS Unit.
 	 * <p>
-	 * openHAB Commands can only be targeted to Device and Scene Bindings, all
-	 * other requests will cause a warning to be logged.
+	 * openHAB Commands can only be targeted to Device and Scene Bindings, all other requests will cause a warning to be
+	 * logged.
 	 */
-	public void invokeCommand(MiosBindingConfig config, Command command,
-			State state) throws Exception {
+	public void invokeCommand(MiosBindingConfig config, Command command, State state) throws Exception {
 		if (config instanceof SceneBindingConfig) {
-			callScene((SceneBindingConfig) config, command, state);
+			invokeScene((SceneBindingConfig) config, command);
 		} else if (config instanceof DeviceBindingConfig) {
-			callDevice((DeviceBindingConfig) config, command, state);
+			invokeDevice((DeviceBindingConfig) config, command, state);
 		} else {
-			logger.warn(
-					"Unhandled command execution for Command ('{}') on binding '{}'",
-					command, config);
+			logger.warn("Unhandled command execution for Command ('{}') on binding '{}'", command, config);
 		}
 	}
 
@@ -333,17 +358,14 @@ public class MiosUnitConnector {
 	/**
 	 * MiOS Poll code.
 	 * 
-	 * This code will stand up a thread to serially poll the target MiOS Unit.
-	 * The initial poll request will return the full content from the MiOS unit.
-	 * Subsequent calls are requested to only return the incremental/changed
-	 * contents.
+	 * This code will stand up a thread to serially poll the target MiOS Unit. The initial poll request will return the
+	 * full content from the MiOS unit. Subsequent calls are requested to only return the incremental/changed contents.
 	 * 
-	 * If a processing error (Timeout, etc) is detected, then a full content
-	 * poll is again initiated (since things can change during the interval)
+	 * If a processing error (Timeout, etc) is detected, then a full content poll is again initiated (since things can
+	 * change during the interval)
 	 * 
-	 * Upon successful polling, a series of calls are made to openHAB to push
-	 * the data to the respective bindings, so that data values will change
-	 * within the user's Rules (etc).
+	 * Upon successful polling, a series of calls are made to openHAB to push the data to the respective bindings, so
+	 * that data values will change within the user's Rules (etc).
 	 * 
 	 * @author Mark Clark
 	 * @since 1.6.0
@@ -381,16 +403,13 @@ public class MiosUnitConnector {
 
 				// Use a timeout on the MiOS URL call that's about 2/3 of what
 				// the connection timeout is.
-				int t = Math.min(c.getIdleConnectionTimeoutInMs(),
-						unit.getTimeout()) / 500 / 3;
+				int t = Math.min(c.getIdleConnectionTimeoutInMs(), unit.getTimeout()) / 500 / 3;
 				int d = unit.getMinimumDelay();
 
-				return String.format(Locale.US, STATUS2_INCREMENTAL_URL,
-						unit.getHostname(), unit.getPort(), loadTime,
+				return String.format(Locale.US, STATUS2_INCREMENTAL_URL, unit.getHostname(), unit.getPort(), loadTime,
 						dataVersion, new Integer(t), new Integer(d));
 			} else {
-				return String.format(Locale.US, STATUS2_URL,
-						unit.getHostname(), unit.getPort());
+				return String.format(Locale.US, STATUS2_URL, unit.getHostname(), unit.getPort());
 			}
 		}
 
@@ -416,28 +435,23 @@ public class MiosUnitConnector {
 			try {
 				getMiosBinding().postPropertyUpdate(p, value, incremental);
 			} catch (Exception e) {
-				logger.error(
-						"Exception '{}' raised pushing property '{}' value '{}' into openHAB",
+				logger.error("Exception '{}' raised pushing property '{}' value '{}' into openHAB",
 						new Object[] { e.getMessage(), p, value, e });
 			}
 		}
 
-		private void processSystem(Map<String, Object> system,
-				boolean incremental) {
-			for (Map.Entry<String, Object> entry : system.entrySet()) {
+		private void processSystem(Map<String, Object> system, boolean incremental) {
+			for (Entry<String, Object> entry : system.entrySet()) {
 				String key = entry.getKey();
 				Object value = entry.getValue();
 
-				if (!key.equals("devices") && !key.equals("scenes")
-						&& !key.equals("rooms") && !key.equals("sections")) {
-					if (value instanceof String || value instanceof Integer
-							|| value instanceof Double
+				if (!key.equals("devices") && !key.equals("scenes") && !key.equals("rooms") && !key.equals("sections")) {
+					if (value instanceof String || value instanceof Integer || value instanceof Double
 							|| value instanceof Boolean) {
 						// Skip over Lua code blocks and
 						// fix [known] date-time values on the way through, so
 						// they use the native type.
-						if (key.equals("DeviceSync") || key.equals("LoadTime")
-								|| key.equals("zwave_heal")
+						if (key.equals("DeviceSync") || key.equals("LoadTime") || key.equals("zwave_heal")
 								|| key.equals("TimeStamp")) {
 							value = fixTimestamp(value);
 						}
@@ -452,9 +466,7 @@ public class MiosUnitConnector {
 							continue;
 						}
 
-						logger.debug(
-								"processSystem: skipping key={}, class={}",
-								key, value.getClass());
+						logger.debug("processSystem: skipping key={}, class={}", key, value.getClass());
 					}
 				}
 			}
@@ -486,12 +498,11 @@ public class MiosUnitConnector {
 				}
 
 				// Enumerate Device Attributes
-				for (Map.Entry<String, Object> da : device.entrySet()) {
+				for (Entry<String, Object> da : device.entrySet()) {
 					String key = da.getKey();
 					Object value = da.getValue();
 
-					if (value instanceof String || value instanceof Integer
-							|| value instanceof Double
+					if (value instanceof String || value instanceof Integer || value instanceof Double
 							|| value instanceof Boolean) {
 						if (key.equals("time_created")) {
 							// fix [known] date-time values on the way through,
@@ -512,21 +523,18 @@ public class MiosUnitConnector {
 						// would be like having an "end of [device] transaction"
 						// marker.
 
-						String property = "device:" + deviceId + '/'
-								+ da.getKey();
+						String property = "device:" + deviceId + '/' + da.getKey();
 						publish(property, value, incremental);
 					} else {
 						// No need to bring these into openHAB, they'll only
 						// bulk up
 						// the system.
-						if (key.equals("states") || key.equals("ControlURLs")
-								|| key.equals("Jobs") || key.equals("tooltip")) {
+						if (key.equals("states") || key.equals("ControlURLs") || key.equals("Jobs")
+								|| key.equals("tooltip")) {
 							continue;
 						}
 
-						logger.debug(
-								"processDevices: skipping key={}, class={}",
-								key, value.getClass());
+						logger.debug("processDevices: skipping key={}, class={}", key, value.getClass());
 					}
 				}
 
@@ -536,8 +544,7 @@ public class MiosUnitConnector {
 				for (Object ds : deviceStates) {
 					@SuppressWarnings("unchecked")
 					Map<String, Object> state = (Map<String, Object>) ds;
-					String var = (String) state.get("service") + "/"
-							+ (String) state.get("variable");
+					String var = (String) state.get("service") + "/" + (String) state.get("variable");
 					String property = "device:" + deviceId + "/service/" + var;
 
 					// Can be String or Integer
@@ -562,13 +569,12 @@ public class MiosUnitConnector {
 				Integer sceneId = (Integer) scene.get("id");
 
 				// Enumerate Scene Attributes
-				for (Map.Entry<String, Object> da : scene.entrySet()) {
+				for (Entry<String, Object> da : scene.entrySet()) {
 					String key = da.getKey();
 
 					Object value = da.getValue();
 
-					if (value instanceof String || value instanceof Integer
-							|| value instanceof Double
+					if (value instanceof String || value instanceof Integer || value instanceof Double
 							|| value instanceof Boolean) {
 						if (key.equals("Timestamp")) {
 							// fix [known] date-time values on the way through,
@@ -589,16 +595,12 @@ public class MiosUnitConnector {
 						// No need to bring these into openHAB, they'll only
 						// bulk up
 						// the system.
-						if (key.equals("timers") || key.equals("triggers")
-								|| key.equals("groups")
-								|| key.equals("tooltip") || key.equals("Jobs")
-								|| key.equals("lua")) {
+						if (key.equals("timers") || key.equals("triggers") || key.equals("groups")
+								|| key.equals("tooltip") || key.equals("Jobs") || key.equals("lua")) {
 							continue;
 						}
 
-						logger.debug(
-								"processScenes: skipping key={}, class={}",
-								key, value.getClass());
+						logger.debug("processScenes: skipping key={}, class={}", key, value.getClass());
 					}
 				}
 			}
@@ -612,8 +614,7 @@ public class MiosUnitConnector {
 			// TODO: Implement
 		}
 
-		private void processResponse(Map<String, Object> response,
-				boolean incremental) {
+		private void processResponse(Map<String, Object> response, boolean incremental) {
 
 			Integer lt = (Integer) response.get("LoadTime");
 			Integer dv = (Integer) response.get("DataVersion");
@@ -627,11 +628,8 @@ public class MiosUnitConnector {
 
 				logger.debug(
 						"processResponse: success! loadTime={}, dataVersion={} devices({}) scenes({}) rooms({}) sections({})",
-						new Object[] { lt, dv,
-								Integer.toString(devices.size()),
-								Integer.toString(scenes.size()),
-								Integer.toString(rooms.size()),
-								Integer.toString(sections.size()) });
+						new Object[] { lt, dv, Integer.toString(devices.size()), Integer.toString(scenes.size()),
+								Integer.toString(rooms.size()), Integer.toString(sections.size()) });
 
 				processDevices(devices, incremental);
 				processScenes(scenes, incremental);
@@ -645,8 +643,7 @@ public class MiosUnitConnector {
 				this.dataVersion = dv;
 				this.failures = 0;
 			} else {
-				throw new RuntimeException(
-						"Processing error on MiOS JSON Response - malformed");
+				throw new RuntimeException("Processing error on MiOS JSON Response - malformed");
 			}
 		}
 
@@ -690,18 +687,15 @@ public class MiosUnitConnector {
 					// configuration indicates to do so, or if we get an error.
 					MiosUnit unit = getMiosUnit();
 					int errorCount = unit.getErrorCount();
-					boolean force = (loopCount == 0l) || (errorCount != 0)
-							&& (failures != 0)
+					boolean force = (loopCount == 0l) || (errorCount != 0) && (failures != 0)
 							&& ((failures % errorCount) == 0);
 
 					boolean incremental = (!force && loadTime != null && dataVersion != null);
 					String uri = getUri(incremental);
 
-					logger.debug("run: URI Built was '{}' loop '{}'", uri,
-							loopCount);
+					logger.debug("run: URI Built was '{}' loop '{}'", uri, loopCount);
 
-					Future<Response> f = getAsyncHttpClient().prepareGet(uri)
-							.execute();
+					Future<Response> f = getAsyncHttpClient().prepareGet(uri).execute();
 					Response r = (Response) f.get();
 
 					// Force the Response Charset to be UTF-8, since MiOS isn't setting
@@ -727,8 +721,7 @@ public class MiosUnitConnector {
 					this.failures++;
 					logger.debug(
 							"run: Exception Error occurred fetching/processing content: {},{}.  Total failures ({})",
-							new Object[] { e.getMessage(), e,
-									Integer.toString(failures) });
+							new Object[] { e.getMessage(), e, Integer.toString(failures) });
 
 					// TODO: Make the pause configurable and/or add a backoff
 					// mechanism.
@@ -742,8 +735,7 @@ public class MiosUnitConnector {
 				}
 			} while (isRunning());
 
-			logger.info("run: Shutting down MiOS Polling thread.  Unit={}",
-					getMiosUnit().getName());
+			logger.info("run: Shutting down MiOS Polling thread.  Unit={}", getMiosUnit().getName());
 			connected = false;
 		}
 	}

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/DeviceBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/DeviceBindingConfig.java
@@ -11,6 +11,7 @@ package org.openhab.binding.mios.internal.config;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -36,8 +37,7 @@ import org.osgi.framework.BundleContext;
  * <li><nobr>
  * <tt>mios="unit:<i>unitName</i>,device:<i>deviceId</i>/service/<i>serviceAlias</i>/<i>serviceVariable</i>,<i>optionalTransformations</i></tt>
  * </nobr>
- * <li><nobr>
- * <tt>mios="unit:<i>unitName</i>,device:<i>deviceId</i>/<i>attrName</i>,<i>optionalTransformations</i></tt>
+ * <li><nobr> <tt>mios="unit:<i>unitName</i>,device:<i>deviceId</i>/<i>attrName</i>,<i>optionalTransformations</i></tt>
  * </nobr>
  * </ul>
  * <p>
@@ -56,8 +56,8 @@ import org.osgi.framework.BundleContext;
  * </ul>
  * <p>
  * 
- * There are also a set of pre-defined UPnP Service aliases, so a short-hand
- * notation can be used for common UPnP ServiceId's:<br>
+ * There are also a set of pre-defined UPnP Service aliases, so a short-hand notation can be used for common UPnP
+ * ServiceId's:<br>
  * <ul>
  * <li>
  * <code><nobr>Number MiOSMemoryAvailable "Available [%.0f KB]" (BindingDemo) {mios="unit:house,device:382/service/SystemMonitor/memoryAvailable"}</nobr></code>
@@ -70,13 +70,12 @@ import org.osgi.framework.BundleContext;
  * </ul>
  * <p>
  * 
- * The complete list of UPnP Service aliases is listed in the documentation
- * file, or can be seen in the file <code>ServiceAliases.properties</code>.
+ * The complete list of UPnP Service aliases is listed in the documentation file, or can be seen in the file
+ * <code>ServiceAliases.properties</code>.
  * <p>
  * 
- * In addition to binding against a Device's Variables, you can bind to the set
- * of Device Attributes it exposes. Specifically it's <code>id</code> and
- * <code>status</code>:
+ * In addition to binding against a Device's Variables, you can bind to the set of Device Attributes it exposes.
+ * Specifically it's <code>id</code> and <code>status</code>:
  * <p>
  * <ul>
  * <li>
@@ -88,38 +87,32 @@ import org.osgi.framework.BundleContext;
  * 
  * <b>Optional Transformations</b>
  * <p>
- * In many cases, the values exposed by a MiOS Unit aren't suitable for use
- * within openHAB, and a value mapping/transformation may be needed.
+ * In many cases, the values exposed by a MiOS Unit aren't suitable for use within openHAB, and a value
+ * mapping/transformation may be needed.
  * <p>
  * 
- * Values may be transformed using an input transformation (<code>in:</code>) or
- * a command transformation (<code>command:</code>). In future, values will also
- * be transformed prior to being sent to a MiOS Unit via the output
+ * Values may be transformed using an input transformation (<code>in:</code>) or a command transformation (
+ * <code>command:</code>). In future, values will also be transformed prior to being sent to a MiOS Unit via the output
  * transformation (<code>out:</code>)
  * <p>
  * 
- * Transformation files are provided, for the common input and command
- * transformations, in the <code>examples/transform</code> directory of the MiOS
- * Binding.
+ * Transformation files are provided, for the common input and command transformations, in the
+ * <code>examples/transform</code> directory of the MiOS Binding.
  * <p>
- * The examples presented here assume that these MAP transformation files have
- * been copied to the appropriate openHAB configuration location (typically
- * <code>configuration/transform</code>).
+ * The examples presented here assume that these MAP transformation files have been copied to the appropriate openHAB
+ * configuration location (typically <code>configuration/transform</code>).
  * <p>
  * 
  * There are example Input transformation maps:
  * <ul>
- * <li><code>miosSwitchIn.map</code> - MiOS Switch device (
- * <code>service/SwitchPower1/Status</code>) properties when mapped to a
- * <code>Switch</code> Item.
- * <li><code>miosStatusIn.map</code> - MiOS Status attributes (
- * <code>/status</code>) to make them readable states when mapped to a
+ * <li><code>miosSwitchIn.map</code> - MiOS Switch device ( <code>service/SwitchPower1/Status</code>) properties when
+ * mapped to a <code>Switch</code> Item.
+ * <li><code>miosStatusIn.map</code> - MiOS Status attributes ( <code>/status</code>) to make them readable states when
+ * mapped to a <code>String</code> Item.
+ * <li><code>miosContactIn.map</code> - MiOS Security Sensor device ( <code>/service/SecuritySensor1/Tripped</code>)
+ * when mapped to a <code>Contact</code> Item.
+ * <li><code>miosZWaveStatusIn.map</code> - MiOS System attribute ( <code>system:/ZWaveStatus</code>) when mapped to a
  * <code>String</code> Item.
- * <li><code>miosContactIn.map</code> - MiOS Security Sensor device (
- * <code>/service/SecuritySensor1/Tripped</code>) when mapped to a
- * <code>Contact</code> Item.
- * <li><code>miosZWaveStatusIn.map</code> - MiOS System attribute (
- * <code>system:/ZWaveStatus</code>) when mapped to a <code>String</code> Item.
  * <li><code>miosWeatherConditionGroupIn.map</code> - MiOS
  * </ul>
  * 
@@ -133,41 +126,30 @@ import org.osgi.framework.BundleContext;
  * <p>
  * And example Command transformation maps:
  * <ul>
- * <li><code>miosArmedCommand.map</code> - MiOS Security Sensor device (
- * <code>/service/SecuritySensor1/Armed</code>) when mapped to a
- * <code>Switch</code> Item.
- * <li><code>miosDimmerCommand.map</code> - MiOS Dimmer device (
- * <code>/service/Dimming1/LoadLevelStatus</code>) when mapped to a
- * <code>Dimmer</code> Item.
- * <li><code>miosLockCommand.map</code> - MiOS Lock device (
- * <code>/service/DoorLock1/Status</code>) properties when mapped to a
- * <code>Switch</code> Item.
+ * <li><code>miosArmedCommand.map</code> - MiOS Security Sensor device ( <code>/service/SecuritySensor1/Armed</code>)
+ * when mapped to a <code>Switch</code> Item.
+ * <li><code>miosDimmerCommand.map</code> - MiOS Dimmer device ( <code>/service/Dimming1/LoadLevelStatus</code>) when
+ * mapped to a <code>Dimmer</code> Item.
+ * <li><code>miosLockCommand.map</code> - MiOS Lock device ( <code>/service/DoorLock1/Status</code>) properties when
+ * mapped to a <code>Switch</code> Item.
  * <li><code>miosTStatModeStatusCommand.map</code> - MiOS Thermostat device (
- * <code>/service/HVAC_UserOperatingMode1/ModeStatus</code>) when mapped to a
- * <code>String</code> Item.
+ * <code>/service/HVAC_UserOperatingMode1/ModeStatus</code>) when mapped to a <code>String</code> Item.
  * <li><code>miosTStatSetpointCoolCommand.map</code> - MiOS Thermostat device (
- * <code>/service/TemperatureSetpoint1_Cool/CurrentSetpoint</code>) when mapped
- * to a <code>Number</code> Item.
+ * <code>/service/TemperatureSetpoint1_Cool/CurrentSetpoint</code>) when mapped to a <code>Number</code> Item.
  * <li><code>miosTStatSetpointHeatCommand.map</code> - MiOS Thermostat device (
- * <code>/service/TemperatureSetpoint1_Heat/CurrentSetpoint</code>) when mapped
- * to a <code>Number</code> Item.
- * <li><code>miosTStatFanOperatingModeCommand.map</code> - MiOS Thermostat
- * device (<code>/service/HVAC_FanOperatingMode1/Mode</code>) when mapped to a
- * <code>String</code> Item.
- * <li><code>miosUPnPRenderingControlVolumeCommand.map</code> - MiOS UPnP Volume
- * (<code>service/RenderingControl/Volume</code>) property when mapped to a
- * <code>Dimmer</code> Item.
+ * <code>/service/TemperatureSetpoint1_Heat/CurrentSetpoint</code>) when mapped to a <code>Number</code> Item.
+ * <li><code>miosTStatFanOperatingModeCommand.map</code> - MiOS Thermostat device (
+ * <code>/service/HVAC_FanOperatingMode1/Mode</code>) when mapped to a <code>String</code> Item.
+ * <li><code>miosUPnPRenderingControlVolumeCommand.map</code> - MiOS UPnP Volume (
+ * <code>service/RenderingControl/Volume</code>) property when mapped to a <code>Dimmer</code> Item.
  * <li><code>miosUPnPRenderingControlMuteCommand.map</code> - MiOS UPnP Mute (
- * <code>service/RenderingControl/Mute</code>) property when mapped to a
- * <code>Switch</code> Item.
- * <li><code>miosUPnPTransportStatePlayModeCommand.map</code> - MiOS UPnP
- * PlayMode (<code>service/AVTransport/TransportState</code>) when mapped to a
- * <code>String</code> Item.
+ * <code>service/RenderingControl/Mute</code>) property when mapped to a <code>Switch</code> Item.
+ * <li><code>miosUPnPTransportStatePlayModeCommand.map</code> - MiOS UPnP PlayMode (
+ * <code>service/AVTransport/TransportState</code>) when mapped to a <code>String</code> Item.
  * </ul>
  * <p>
  * 
- * More details on these mappings can be found in the
- * <code>README.md<code> file associated
+ * More details on these mappings can be found in the <code>README.md<code> file associated
  * with this Binding.
  * <p>
  * 
@@ -181,18 +163,11 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 	private static Map<String, String> COMMAND_DEFAULTS = new HashMap<String, String>();
 
 	static {
-		COMMAND_DEFAULTS
-				.put("ON",
-						"urn:upnp-org:serviceId:SwitchPower1/SetTarget(newTargetValue=1)");
-		COMMAND_DEFAULTS
-				.put("OFF",
-						"urn:upnp-org:serviceId:SwitchPower1/SetTarget(newTargetValue=0)");
-		COMMAND_DEFAULTS.put("TOGGLE",
-				"urn:micasaverde-com:serviceId:HaDevice1/ToggleState()");
-		COMMAND_DEFAULTS.put("INCREASE",
-				"urn:upnp-org:serviceId:Dimming1/StepUp()");
-		COMMAND_DEFAULTS.put("DECREASE",
-				"urn:upnp-org:serviceId:Dimming1/StepDown()");
+		COMMAND_DEFAULTS.put("ON", "urn:upnp-org:serviceId:SwitchPower1/SetTarget(newTargetValue=1)");
+		COMMAND_DEFAULTS.put("OFF", "urn:upnp-org:serviceId:SwitchPower1/SetTarget(newTargetValue=0)");
+		COMMAND_DEFAULTS.put("TOGGLE", "urn:micasaverde-com:serviceId:HaDevice1/ToggleState()");
+		COMMAND_DEFAULTS.put("INCREASE", "urn:upnp-org:serviceId:Dimming1/StepUp()");
+		COMMAND_DEFAULTS.put("DECREASE", "urn:upnp-org:serviceId:Dimming1/StepDown()");
 	}
 
 	private static Properties aliasMap = new Properties();
@@ -209,13 +184,11 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 
 		try {
 			aliasMap.load(input);
-			logger.debug(
-					"Successfully loaded UPnP Service Aliases from '{}', entries '{}'",
-					SERVICE_ALIASES, aliasMap.size());
+			logger.debug("Successfully loaded UPnP Service Aliases from '{}', entries '{}'", SERVICE_ALIASES,
+					aliasMap.size());
 		} catch (Exception e) {
 			// Pre-shipped with the Binding, so it should never error out.
-			logger.error("Failed to load Service Alias file '{}', Exception",
-					SERVICE_ALIASES, e);
+			logger.error("Failed to load Service Alias file '{}', Exception", SERVICE_ALIASES, e);
 		}
 
 		input = cl.getResourceAsStream(PARAM_DEFAULTS);
@@ -224,24 +197,19 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 			Properties tmp = new Properties();
 			tmp.load(input);
 
-			for (Map.Entry<Object, Object> e : tmp.entrySet()) {
-				paramDefaults.put((String) e.getKey(),
-						ParameterDefaults.parse((String) e.getValue()));
+			for (Entry<Object, Object> e : tmp.entrySet()) {
+				paramDefaults.put((String) e.getKey(), ParameterDefaults.parse((String) e.getValue()));
 			}
 
-			logger.debug(
-					"Successfully loaded Device Parameter defaults from '{}', entries '{}'",
-					PARAM_DEFAULTS, paramDefaults.size());
+			logger.debug("Successfully loaded Device Parameter defaults from '{}', entries '{}'", PARAM_DEFAULTS,
+					paramDefaults.size());
 		} catch (Exception e) {
 			// Pre-shipped with the Binding, so it should never error out.
-			logger.error(
-					"Failed to load Device Parameter defaults file '{}', Exception",
-					PARAM_DEFAULTS, e);
+			logger.error("Failed to load Device Parameter defaults file '{}', Exception", PARAM_DEFAULTS, e);
 		}
 	}
 
-	private static final Pattern SERVICE_IN_PATTERN = Pattern
-			.compile("service/(?<serviceName>.+)/(?<serviceVar>.+)");
+	private static final Pattern SERVICE_IN_PATTERN = Pattern.compile("service/(?<serviceName>.+)/(?<serviceVar>.+)");
 
 	private static final Pattern SERVICE_COMMAND_TRANSFORM_PATTERN = Pattern
 			.compile("(?<transform>(?<transformCommand>[a-zA-Z]+)\\((?<transformParam>.*)\\))");
@@ -255,13 +223,23 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 
 	private TransformationService commandTransformationService;
 
-	private DeviceBindingConfig(String context, String itemName,
-			String unitName, int id, String stuff,
-			Class<? extends Item> itemType, String commandTransform,
-			String inTransform, String outTransform)
+	private DeviceBindingConfig(String context, String itemName, String unitName, int id, String stuff,
+			Class<? extends Item> itemType, String commandTransform, String inTransform, String outTransform)
 			throws BindingConfigParseException {
-		super(context, itemName, unitName, id, stuff, itemType,
-				commandTransform, inTransform, outTransform);
+		super(context, itemName, unitName, id, stuff, itemType, commandTransform, inTransform, outTransform);
+	}
+
+	/**
+	 * Map Aliased Service names into their "formal" UPnP-style format.
+	 * 
+	 * @param source
+	 *            the original Service name to be mapped
+	 * @return the mapped UPnP-style Service name, if an alias mapping exists, or the original source value.
+	 */
+	public static final String mapServiceAlias(String source) {
+		String mapped = (String) aliasMap.get(source);
+
+		return (mapped == null) ? source : mapped;
 	}
 
 	/**
@@ -269,11 +247,9 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 	 * 
 	 * @return an initialized MiOS Device Binding Configuration object.
 	 */
-	public static final MiosBindingConfig create(String context,
-			String itemName, String unitName, int id, String inStuff,
-			Class<? extends Item> itemType, String commandTransform,
-			String inTransform, String outTransform)
-			throws BindingConfigParseException {
+	public static final MiosBindingConfig create(String context, String itemName, String unitName, int id,
+			String inStuff, Class<? extends Item> itemType, String commandTransform, String inTransform,
+			String outTransform) throws BindingConfigParseException {
 		try {
 			// Before we initialize, normalize the serviceId string used in any
 			// outgoing stuff.
@@ -294,10 +270,7 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 				iVar = matcher.group("serviceVar");
 
 				// Handle service name aliases.
-				tmp = (String) aliasMap.get(iName);
-				if (tmp != null) {
-					iName = tmp;
-				}
+				iName = mapServiceAlias(iName);
 
 				// Rebuild, since we've normalized the name.
 				newInStuff = "service/" + iName + '/' + iVar;
@@ -310,31 +283,21 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 			//
 			ParameterDefaults pd = paramDefaults.get(newInStuff);
 			if (pd != null) {
-				logger.trace(
-						"Device ParameterDefaults FOUND '{}' for '{}', '{}'",
-						itemName, newInStuff, pd);
+				logger.trace("Device ParameterDefaults FOUND '{}' for '{}', '{}'", itemName, newInStuff, pd);
 				if (commandTransform == null) {
 					commandTransform = pd.getCommandTransform();
-					logger.trace(
-							"Device ParameterDefaults '{}' defaulted command: to '{}'",
-							itemName, commandTransform);
+					logger.trace("Device ParameterDefaults '{}' defaulted command: to '{}'", itemName, commandTransform);
 				}
 				if (inTransform == null) {
 					inTransform = pd.getInTransform();
-					logger.trace(
-							"Device ParameterDefaults '{}' defaulted in: to '{}'",
-							itemName, inTransform);
+					logger.trace("Device ParameterDefaults '{}' defaulted in: to '{}'", itemName, inTransform);
 				}
 				if (outTransform == null) {
 					outTransform = pd.getOutTransform();
-					logger.trace(
-							"Device ParameterDefaults '{}' defaulted out: to '{}'",
-							itemName, outTransform);
+					logger.trace("Device ParameterDefaults '{}' defaulted out: to '{}'", itemName, outTransform);
 				}
 			} else {
-				logger.trace(
-						"Device ParameterDefaults NOT FOUND '{}' for '{}'",
-						itemName, newInStuff);
+				logger.trace("Device ParameterDefaults NOT FOUND '{}' for '{}'", itemName, newInStuff);
 			}
 
 			String cTransform = null;
@@ -347,8 +310,7 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 				cMap = COMMAND_DEFAULTS;
 			} else if (newCommandTransform != null) {
 				// Try for a match as a TransformationService.
-				matcher = SERVICE_COMMAND_TRANSFORM_PATTERN
-						.matcher(newCommandTransform);
+				matcher = SERVICE_COMMAND_TRANSFORM_PATTERN.matcher(newCommandTransform);
 				if (matcher.matches()) {
 					cTransform = matcher.group("transformCommand");
 					cParam = matcher.group("transformParam");
@@ -357,8 +319,7 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 					String[] commandList = newCommandTransform.split("\\|");
 					String command;
 
-					Map<String, String> l = new HashMap<String, String>(
-							commandList.length);
+					Map<String, String> l = new HashMap<String, String>(commandList.length);
 
 					String mapName;
 					String serviceStr;
@@ -367,8 +328,7 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 
 					for (int i = 0; i < commandList.length; i++) {
 						command = commandList[i];
-						matcher = SERVICE_COMMAND_INMAP_PATTERN
-								.matcher(command);
+						matcher = SERVICE_COMMAND_INMAP_PATTERN.matcher(command);
 						if (matcher.matches()) {
 							mapName = matcher.group("mapName");
 							serviceName = matcher.group("serviceName");
@@ -376,10 +336,7 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 
 							if (serviceName != null) {
 								// Handle any Service Aliases that might have been used in the inline Map.
-								tmp = (String) aliasMap.get(serviceName);
-								if (tmp != null) {
-									serviceName = tmp;
-								}
+								serviceName = mapServiceAlias(serviceName);
 
 								serviceStr = serviceName + '/' + serviceAction;
 							} else {
@@ -389,28 +346,24 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 							String oldMapName = l.put(mapName, serviceStr);
 
 							if (oldMapName != null) {
-								throw new BindingConfigParseException(
-										String.format(
-												"Duplicate inline Map entry '%s' in command: '%s'",
-												oldMapName, newCommandTransform));
+								throw new BindingConfigParseException(String.format(
+										"Duplicate inline Map entry '%s' in command: '%s'", oldMapName,
+										newCommandTransform));
 							}
 						} else {
-							throw new BindingConfigParseException(
-									String.format(
-											"Invalid command, parameter format '%s' in command: '%s'",
-											command, newCommandTransform));
+							throw new BindingConfigParseException(String.format(
+									"Invalid command, parameter format '%s' in command: '%s'", command,
+									newCommandTransform));
 						}
 					}
 					cMap = l;
 				}
 			}
 
-			logger.trace("newInStuff '{}', iName '{}', iVar '{}'",
-					new Object[] { newInStuff, iName, iVar });
+			logger.trace("newInStuff '{}', iName '{}', iVar '{}'", new Object[] { newInStuff, iName, iVar });
 
-			DeviceBindingConfig c = new DeviceBindingConfig(context, itemName,
-					unitName, id, newInStuff, itemType, newCommandTransform,
-					inTransform, outTransform);
+			DeviceBindingConfig c = new DeviceBindingConfig(context, itemName, unitName, id, newInStuff, itemType,
+					newCommandTransform, inTransform, outTransform);
 			c.initialize();
 
 			c.commandTransformName = cTransform;
@@ -458,22 +411,19 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 
 		BundleContext context = MiosActivator.getContext();
 
-		commandTransformationService = TransformationHelper
-				.getTransformationService(context, name);
+		commandTransformationService = TransformationHelper.getTransformationService(context, name);
 
 		if (commandTransformationService == null) {
 
-			logger.warn(
-					"Transformation Service (command) '{}' not found for declaration '{}'.",
-					name, getCommandTransform());
+			logger.warn("Transformation Service (command) '{}' not found for declaration '{}'.", name,
+					getCommandTransform());
 		}
 
 		return commandTransformationService;
 	}
 
 	@Override
-	public String transformCommand(Command command)
-			throws TransformationException {
+	public String transformCommand(Command command) throws TransformationException {
 		// Quickly return null if we don't support commands.
 		if (getCommandTransform() == null) {
 			return null;
@@ -489,8 +439,7 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 			// If we don't have a transform, look for a special one called
 			// "_default".
 			if (result == null || "".equals(result)) {
-				result = ts.transform(getCommandTransformParam(),
-						DEFAULT_COMMAND_TRANSFORM);
+				result = ts.transform(getCommandTransformParam(), DEFAULT_COMMAND_TRANSFORM);
 			}
 		} else {
 			Map<String, String> map = getCommandMap();

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/MiosBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/MiosBindingConfig.java
@@ -44,8 +44,7 @@ import org.slf4j.LoggerFactory;
  * MiOS specific abstract class for the openHAB {@link BindingConfig}.
  * <p>
  * 
- * Sub-classes of this class represent the various "types" of data that can be
- * bound within a MiOS System.
+ * Sub-classes of this class represent the various "types" of data that can be bound within a MiOS System.
  * <p>
  * These include the following objects: <br>
  * <ul>
@@ -63,20 +62,17 @@ import org.slf4j.LoggerFactory;
  * </ul>
  * <p>
  * 
- * Each sub-class has a specific format for the <i>miosThing</i>, and examples
- * are outlined in those sub-classes, in addition to the <code>README.md</code>
- * file shipped with the binding.
+ * Each sub-class has a specific format for the <i>miosThing</i>, and examples are outlined in those sub-classes, in
+ * addition to the <code>README.md</code> file shipped with the binding.
  * 
  * 
  * @author Mark Clark
  * @since 1.6.0
  */
 public abstract class MiosBindingConfig implements BindingConfig {
-	private static Pattern TRANSFORM_PATTERN = Pattern
-			.compile("(?<transform>.+)[(]{1}?(?<param>.*)[)]{1}");
+	private static Pattern TRANSFORM_PATTERN = Pattern.compile("(?<transform>.+)[(]{1}?(?<param>.*)[)]{1}");
 
-	protected static final Logger logger = LoggerFactory
-			.getLogger(MiosBindingConfig.class);
+	protected static final Logger logger = LoggerFactory.getLogger(MiosBindingConfig.class);
 
 	private int miosId;
 	private String context;
@@ -99,10 +95,8 @@ public abstract class MiosBindingConfig implements BindingConfig {
 	private TransformationService inTransformationService;
 	private TransformationService outTransformationService;
 
-	protected MiosBindingConfig(String context, String itemName,
-			String unitName, int miosId, String miosStuff,
-			Class<? extends Item> itemType, String commandTransform,
-			String inTransform, String outTransform)
+	protected MiosBindingConfig(String context, String itemName, String unitName, int miosId, String miosStuff,
+			Class<? extends Item> itemType, String commandTransform, String inTransform, String outTransform)
 			throws BindingConfigParseException {
 		// Crude parameter validations
 		assert (miosId >= 0);
@@ -125,12 +119,9 @@ public abstract class MiosBindingConfig implements BindingConfig {
 				this.inTransformName = m.group("transform");
 				this.inTransformParam = m.group("param");
 
-				logger.trace("start: IN '{}', '{}'", this.inTransformName,
-						this.inTransformParam);
+				logger.trace("start: IN '{}', '{}'", this.inTransformName, this.inTransformParam);
 			} else {
-				logger.warn(
-						"Unable to parse (in) Transformation string '{}', ignored.",
-						inTransform);
+				logger.warn("Unable to parse (in) Transformation string '{}', ignored.", inTransform);
 			}
 		}
 
@@ -141,12 +132,9 @@ public abstract class MiosBindingConfig implements BindingConfig {
 				this.outTransformName = m.group("transform");
 				this.outTransformParam = m.group("param");
 
-				logger.trace("start: OUT '{}', '{}'", this.outTransformName,
-						this.outTransformParam);
+				logger.trace("start: OUT '{}', '{}'", this.outTransformName, this.outTransformParam);
 			} else {
-				logger.warn(
-						"Unable to parse (out) Transformation string '{}', ignored.",
-						outTransform);
+				logger.warn("Unable to parse (out) Transformation string '{}', ignored.", outTransform);
 			}
 		}
 	}
@@ -154,8 +142,7 @@ public abstract class MiosBindingConfig implements BindingConfig {
 	/**
 	 * The name of the openHAB context.
 	 * 
-	 * @return the name of the openHAB context this Binding Configuration is
-	 *         associated with.
+	 * @return the name of the openHAB context this Binding Configuration is associated with.
 	 */
 	public String getContext() {
 		return this.context;
@@ -164,8 +151,7 @@ public abstract class MiosBindingConfig implements BindingConfig {
 	/**
 	 * The name of the openHAB Item.
 	 * 
-	 * @return the name of the Item this Binding Configuration is associated
-	 *         with.
+	 * @return the name of the Item this Binding Configuration is associated with.
 	 */
 	public String getItemName() {
 		return this.itemName;
@@ -175,8 +161,7 @@ public abstract class MiosBindingConfig implements BindingConfig {
 	 * The name of the MiOS Unit.
 	 * <p>
 	 * 
-	 * @return the name of the MiOS Unit this Binding Configuration is
-	 *         associated with.
+	 * @return the name of the MiOS Unit this Binding Configuration is associated with.
 	 */
 	public String getUnitName() {
 		return unitName;
@@ -186,13 +171,12 @@ public abstract class MiosBindingConfig implements BindingConfig {
 	 * The type of MiOS object.
 	 * <p>
 	 * 
-	 * The MiOS Binding supports binding to Device, Scene, and System objects
-	 * within a MiOS System. This method returns which type of MiOS object the
-	 * Binding Configuration represents, using the same format/value used in the
-	 * Binding Configuration entry.
+	 * The MiOS Binding supports binding to Device, Scene, and System objects within a MiOS System. This method returns
+	 * which type of MiOS object the Binding Configuration represents, using the same format/value used in the Binding
+	 * Configuration entry.
 	 * <p>
-	 * The value returned is dependent upon the specific sub-class of
-	 * MiOSBindingConfig materialized from the Item configuration information.
+	 * The value returned is dependent upon the specific sub-class of MiOSBindingConfig materialized from the Item
+	 * configuration information.
 	 * 
 	 * @return the type of MiOS object.
 	 */
@@ -202,29 +186,24 @@ public abstract class MiosBindingConfig implements BindingConfig {
 	 * The id of the MiOS object.
 	 * <p>
 	 * 
-	 * Each object within a MiOS Unit has a type-specific Id. If the type of
-	 * object doesn't have an Id, then the value will be 0.
+	 * Each object within a MiOS Unit has a type-specific Id. If the type of object doesn't have an Id, then the value
+	 * will be 0.
 	 * 
-	 * @return the Id of the MiOS object, or 0 if the type doesn't allocate
-	 *         Id's.
+	 * @return the Id of the MiOS object, or 0 if the type doesn't allocate Id's.
 	 */
 	public int getMiosId() {
 		return miosId;
 	};
 
 	/**
-	 * A type-specific Name/Reference representing a named subcomponent of the
-	 * MiOS object.
+	 * A type-specific Name/Reference representing a named subcomponent of the MiOS object.
 	 * <p>
 	 * 
-	 * Each object within a MiOS Unit has a type-specific Name/Reference string.
-	 * This value works in conjunction with the MiOS Id, to further define the
-	 * data to be returned. One "id" in a MiOS system may have multiple
-	 * attributes associated with it, and this string is used to disambiguate
-	 * those attributes.
+	 * Each object within a MiOS Unit has a type-specific Name/Reference string. This value works in conjunction with
+	 * the MiOS Id, to further define the data to be returned. One "id" in a MiOS system may have multiple attributes
+	 * associated with it, and this string is used to disambiguate those attributes.
 	 * 
-	 * @return the Name/Reference of the MiOS object represented by this Binding
-	 *         Configuration.
+	 * @return the Name/Reference of the MiOS object represented by this Binding Configuration.
 	 */
 	public String getMiosStuff() {
 		return miosStuff;
@@ -234,14 +213,11 @@ public abstract class MiosBindingConfig implements BindingConfig {
 	 * Convert to a Property string.
 	 * <p>
 	 * 
-	 * This form includes the MiOS Device locator information (Id, Type, and
-	 * Stuff) only.
+	 * This form includes the MiOS Device locator information (Id, Type, and Stuff) only.
 	 * <p>
-	 * It contains only enough information to identify the target component
-	 * within the MiOS Unit.
+	 * It contains only enough information to identify the target component within the MiOS Unit.
 	 * 
-	 * @return the Binding Configuration as a string, suitable for use within
-	 *         openHAB Configuration files.
+	 * @return the Binding Configuration as a string, suitable for use within openHAB Configuration files.
 	 */
 	public String toProperty() {
 		return cachedProperty;
@@ -251,10 +227,8 @@ public abstract class MiosBindingConfig implements BindingConfig {
 	 * Convert to a full Binding string.
 	 * <p>
 	 * 
-	 * This form includes the MiOS Device locator information, from
-	 * <code>toProperty()</code>, in addition to any transformations (
-	 * <code>in:</code>, <code>out:</code>, <code>command:</code>) specified in
-	 * the original Binding.
+	 * This form includes the MiOS Device locator information, from <code>toProperty()</code>, in addition to any
+	 * transformations ( <code>in:</code>, <code>out:</code>, <code>command:</code>) specified in the original Binding.
 	 */
 	public String toBinding() {
 		return cachedBinding;
@@ -301,23 +275,19 @@ public abstract class MiosBindingConfig implements BindingConfig {
 
 		BundleContext context = MiosActivator.getContext();
 
-		inTransformationService = TransformationHelper
-				.getTransformationService(context, name);
+		inTransformationService = TransformationHelper.getTransformationService(context, name);
 
 		if (inTransformationService == null) {
 
-			logger.warn(
-					"Transformation Service (in) '{}' not found for declaration '{}'.",
-					name, getInTransform());
+			logger.warn("Transformation Service (in) '{}' not found for declaration '{}'.", name, getInTransform());
 		}
 
 		return inTransformationService;
 	}
 
 	/**
-	 * Returns a {@link State} which is inherited from the {@link Item}s
-	 * accepted DataTypes. The call is delegated to the {@link TypeParser}. If
-	 * <code>item</code> is <code>null</code> the {@link StringType} is used.
+	 * Returns a {@link State} which is inherited from the {@link Item}s accepted DataTypes. The call is delegated to
+	 * the {@link TypeParser}. If <code>item</code> is <code>null</code> the {@link StringType} is used.
 	 * <p>
 	 * 
 	 * Code borrowed from {@link HttpBinding}.
@@ -325,8 +295,8 @@ public abstract class MiosBindingConfig implements BindingConfig {
 	 * @param itemType
 	 * @param value
 	 * 
-	 * @return a {@link State} which type is inherited by the {@link TypeParser}
-	 *         or a {@link StringType} if <code>item</code> is <code>null</code>
+	 * @return a {@link State} which type is inherited by the {@link TypeParser} or a {@link StringType} if
+	 *         <code>item</code> is <code>null</code>
 	 */
 	private State createState(String value) {
 		Class<? extends Item> itemType = getItemType();
@@ -386,48 +356,39 @@ public abstract class MiosBindingConfig implements BindingConfig {
 				result = StringType.valueOf(value);
 			}
 
-			logger.trace(
-					"createState: Converted '{}' to '{}', bound to '{}'",
-					new Object[] { value, result.getClass().getName(), itemType });
+			logger.trace("createState: Converted '{}' to '{}', bound to '{}'", new Object[] { value,
+					result.getClass().getName(), itemType });
 
 			return result;
 		} catch (Exception e) {
-			logger.debug("Couldn't create state of type '{}' for value '{}'",
-					itemType, value);
+			logger.debug("Couldn't create state of type '{}' for value '{}'", itemType, value);
 			return StringType.valueOf(value);
 		}
 	}
 
 	/**
-	 * Transform data from a MiOS Unit into a form suitable for use in an
-	 * openHAB Item.
+	 * Transform data from a MiOS Unit into a form suitable for use in an openHAB Item.
 	 * <p>
 	 * 
-	 * Data received from a MiOS unit is in a number of different formats
-	 * (String, Boolean, DataTime, etc). These values may need to be transformed
-	 * from their original format prior to being pushed into the corresponding
+	 * Data received from a MiOS unit is in a number of different formats (String, Boolean, DataTime, etc). These values
+	 * may need to be transformed from their original format prior to being pushed into the corresponding openHAB Item.
+	 * <p>
+	 * This method is used internally within the MiOS Binding to perform that transformation.
+	 * <p>
+	 * This method is responsible for transforming the inbound value from the MiOS Unit, into the form required by the
 	 * openHAB Item.
 	 * <p>
-	 * This method is used internally within the MiOS Binding to perform that
-	 * transformation.
+	 * metadata supplied by the user, via the <code>in:</code> parameter, in the Binding Configuration is used to define
+	 * the transformation that must be performed.
 	 * <p>
-	 * This method is responsible for transforming the inbound value from the
-	 * MiOS Unit, into the form required by the openHAB Item.
+	 * If the <code>in:</code> parameter is missing, then no transformation will occur, and the source-value will be
+	 * returned (as a <code>StringType</code>).
 	 * <p>
-	 * metadata supplied by the user, via the <code>in:</code> parameter, in the
-	 * Binding Configuration is used to define the transformation that must be
-	 * performed.
-	 * <p>
-	 * If the <code>in:</code> parameter is missing, then no transformation will
-	 * occur, and the source-value will be returned (as a
-	 * <code>StringType</code>).
-	 * <p>
-	 * If the <code>in:</code> parameter is present, then it's value is used to
-	 * determine which openHAB TransformationService should be used to transform
-	 * the value.
+	 * If the <code>in:</code> parameter is present, then it's value is used to determine which openHAB
+	 * TransformationService should be used to transform the value.
 	 * 
-	 * @return the transformed value, or the input (<code>value</code>) if no
-	 *         transformation has been specified in the Binding Configuration.
+	 * @return the transformed value, or the input (<code>value</code>) if no transformation has been specified in the
+	 *         Binding Configuration.
 	 * 
 	 * @throws TransformationException
 	 *             if the underlying Transformation fails in any manner.
@@ -436,15 +397,13 @@ public abstract class MiosBindingConfig implements BindingConfig {
 		TransformationService ts = getInTransformationService();
 
 		if (ts != null) {
-			return createState(ts.transform(getInTransformParam(),
-					value.toString()));
+			return createState(ts.transform(getInTransformParam(), value.toString()));
 		} else {
 			if (value instanceof StringType) {
 				value = createState(value.toString());
 
-				logger.trace(
-						"transformIn: Converted value '{}' from StringType to more scoped type '{}'",
-						value, value.getClass());
+				logger.trace("transformIn: Converted value '{}' from StringType to more scoped type '{}'", value,
+						value.getClass());
 			}
 
 			return value;
@@ -464,41 +423,34 @@ public abstract class MiosBindingConfig implements BindingConfig {
 
 		BundleContext context = MiosActivator.getContext();
 
-		outTransformationService = TransformationHelper
-				.getTransformationService(context, name);
+		outTransformationService = TransformationHelper.getTransformationService(context, name);
 
 		if (outTransformationService == null) {
 
-			logger.warn(
-					"Transformation Service (out) '{}' not found for declaration '{}'.",
-					name, getOutTransform());
+			logger.warn("Transformation Service (out) '{}' not found for declaration '{}'.", name, getOutTransform());
 		}
 
 		return outTransformationService;
 	}
 
 	/**
-	 * Transform data in an openHAB Item into a form suitable for use in calls
-	 * made to a MiOS Unit.
+	 * Transform data in an openHAB Item into a form suitable for use in calls made to a MiOS Unit.
 	 * <p>
 	 * 
-	 * In order to calls a MiOS Unit, we may need to transform an Item's current
-	 * value from it's openHAB State to a form suitable for transmission to
-	 * remote MiOS Unit.
+	 * In order to calls a MiOS Unit, we may need to transform an Item's current value from it's openHAB State to a form
+	 * suitable for transmission to remote MiOS Unit.
 	 * <p>
-	 * This method is responsible for transforming an Item's State value, using
-	 * metadata supplied by the user, via the <code>out:</code> parameter, in
-	 * the Binding Configuration.
+	 * This method is responsible for transforming an Item's State value, using metadata supplied by the user, via the
+	 * <code>out:</code> parameter, in the Binding Configuration.
 	 * <p>
-	 * If the <code>out:</code> parameter is missing, then no transformation
-	 * will occur, and the source-value will be returned.
+	 * If the <code>out:</code> parameter is missing, then no transformation will occur, and the source-value will be
+	 * returned.
 	 * <p>
-	 * If the <code>out:</code> parameter is present, then it's value is used to
-	 * determine which openHAB TransformationService should be used to transform
-	 * the value.
+	 * If the <code>out:</code> parameter is present, then it's value is used to determine which openHAB
+	 * TransformationService should be used to transform the value.
 	 * 
-	 * @return the transformed value, or the input (<code>value</code>) if no
-	 *         transformation has been specified in the Binding Configuration.
+	 * @return the transformed value, or the input (<code>value</code>) if no transformation has been specified in the
+	 *         Binding Configuration.
 	 * 
 	 * @throws TransformationException
 	 *             if the underlying Transformation fails in any manner.
@@ -507,44 +459,37 @@ public abstract class MiosBindingConfig implements BindingConfig {
 		TransformationService ts = getOutTransformationService();
 
 		if (ts != null) {
-			return createState(ts.transform(getOutTransformParam(),
-					value.toString()));
+			return createState(ts.transform(getOutTransformParam(), value.toString()));
 		} else {
 			return value;
 		}
 	}
 
 	/**
-	 * Transform an openHAB {@link Command} into a call suitable for invoking a
-	 * service on a MiOS Unit.
+	 * Transform an openHAB {@link Command} into a call suitable for invoking a service on a MiOS Unit.
 	 * <p>
 	 * 
-	 * In order to call a MiOS Unit, we need the openHAB {@link Command} in the
-	 * format they understand. This method is responsible for transforming the
-	 * Command, using the metadata supplied by the user in the
-	 * <code>command:</code> parameter of the Binding Configuration. Internally,
-	 * this method uses that metadata to perform a transformation, using the
-	 * openHAB Transformation service, to perform the mapping.
+	 * In order to call a MiOS Unit, we need the openHAB {@link Command} in the format they understand. This method is
+	 * responsible for transforming the Command, using the metadata supplied by the user in the <code>command:</code>
+	 * parameter of the Binding Configuration. Internally, this method uses that metadata to perform a transformation,
+	 * using the openHAB Transformation service, to perform the mapping.
 	 * <p>
-	 * If the <code>command:</code> parameter is missing, then no commands can
-	 * be delivered to the MiOS Unit, and <code>null</code> is returned.
+	 * If the <code>command:</code> parameter is missing, then no commands can be delivered to the MiOS Unit, and
+	 * <code>null</code> is returned.
 	 * <p>
-	 * If the <code>command:</code> parameter is present, then the associated
-	 * openHAB Transformation Service is invoked to perform the required
-	 * mapping, and the transformed value is returned.
+	 * If the <code>command:</code> parameter is present, then the associated openHAB Transformation Service is invoked
+	 * to perform the required mapping, and the transformed value is returned.
 	 * 
-	 * @return the transformed value, or null if no transformation has been
-	 *         specified in the Binding Configuration.
+	 * @return the transformed value, or null if no transformation has been specified in the Binding Configuration.
 	 * 
 	 * @throws TransformationException
 	 *             if the underlying Transformation fails in any manner.
 	 */
-	public abstract String transformCommand(Command command)
-			throws TransformationException;
+	public abstract String transformCommand(Command command) throws TransformationException;
 
 	/**
-	 * Implementation method to be overridden by sub-classes when they have a
-	 * different "format" of output for <code>toProperty()</code>.
+	 * Implementation method to be overridden by sub-classes when they have a different "format" of output for
+	 * <code>toProperty()</code>.
 	 * <p>
 	 */
 	protected void initialize() {
@@ -560,8 +505,7 @@ public abstract class MiosBindingConfig implements BindingConfig {
 		unit = (unit == null) ? "" : "unit:" + unit + ',';
 
 		if (stuff != null) {
-			result.append(unit).append(getMiosType()).append(':').append(id)
-					.append('/').append(stuff);
+			result.append(unit).append(getMiosType()).append(':').append(id).append('/').append(stuff);
 		} else {
 			result.append(unit).append(getMiosType()).append(':').append(id);
 		}
@@ -590,11 +534,11 @@ public abstract class MiosBindingConfig implements BindingConfig {
 	 * Return the Command Transformation binding parameter.
 	 * <p>
 	 * 
-	 * If the Binding configuration has the <code>command:</code> parameter
-	 * specified, then return that value. Otherwise return <code>null</code>.
+	 * If the Binding configuration has the <code>command:</code> parameter specified, then return that value. Otherwise
+	 * return <code>null</code>.
 	 * 
-	 * @return the value of the <code>command:</code> Binding configuration
-	 *         parameter, or <code>null</code> if not specified.
+	 * @return the value of the <code>command:</code> Binding configuration parameter, or <code>null</code> if not
+	 *         specified.
 	 */
 	protected String getCommandTransform() {
 
@@ -612,26 +556,22 @@ public abstract class MiosBindingConfig implements BindingConfig {
 	 * Validate the Item's data type against the <code>BindingConfig</code>.
 	 * <p>
 	 * 
-	 * If this validation fails, then a <code>BindingConfigParseException</code>
-	 * is thrown. By default, this method will succeed if the Item is a
-	 * <code>StringItem</code>, <code>NumberItem</code>, <code>SwitchItem</code>
-	 * , <code>DimmerItem</code>, <code>ContactItem</code>,
-	 * <code>DataTimeItem</code>.
+	 * If this validation fails, then a <code>BindingConfigParseException</code> is thrown. By default, this method will
+	 * succeed if the Item is a <code>StringItem</code>, <code>NumberItem</code>, <code>SwitchItem</code> ,
+	 * <code>DimmerItem</code>, <code>ContactItem</code>, <code>DataTimeItem</code>.
 	 * <p>
-	 * Subclasses can augment this behavior or replace it, so that Bindings can
-	 * reconfigure their support for Item Types.
+	 * Subclasses can augment this behavior or replace it, so that Bindings can reconfigure their support for Item
+	 * Types.
 	 * 
 	 * @param item
 	 *            the Item that requiring validation.
 	 * @exception BindingConfigParseException
-	 *                when the validation of the <code>BindingConfig</code>
-	 *                fails for the Item.
+	 *                when the validation of the <code>BindingConfig</code> fails for the Item.
 	 */
 	public void validateItemType(Item item) throws BindingConfigParseException {
 		Class<? extends Item> t = getItemType();
 
-		if (!((t == StringItem.class) || (t == SwitchItem.class)
-				|| (t == DimmerItem.class) || (t == NumberItem.class)
+		if (!((t == StringItem.class) || (t == SwitchItem.class) || (t == DimmerItem.class) || (t == NumberItem.class)
 				|| (t == ContactItem.class) || (t == DateTimeItem.class))) {
 
 			throw new BindingConfigParseException(

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/ParameterDefaults.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/ParameterDefaults.java
@@ -14,8 +14,7 @@ public class ParameterDefaults {
 	private String mCommandTransform;
 	private String mFormatted;
 
-	private ParameterDefaults(String formatted, String in, String out,
-			String command) {
+	private ParameterDefaults(String formatted, String in, String out, String command) {
 		mFormatted = formatted;
 		mInTransform = in;
 		mOutTransform = out;

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/RoomBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/RoomBindingConfig.java
@@ -20,12 +20,9 @@ import org.openhab.model.item.binding.BindingConfigParseException;
  */
 public class RoomBindingConfig extends MiosBindingConfig {
 
-	private RoomBindingConfig(String context, String itemName, String unitName,
-			int id, String stuff, Class<? extends Item> itemType,
-			String inTransform, String outTransform)
-			throws BindingConfigParseException {
-		super(context, itemName, unitName, id, stuff, itemType, null,
-				inTransform, outTransform);
+	private RoomBindingConfig(String context, String itemName, String unitName, int id, String stuff,
+			Class<? extends Item> itemType, String inTransform, String outTransform) throws BindingConfigParseException {
+		super(context, itemName, unitName, id, stuff, itemType, null, inTransform, outTransform);
 	}
 
 	/**
@@ -33,12 +30,11 @@ public class RoomBindingConfig extends MiosBindingConfig {
 	 * 
 	 * @return an initialized MiOS Room Binding Configuration object.
 	 */
-	public static final MiosBindingConfig create(String context,
-			String itemName, String unitName, int id, String stuff,
-			Class<? extends Item> itemType, String inTransform,
-			String outTransform) throws BindingConfigParseException {
-		MiosBindingConfig c = new RoomBindingConfig(context, itemName,
-				unitName, id, stuff, itemType, inTransform, outTransform);
+	public static final MiosBindingConfig create(String context, String itemName, String unitName, int id,
+			String stuff, Class<? extends Item> itemType, String inTransform, String outTransform)
+			throws BindingConfigParseException {
+		MiosBindingConfig c = new RoomBindingConfig(context, itemName, unitName, id, stuff, itemType, inTransform,
+				outTransform);
 
 		c.initialize();
 		return c;
@@ -55,15 +51,12 @@ public class RoomBindingConfig extends MiosBindingConfig {
 	}
 
 	/**
-	 * This method throws a {@link TransformationException}, as MiOS Room
-	 * attributes don't support being called.
+	 * This method throws a {@link TransformationException}, as MiOS Room attributes don't support being called.
 	 * 
 	 * @throws TransformationException
 	 */
 	@Override
-	public String transformCommand(Command command)
-			throws TransformationException {
-		throw new TransformationException(
-				"Room attributes don't support Command Transformations");
+	public String transformCommand(Command command) throws TransformationException {
+		throw new TransformationException("Room attributes don't support Command Transformations");
 	}
 }

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/SceneBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/SceneBindingConfig.java
@@ -11,6 +11,7 @@ package org.openhab.binding.mios.internal.config;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.openhab.core.items.Item;
@@ -23,8 +24,7 @@ import org.openhab.model.item.binding.BindingConfigParseException;
  * 
  * The scene-specific form of a MiOS Binding is:<br>
  * <ul>
- * <li><nobr>
- * <tt>mios="unit:<i>unitName</i>,scene:<i>sceneId</i>/<i>attrName</i>,<i>optionalTransformations</i></tt>
+ * <li><nobr> <tt>mios="unit:<i>unitName</i>,scene:<i>sceneId</i>/<i>attrName</i>,<i>optionalTransformations</i></tt>
  * </nobr>
  * </ul>
  * <p>
@@ -42,16 +42,14 @@ import org.openhab.model.item.binding.BindingConfigParseException;
  * 
  * <b>Optional Transformations</b>
  * <p>
- * See the Optional Transformations section of the JavaDoc for
- * {@link DeviceBindingConfig} for a description of the main options here.
+ * See the Optional Transformations section of the JavaDoc for {@link DeviceBindingConfig} for a description of the main
+ * options here.
  * 
  * The one addition is that Scene Bindings also support:
  * <ul>
- * <li><code>command:</code> - map <i>any</i> openHAB Command sent to the Item,
- * and use it to trigger Scene execution.
- * <li><code>command:ON</code> - map <i>only</i> the <code>ON</code> Command
- * sent to the Item, and use it to trigger Scene execution ("<code>ON</code>"
- * can be any openHAB Command string)
+ * <li><code>command:</code> - map <i>any</i> openHAB Command sent to the Item, and use it to trigger Scene execution.
+ * <li><code>command:ON</code> - map <i>only</i> the <code>ON</code> Command sent to the Item, and use it to trigger
+ * Scene execution ("<code>ON</code>" can be any openHAB Command string)
  * </ul>
  * 
  * @author Mark Clark
@@ -72,29 +70,22 @@ public class SceneBindingConfig extends MiosBindingConfig {
 			Properties tmp = new Properties();
 			tmp.load(input);
 
-			for (Map.Entry<Object, Object> e : tmp.entrySet()) {
-				paramDefaults.put((String) e.getKey(),
-						ParameterDefaults.parse((String) e.getValue()));
+			for (Entry<Object, Object> e : tmp.entrySet()) {
+				paramDefaults.put((String) e.getKey(), ParameterDefaults.parse((String) e.getValue()));
 			}
 
-			logger.debug(
-					"Successfully loaded Scene Parameter defaults from '{}', entries '{}'",
-					PARAM_DEFAULTS, paramDefaults.size());
+			logger.debug("Successfully loaded Scene Parameter defaults from '{}', entries '{}'", PARAM_DEFAULTS,
+					paramDefaults.size());
 		} catch (Exception e) {
 			// Pre-shipped with the Binding, so it should never error out.
-			logger.error(
-					"Failed to load Scene Parameter defaults file '{}', Exception",
-					PARAM_DEFAULTS, e);
+			logger.error("Failed to load Scene Parameter defaults file '{}', Exception", PARAM_DEFAULTS, e);
 		}
 	}
 
-	private SceneBindingConfig(String context, String itemName,
-			String unitName, int id, String stuff,
-			Class<? extends Item> itemType, String commandTransform,
-			String inTransform, String outTransform)
+	private SceneBindingConfig(String context, String itemName, String unitName, int id, String stuff,
+			Class<? extends Item> itemType, String commandTransform, String inTransform, String outTransform)
 			throws BindingConfigParseException {
-		super(context, itemName, unitName, id, stuff, itemType,
-				commandTransform, inTransform, outTransform);
+		super(context, itemName, unitName, id, stuff, itemType, commandTransform, inTransform, outTransform);
 	}
 
 	/**
@@ -102,41 +93,30 @@ public class SceneBindingConfig extends MiosBindingConfig {
 	 * 
 	 * @return an initialized MiOS Scene Binding Configuration object.
 	 */
-	public static final MiosBindingConfig create(String context,
-			String itemName, String unitName, int id, String stuff,
-			Class<? extends Item> itemType, String commandTransform,
-			String inTransform, String outTransform)
-			throws BindingConfigParseException {
+	public static final MiosBindingConfig create(String context, String itemName, String unitName, int id,
+			String stuff, Class<? extends Item> itemType, String commandTransform, String inTransform,
+			String outTransform) throws BindingConfigParseException {
 		ParameterDefaults pd = paramDefaults.get(stuff);
 		if (pd != null) {
-			logger.trace("Scene ParameterDefaults FOUND '{}' for '{}', '{}'",
-					itemName, stuff, pd);
+			logger.trace("Scene ParameterDefaults FOUND '{}' for '{}', '{}'", itemName, stuff, pd);
 			if (commandTransform == null) {
 				commandTransform = pd.getCommandTransform();
-				logger.trace(
-						"Scene ParameterDefaults '{}' defaulted command: to '{}'",
-						itemName, commandTransform);
+				logger.trace("Scene ParameterDefaults '{}' defaulted command: to '{}'", itemName, commandTransform);
 			}
 			if (inTransform == null) {
 				inTransform = pd.getInTransform();
-				logger.trace(
-						"Scene ParameterDefaults '{}' defaulted in: to '{}'",
-						itemName, inTransform);
+				logger.trace("Scene ParameterDefaults '{}' defaulted in: to '{}'", itemName, inTransform);
 			}
 			if (outTransform == null) {
 				outTransform = pd.getOutTransform();
-				logger.trace(
-						"Scene ParameterDefaults '{}' defaulted out: to '{}'",
-						itemName, outTransform);
+				logger.trace("Scene ParameterDefaults '{}' defaulted out: to '{}'", itemName, outTransform);
 			}
 		} else {
-			logger.trace("Scene ParameterDefaults NOT FOUND '{}' for '{}'",
-					itemName, stuff);
+			logger.trace("Scene ParameterDefaults NOT FOUND '{}' for '{}'", itemName, stuff);
 		}
 
-		MiosBindingConfig c = new SceneBindingConfig(context, itemName,
-				unitName, id, stuff, itemType, commandTransform, inTransform,
-				outTransform);
+		MiosBindingConfig c = new SceneBindingConfig(context, itemName, unitName, id, stuff, itemType,
+				commandTransform, inTransform, outTransform);
 
 		c.initialize();
 		return c;
@@ -153,8 +133,7 @@ public class SceneBindingConfig extends MiosBindingConfig {
 	}
 
 	@Override
-	public String transformCommand(Command command)
-			throws TransformationException {
+	public String transformCommand(Command command) throws TransformationException {
 		String key = command.toString();
 
 		String cThing = getCommandTransform();

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/SystemBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/SystemBindingConfig.java
@@ -11,6 +11,7 @@ package org.openhab.binding.mios.internal.config;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.openhab.core.items.Item;
@@ -23,8 +24,7 @@ import org.openhab.model.item.binding.BindingConfigParseException;
  * 
  * The system-specific form of a MiOS Binding is:<br>
  * <ul>
- * <li><nobr> <tt>mios="unit:<i>unitName</i>,system:/<i>attrName</i></tt>
- * </nobr>
+ * <li><nobr> <tt>mios="unit:<i>unitName</i>,system:/<i>attrName</i></tt> </nobr>
  * </ul>
  * <p>
  * 
@@ -68,28 +68,21 @@ public class SystemBindingConfig extends MiosBindingConfig {
 			Properties tmp = new Properties();
 			tmp.load(input);
 
-			for (Map.Entry<Object, Object> e : tmp.entrySet()) {
-				paramDefaults.put((String) e.getKey(),
-						ParameterDefaults.parse((String) e.getValue()));
+			for (Entry<Object, Object> e : tmp.entrySet()) {
+				paramDefaults.put((String) e.getKey(), ParameterDefaults.parse((String) e.getValue()));
 			}
 
-			logger.debug(
-					"Successfully loaded System Parameter defaults from '{}', entries '{}'",
-					PARAM_DEFAULTS, paramDefaults.size());
+			logger.debug("Successfully loaded System Parameter defaults from '{}', entries '{}'", PARAM_DEFAULTS,
+					paramDefaults.size());
 		} catch (Exception e) {
 			// Pre-shipped with the Binding, so it should never error out.
-			logger.error(
-					"Failed to load System Parameter defaults file '{}', Exception",
-					PARAM_DEFAULTS, e);
+			logger.error("Failed to load System Parameter defaults file '{}', Exception", PARAM_DEFAULTS, e);
 		}
 	}
 
-	private SystemBindingConfig(String context, String itemName,
-			String unitName, String stuff, Class<? extends Item> itemType,
-			String inTransform, String outTransform)
-			throws BindingConfigParseException {
-		super(context, itemName, unitName, 0, stuff, itemType, null,
-				inTransform, outTransform);
+	private SystemBindingConfig(String context, String itemName, String unitName, String stuff,
+			Class<? extends Item> itemType, String inTransform, String outTransform) throws BindingConfigParseException {
+		super(context, itemName, unitName, 0, stuff, itemType, null, inTransform, outTransform);
 	}
 
 	/**
@@ -97,33 +90,25 @@ public class SystemBindingConfig extends MiosBindingConfig {
 	 * 
 	 * @return an initialized MiOS System Binding Configuration object.
 	 */
-	public static final MiosBindingConfig create(String context,
-			String itemName, String unitName, String stuff,
-			Class<? extends Item> itemType, String inTransform,
-			String outTransform) throws BindingConfigParseException {
+	public static final MiosBindingConfig create(String context, String itemName, String unitName, String stuff,
+			Class<? extends Item> itemType, String inTransform, String outTransform) throws BindingConfigParseException {
 		ParameterDefaults pd = paramDefaults.get(stuff);
 		if (pd != null) {
-			logger.trace("System ParameterDefaults FOUND '{}' for '{}', '{}'",
-					itemName, stuff, pd);
+			logger.trace("System ParameterDefaults FOUND '{}' for '{}', '{}'", itemName, stuff, pd);
 			if (inTransform == null) {
 				inTransform = pd.getInTransform();
-				logger.trace(
-						"System ParameterDefaults '{}' defaulted in: to '{}'",
-						itemName, inTransform);
+				logger.trace("System ParameterDefaults '{}' defaulted in: to '{}'", itemName, inTransform);
 			}
 			if (outTransform == null) {
 				outTransform = pd.getOutTransform();
-				logger.trace(
-						"System ParameterDefaults '{}' defaulted out: to '{}'",
-						itemName, outTransform);
+				logger.trace("System ParameterDefaults '{}' defaulted out: to '{}'", itemName, outTransform);
 			}
 		} else {
-			logger.trace("System ParameterDefaults NOT FOUND '{}' for '{}'",
-					itemName, stuff);
+			logger.trace("System ParameterDefaults NOT FOUND '{}' for '{}'", itemName, stuff);
 		}
 
-		MiosBindingConfig c = new SystemBindingConfig(context, itemName,
-				unitName, stuff, itemType, inTransform, outTransform);
+		MiosBindingConfig c = new SystemBindingConfig(context, itemName, unitName, stuff, itemType, inTransform,
+				outTransform);
 
 		c.initialize();
 		return c;
@@ -140,15 +125,12 @@ public class SystemBindingConfig extends MiosBindingConfig {
 	}
 
 	/**
-	 * This method throws a {@link TransformationException}, as MiOS System
-	 * attributes don't support being called.
+	 * This method throws a {@link TransformationException}, as MiOS System attributes don't support being called.
 	 * 
 	 * @throws TransformationException
 	 */
 	@Override
-	public String transformCommand(Command command)
-			throws TransformationException {
-		throw new TransformationException(
-				"System attributes don't support Command Transformations");
+	public String transformCommand(Command command) throws TransformationException {
+		throw new TransformationException("System attributes don't support Command Transformations");
 	}
 }

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -497,6 +497,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.openhab.action</groupId>
+			<artifactId>org.openhab.action.mios</artifactId>
+			<version>${project.version}</version>
+			<type>jar</type>
+		</dependency>
+		<dependency>
+			<groupId>org.openhab.action</groupId>
 			<artifactId>org.openhab.action.astro</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>


### PR DESCRIPTION
This PR contains the initial set of changes to get Action/Rule support for the MiOS Bridge Binding.  Submitting the PR to get functional feedback, and there are a few items that are still on the todo list like:
* #2144 adding queue-limit support, on all HTTP callouts, so-as not to overwhelm the MiOS Unit under control
* ~~refactoring the code (if needed) to use the `org.openhab.io.mios` style/structure (if needed)~~ [Discussion] (https://groups.google.com/forum/#!searchin/openhab/org.openhab.io/openhab/shwaKCdEW68/oafrVa8F1WUJ)
* #2145 work out why the syntactic-sugar version (eg. `GuestBedroom2LightsId.sendMiosAction(...)`) doesn't work when the regular form does (eg. `sendMiosAction(GuestBedroom2LightsId, ...)`)


The changes are as follows:

### General...
* Reformatting codebase to new 120 character line-limit

### MiOS Action Binding...
* Create rudimentary MiOS Action Binding for Rule extensions (`sendMiosAction`, `sendMiosScene`)
* Create documentation in it's own `README.md`

### MiOS Bridge Binding...
* Add hooks to support MiOS Action Binding (`MiosActionProvider` interface, exposure in OSGi config)
* Update documentation in the existing `README.md`