### PR TITLE
Fix RRD4J error at midnight

### DIFF
--- a/bundles/persistence/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jService.java
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jService.java
@@ -165,7 +165,7 @@ public class RRD4jService implements QueryablePersistenceService {
 		RrdDb db = getDB(itemName, consolidationFunction);
 		if(db!=null) {
 			long start = 0L;
-			long end = filter.getEndDate()==null ? System.currentTimeMillis()/1000 - 1 : filter.getEndDate().getTime()/1000;
+			long end = filter.getEndDate()==null ? System.currentTimeMillis()/1000 : filter.getEndDate().getTime()/1000;
 
 			try {
 				if(filter.getBeginDate()==null) {


### PR DESCRIPTION
Fixes issue #1036.
Problem was that if the RRD4jService.query() method was executed at exactly midnight, it would use 00:00:00 as the start time and 23:59:59 of the previous day as the end time. This caused an IllegalArgumentException.

A concern was that the end date was set to currentTime - 1 in the current implementation because the rrd4j library was not able to handle a date in the future (or a date very very close to this).

Therefore I've run a test version without substracting one second (this PR) and another test version with actually adding 10 seconds (to make sure the end date is in the future) on my system for about one week, both of which worked fine.
Possibly it was an old version of the rrd4j library which was not able to handle dates in the future.