### PR TITLE
modbus:serial added "SerialEncodings" selectability 

### DIFF
--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/Modbus.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/Modbus.java
@@ -227,5 +227,11 @@ public interface Modbus {
    */
   public static final String DEFAULT_SERIAL_ENCODING = SERIAL_ENCODING_ASCII;
 
+  /**
+   * presents a list of valid modbus serial encoding options
+   */
+  public static final String[] validSerialEncodings = {
+			SERIAL_ENCODING_ASCII, SERIAL_ENCODING_RTU, SERIAL_ENCODING_BIN };
+
 }//class Modbus
 

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ASCIIInputStream.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ASCIIInputStream.java
@@ -57,7 +57,7 @@ public class ASCIIInputStream
    */
   public int read() throws IOException {
     StringBuffer sbuf = new StringBuffer(2);
-    int ch = in.read();
+    int ch = in.read(); //!@todo that thing blocks until something was received
     if(ch == -1) {
       return -1;
     }

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/net/SerialConnection.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/net/SerialConnection.java
@@ -102,7 +102,7 @@ public class SerialConnection
           CommPortIdentifier.getPortIdentifier(m_Parameters.getPortName());
     } catch (NoSuchPortException e) {
       if(Modbus.debug) System.out.println(e.getMessage());
-      throw new Exception(e.getMessage());
+      throw new Exception("Could not get port identifier, maybe insufficient permissions. " + e.getMessage());
     }
     //System.out.println("Got Port Identifier");
 

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
@@ -55,8 +55,9 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider> 
 	private static final String TCP_PREFIX = "tcp";
 	private static final String SERIAL_PREFIX = "serial";
 
+	private static final String VALID_COFIG_KEYS = "connection|id|start|length|type|valuetype";
 	private static final Pattern EXTRACT_MODBUS_CONFIG_PATTERN =
-		Pattern.compile("^("+TCP_PREFIX+"|"+UDP_PREFIX+"|"+SERIAL_PREFIX+"|)\\.(.*?)\\.(connection|id|pollInterval|start|length|type|valuetype)$");
+		Pattern.compile("^("+TCP_PREFIX+"|"+UDP_PREFIX+"|"+SERIAL_PREFIX+"|)\\.(.*?)\\.(" + VALID_COFIG_KEYS + ")$");
 
 	/** Stores instances of all the slaves defined in cfg file */
 	private static Map<String, ModbusSlave> modbusSlaves = new ConcurrentHashMap<String, ModbusSlave>();
@@ -246,7 +247,7 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider> 
 						ModbusSlave.setWriteMultipleRegisters(Boolean.valueOf(config.get(key).toString()));
 					} else {
 						logger.debug("given modbus-slave-config-key '" + key
-							+ "' does not follow the expected pattern 'pollInterval' or '<slaveId>.<connection|id|start|length|type>'");
+							+ "' does not follow the expected pattern or 'serial.<slaveId>.<" + VALID_COFIG_KEYS + ">'");
 					}
 					continue;
 				}

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
@@ -319,6 +319,7 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider> 
 				}
 			}
 
+			logger.debug("config looked good, proceeding with slave-connections");
 			// connect instances to modbus slaves
 			for (ModbusSlave slave : modbusSlaves.values()) {
 				slave.connect();

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
@@ -260,13 +260,14 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider> 
 				if (modbusSlave == null) {
 					if (matcher.group(1).equals(TCP_PREFIX)) {
 						modbusSlave = new ModbusTcpSlave(slave);
-                                        } else if (matcher.group(1).equals(UDP_PREFIX)) {
+					} else if (matcher.group(1).equals(UDP_PREFIX)) {
 						modbusSlave = new ModbusUdpSlave(slave);
 					} else if (matcher.group(1).equals(SERIAL_PREFIX)) {
 						modbusSlave = new ModbusSerialSlave(slave);
 					} else {
 						throw new ConfigurationException(slave, "the given slave type '" + slave + "' is unknown");
 					}
+					logger.debug("modbusSlave '" + slave + "' instanciated");
 					modbusSlaves.put(slave,modbusSlave);
 				}
 
@@ -276,11 +277,15 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider> 
 				if ("connection".equals(configKey)) {
 					String[] chunks = value.split(":");
 					if (modbusSlave instanceof ModbusIPSlave) {
+						// expecting: 
+						//		<devicePort>:<port>
 						((ModbusIPSlave) modbusSlave).setHost(chunks[0]);
 						if (chunks.length == 2) {
 							((ModbusIPSlave) modbusSlave).setPort(Integer.valueOf(chunks[1]));
 						}
 					} else if (modbusSlave instanceof ModbusSerialSlave) {
+						// expecting: 
+						//		<devicePort>[:<baudRate>:<dataBits>:<parity>:<stopBits>:<encoding>]
 						((ModbusSerialSlave) modbusSlave).setPort(chunks[0]);
 						if (chunks.length >= 2) {
 							((ModbusSerialSlave) modbusSlave).setBaud(Integer.valueOf(chunks[1]));
@@ -291,8 +296,11 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider> 
 						if (chunks.length >= 4) {
 							((ModbusSerialSlave) modbusSlave).setParity(chunks[3]);
 						}
-						if (chunks.length == 5) {
+						if (chunks.length >= 5) {
 							((ModbusSerialSlave) modbusSlave).setStopbits(Integer.valueOf(chunks[4]));
+						}
+						if (chunks.length == 6) {
+							((ModbusSerialSlave) modbusSlave).setEncoding(chunks[5]);
 						}
 					}
 				} else if ("start".equals(configKey)) {

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
@@ -130,8 +130,9 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider> 
 			}
 
 			State currentState = config.getItemState();
-			if (! newState.equals(currentState))
+			if (! newState.equals(currentState)) {
 				eventPublisher.postUpdate(itemName, newState);
+			}
 		}
 	}
 

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusSerialSlave.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusSerialSlave.java
@@ -38,6 +38,7 @@ public class ModbusSerialSlave extends ModbusSlave {
 	private static int dataBits = 8;
 	private static String parity = "None"; // "none", "even" or "odd"
 	private static int stopBits = 1;
+	private static String serialEncoding = Modbus.DEFAULT_SERIAL_ENCODING;
 	
 	public void setPort(String port) {
 		ModbusSerialSlave.port = port;
@@ -59,7 +60,24 @@ public class ModbusSerialSlave extends ModbusSlave {
 	public void setStopbits(int stopBits) {
 		ModbusSerialSlave.stopBits = stopBits;
 	}
-	//	String port = null;
+
+	private boolean isEncodingValid(String serialEncoding) {
+		for (String str : Modbus.validSerialEncodings) {
+			if (str.trim().contains(serialEncoding))
+				return true;
+		}
+		return false;
+	}
+
+	public void setEncoding(String serialEncoding) {
+		serialEncoding = serialEncoding.toLowerCase();
+
+		if ( isEncodingValid(serialEncoding) ) {
+			ModbusSerialSlave.serialEncoding = serialEncoding;
+		} else {
+			logger.info("Encoding '" + serialEncoding + "' is unknown");
+		}
+	}
 
 	private static SerialConnection connection = null;
 
@@ -90,23 +108,23 @@ public class ModbusSerialSlave extends ModbusSlave {
 			//			}
 
 			if (connection == null) {
+				logger.debug("connection was null, going to create a new one");
 				SerialParameters params = new SerialParameters();
 				params.setPortName(port);
 				params.setBaudRate(baud);
 				params.setDatabits(dataBits);
 				params.setParity(parity);
 				params.setStopbits(stopBits);
-				params.setEncoding(Modbus.SERIAL_ENCODING_RTU);
+				params.setEncoding(serialEncoding);
 				params.setEcho(false);
 				connection = new SerialConnection(params);
-				connection.open();
 			}
 			if (!connection.isOpen()) {
 				connection.open();
 			}
 			((ModbusSerialTransaction)transaction).setSerialConnection(connection);
 		} catch (Exception e) {
-			logger.debug("ModbusSlave: Error connecting to master: " + e.getMessage());				
+			logger.error("ModbusSlave: Error connecting to master: " + e.getMessage());				
 			return false;
 		}
 		return true;

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusSlave.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusSlave.java
@@ -84,6 +84,16 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
 	 */
 	private String valueType = ModbusBindingProvider.VALUE_TYPE_UINT16;
 
+	/**
+	 * A multiplier for the raw incoming data
+	 * @note rawMultiplier can also be used for divisions, by simply
+	 * setting the value smaller than zero.
+	 * 
+	 * E.g.:
+	 * - data/100 ... rawDataMultiplier=0.01
+	 */
+	private double rawDataMultiplier = 1.0;
+
 	private Object storage;
 	protected ModbusTransaction transaction = null; 
 
@@ -375,4 +385,11 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
 		this.valueType = valueType;
 	}
 
+	void setRawDataMultiplier(double value) {
+		this.rawDataMultiplier = value;
+	}
+
+	double getRawDataMultiplier() {
+		return rawDataMultiplier;
+	}
 }


### PR DESCRIPTION
such that one is able to setup the serial encoding (e.g. ascii, rtu, bin)
along with the other "connection" port settings via the openhab.cfg

First pull request since.. quite a time via github, be nice ;)