### PR TITLE
Fix for scaling decimal values in pilight binding

### DIFF
--- a/bundles/binding/org.openhab.binding.pilight.test/.classpath
+++ b/bundles/binding/org.openhab.binding.pilight.test/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/test/java"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="output" path="target/test-classes"/>
+</classpath>

--- a/bundles/binding/org.openhab.binding.pilight.test/.project
+++ b/bundles/binding/org.openhab.binding.pilight.test/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.pilight.test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/binding/org.openhab.binding.pilight.test/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/binding/org.openhab.binding.pilight.test/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning

--- a/bundles/binding/org.openhab.binding.pilight.test/.settings/org.maven.ide.eclipse.prefs
+++ b/bundles/binding/org.openhab.binding.pilight.test/.settings/org.maven.ide.eclipse.prefs
@@ -1,0 +1,8 @@
+activeProfiles=
+eclipse.preferences.version=1
+fullBuildGoals=process-test-resources
+includeModules=false
+resolveWorkspaceProjects=true
+resourceFilterGoals=process-resources resources\:testResources
+skipCompilerPlugin=true
+version=1

--- a/bundles/binding/org.openhab.binding.pilight.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.pilight.test/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Tests for the pilight binding
+Bundle-SymbolicName: org.openhab.binding.pilight.test
+Bundle-Version: 1.7.0.qualifier
+Bundle-Vendor: openHAB.org
+Fragment-Host: org.openhab.binding.pilight
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Require-Bundle: org.junit;bundle-version="4.8.1"

--- a/bundles/binding/org.openhab.binding.pilight.test/build.properties
+++ b/bundles/binding/org.openhab.binding.pilight.test/build.properties
@@ -1,0 +1,3 @@
+source.. = src/test/java/
+output.. = target/test-classes/
+bin.includes = META-INF/

--- a/bundles/binding/org.openhab.binding.pilight.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.pilight.test/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<parent>
+		<groupId>org.openhab.bundles</groupId>
+		<artifactId>binding</artifactId>
+		<version>1.7.0-SNAPSHOT</version>
+	</parent>
+
+	<properties>
+		<bundle.symbolicName>org.openhab.binding.pilight.test</bundle.symbolicName>
+		<bundle.namespace>org.openhab.binding.pilight.test</bundle.namespace>
+	</properties>
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.openhab.binding</groupId>
+	<artifactId>org.openhab.binding.pilight.test</artifactId>
+
+	<name>openHAB pilight Binding Tests</name>
+
+	<packaging>eclipse-test-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tycho-version}</version>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/bundles/binding/org.openhab.binding.pilight.test/src/test/java/org/openhab/binding/pilight/internal/PilightGenericBindingProviderTest.java
+++ b/bundles/binding/org.openhab.binding.pilight.test/src/test/java/org/openhab/binding/pilight/internal/PilightGenericBindingProviderTest.java
@@ -51,23 +51,15 @@ public class PilightGenericBindingProviderTest {
 		Assert.assertEquals(number0.toBigDecimal().compareTo(new BigDecimal("23")), 0);
 
 		config.setScale(1);
-		DecimalType number1 = (DecimalType) binding.getState("23.3", config);
+		DecimalType number1 = (DecimalType) binding.getState("233", config);
 		Assert.assertEquals(number1.toBigDecimal().compareTo(new BigDecimal("23.3")), 0);
 
-		config.setScale(0);
-		DecimalType number2 = (DecimalType) binding.getState("2.3", config);
-		Assert.assertEquals(number2.toBigDecimal().compareTo(new BigDecimal("23")), 0);
-		
 		config.setScale(2);
-		DecimalType number3 = (DecimalType) binding.getState("233", config);
-		Assert.assertEquals(number3.toBigDecimal().compareTo(new BigDecimal("2.33")), 0);
+		DecimalType number2 = (DecimalType) binding.getState("2233", config);
+		Assert.assertEquals(number2.toBigDecimal().compareTo(new BigDecimal("22.33")), 0);
 		
 		config.setScale(-1);
-		DecimalType number4 = (DecimalType) binding.getState("233", config);
-		Assert.assertEquals(number4.toBigDecimal().compareTo(new BigDecimal("2330")), 0);
-		
-		config.setScale(1);
-		DecimalType number5 = (DecimalType) binding.getState("233", config);
-		Assert.assertEquals(number5.toBigDecimal().compareTo(new BigDecimal("23.3")), 0);
+		DecimalType number3 = (DecimalType) binding.getState("233", config);
+		Assert.assertEquals(number3.toBigDecimal().compareTo(new BigDecimal("2330")), 0);
 	}
 }

--- a/bundles/binding/org.openhab.binding.pilight.test/src/test/java/org/openhab/binding/pilight/internal/PilightGenericBindingProviderTest.java
+++ b/bundles/binding/org.openhab.binding.pilight.test/src/test/java/org/openhab/binding/pilight/internal/PilightGenericBindingProviderTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.pilight.internal;
+
+import java.math.BigDecimal;
+
+import junit.framework.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openhab.binding.pilight.internal.PilightBinding;
+import org.openhab.binding.pilight.internal.PilightBindingConfig;
+import org.openhab.binding.pilight.internal.PilightGenericBindingProvider;
+import org.openhab.core.items.Item;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.model.item.binding.BindingConfigParseException;
+
+/**
+ * @author Jeroen Idserda
+ * @since 1.7.0
+ */
+public class PilightGenericBindingProviderTest {
+	
+	private PilightGenericBindingProvider provider;
+	private PilightBinding binding;
+	private Item testItem;
+	
+	@Before
+	public void init() {
+		provider = new PilightGenericBindingProvider();
+		binding = new PilightBinding();
+		testItem = new NumberItem("NumberItem");;
+	}
+
+	@Test
+	public void testNumberItemScale() throws BindingConfigParseException {
+		
+		String bindingConfig = "kaku#outside:weather,property=temperature";
+		
+		PilightBindingConfig config = provider.parseBindingConfig(testItem, bindingConfig);
+		Assert.assertNotNull(config);
+		
+		DecimalType number0 = (DecimalType) binding.getState("23", config);
+		Assert.assertEquals(number0.toBigDecimal().compareTo(new BigDecimal("23")), 0);
+
+		config.setScale(1);
+		DecimalType number1 = (DecimalType) binding.getState("23.3", config);
+		Assert.assertEquals(number1.toBigDecimal().compareTo(new BigDecimal("23.3")), 0);
+
+		config.setScale(0);
+		DecimalType number2 = (DecimalType) binding.getState("2.3", config);
+		Assert.assertEquals(number2.toBigDecimal().compareTo(new BigDecimal("23")), 0);
+		
+		config.setScale(2);
+		DecimalType number3 = (DecimalType) binding.getState("233", config);
+		Assert.assertEquals(number3.toBigDecimal().compareTo(new BigDecimal("2.33")), 0);
+		
+		config.setScale(-1);
+		DecimalType number4 = (DecimalType) binding.getState("233", config);
+		Assert.assertEquals(number4.toBigDecimal().compareTo(new BigDecimal("2330")), 0);
+		
+		config.setScale(1);
+		DecimalType number5 = (DecimalType) binding.getState("233", config);
+		Assert.assertEquals(number5.toBigDecimal().compareTo(new BigDecimal("23.3")), 0);
+	}
+}

--- a/bundles/binding/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightBinding.java
+++ b/bundles/binding/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightBinding.java
@@ -107,8 +107,9 @@ public class PilightBinding extends AbstractBinding<PilightBindingProvider> impl
 				String value = status.getValues().get(property);
 				State state = getState(value, config);
 				
-				if (state != null)
+				if (state != null) {
 					eventPublisher.postUpdate(config.getItemName(), state);
+				}
 			}
 		}
 	}
@@ -120,7 +121,8 @@ public class PilightBinding extends AbstractBinding<PilightBindingProvider> impl
 			state = new StringType(value);
 		} else if (config.getItemType().equals(NumberItem.class)) {
 			if (!StringUtils.isBlank(value)) {
-				value = value.replace(".", "").replace(",","");
+				// Number values are always received as an integer with an optional parameter describing 
+				// the number of decimals (scale, default = 0). 
 				BigDecimal numberValue = new BigDecimal(value);
 				numberValue = numberValue.divide(new BigDecimal(Math.pow(10,config.getScale())), config.getScale(), RoundingMode.HALF_UP);
 				state = new DecimalType(numberValue);

--- a/bundles/binding/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightBinding.java
+++ b/bundles/binding/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightBinding.java
@@ -22,6 +22,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.JsonGenerator.Feature;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.openhab.binding.pilight.PilightBindingProvider;
@@ -34,7 +35,6 @@ import org.openhab.binding.pilight.internal.communication.Status;
 import org.openhab.binding.pilight.internal.communication.Update;
 import org.openhab.binding.pilight.internal.communication.Values;
 import org.openhab.core.binding.AbstractBinding;
-import org.openhab.core.binding.BindingChangeListener;
 import org.openhab.core.binding.BindingProvider;
 import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.items.StringItem;
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
  * @author Jeroen Idserda
  * @since 1.0
  */
-public class PilightBinding extends AbstractBinding<PilightBindingProvider> implements ManagedService,BindingChangeListener {
+public class PilightBinding extends AbstractBinding<PilightBindingProvider> implements ManagedService {
 
 	private static final Logger logger = 
 		LoggerFactory.getLogger(PilightBinding.class);
@@ -105,21 +105,26 @@ public class PilightBinding extends AbstractBinding<PilightBindingProvider> impl
 			String property = config.getProperty();
 			if (status.getValues().containsKey(property)) {
 				String value = status.getValues().get(property);
-				State state = getStateFromProperty(value, config);
-				eventPublisher.postUpdate(config.getItemName(), state);
+				State state = getState(value, config);
+				
+				if (state != null)
+					eventPublisher.postUpdate(config.getItemName(), state);
 			}
 		}
 	}
 
-	private State getStateFromProperty(String value, PilightBindingConfig config) {
+	protected State getState(String value, PilightBindingConfig config) {
 		State state = null;
 		
 		if (config.getItemType().equals(StringItem.class)) {
 			state = new StringType(value);
 		} else if (config.getItemType().equals(NumberItem.class)) {
-			BigDecimal numberValue = new BigDecimal(value).setScale(config.getScale());
-			numberValue = numberValue.divide(new BigDecimal(config.getScale()*10), config.getScale(), RoundingMode.HALF_UP);
-			state = new DecimalType(numberValue);
+			if (!StringUtils.isBlank(value)) {
+				value = value.replace(".", "").replace(",","");
+				BigDecimal numberValue = new BigDecimal(value);
+				numberValue = numberValue.divide(new BigDecimal(Math.pow(10,config.getScale())), config.getScale(), RoundingMode.HALF_UP);
+				state = new DecimalType(numberValue);
+			}
 		}
 		
 		return state;
@@ -320,6 +325,7 @@ public class PilightBinding extends AbstractBinding<PilightBindingProvider> impl
 			}
 		}));
 		connection.getListener().start();
+		setInitialState();
 	}
 
 	/**
@@ -348,12 +354,14 @@ public class PilightBinding extends AbstractBinding<PilightBindingProvider> impl
 					
 					return state;
 				} else if (devType.equals(DeviceType.VALUE)) {
-					bindingConfig.setScale(dev.getScale());
+					if (dev.getScale() != null) {
+						bindingConfig.setScale(dev.getScale());
+					}
 					
 					String property = bindingConfig.getProperty();
 					if (dev.getProperties().containsKey(property)) {
 						String value = dev.getProperties().get(property);
-						return getStateFromProperty(value, bindingConfig);
+						return getState(value, bindingConfig);
 					}
 				}
 			}
@@ -366,8 +374,25 @@ public class PilightBinding extends AbstractBinding<PilightBindingProvider> impl
 	 */
 	@Override
 	public void bindingChanged(BindingProvider provider, String itemName) {
+		logger.debug("Binding changed for item {}", itemName);
 		checkItemState(provider, itemName);
-		super.bindingChanged(provider, itemName);
+	}
+	
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	public void allBindingsChanged(BindingProvider provider) {
+		logger.debug("All bindings changed");
+		for (String itemName : provider.getItemNames()) {
+			checkItemState(provider, itemName);
+		}
+	}
+	
+	private void setInitialState() {
+		for (PilightBindingProvider provider : providers) {
+			allBindingsChanged(provider);
+		}
 	}
 
 	/**

--- a/bundles/binding/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightBindingConfig.java
@@ -31,7 +31,7 @@ public class PilightBindingConfig implements BindingConfig {
 		
 		private String property; 
 		
-		private Integer scale = 1; 
+		private int scale = 0; 
 		
 		public String getItemName() {
 			return itemName;
@@ -82,11 +82,11 @@ public class PilightBindingConfig implements BindingConfig {
 			this.property = value;
 		}
 		
-		public Integer getScale() {
+		public int getScale() {
 			return scale;
 		}
 		
-		public void setScale(Integer scale) {
+		public void setScale(int scale) {
 			this.scale = scale;
 		}
 		

--- a/bundles/binding/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.pilight/src/main/java/org/openhab/binding/pilight/internal/PilightGenericBindingProvider.java
@@ -70,8 +70,15 @@ public class PilightGenericBindingProvider extends AbstractGenericBindingProvide
 	public void processBindingConfiguration(String context, Item item, String bindingConfig) throws BindingConfigParseException {
 		super.processBindingConfiguration(context, item, bindingConfig);
 		
+		PilightBindingConfig config = parseBindingConfig(item, bindingConfig);
+
+		if (config != null) {
+			addBindingConfig(item, config);
+		}
+	}
+
+	protected PilightBindingConfig parseBindingConfig(Item item, String bindingConfig) {
 		bindingConfig =	bindingConfig.replace(" ", "");
-		
 		Matcher matcher = CONFIG_PATTERN.matcher(bindingConfig);
 		
 		if (matcher.matches()) {
@@ -108,11 +115,13 @@ public class PilightGenericBindingProvider extends AbstractGenericBindingProvide
 			} else {
 				logger.info("pilight:{} item {} bound to device {} in location {}{}", config.getInstance(), config.getItemName(), config.getDevice(), 
 						config.getLocation(), config.getProperty() != null ? ", property " + config.getProperty() : "");
-				addBindingConfig(item, config);
+				return config;
 			}
 		} else {
 			logger.error("Item config {} does not match instance#location:device,property=optional pattern", bindingConfig);
 		}
+		
+		return null;
 	}
 	
 	public PilightBindingConfig getBindingConfig(String itemName) {

--- a/bundles/binding/pom.xml
+++ b/bundles/binding/pom.xml
@@ -74,6 +74,7 @@
     <module>org.openhab.binding.systeminfo</module>
     <module>org.openhab.binding.piface</module>
     <module>org.openhab.binding.pilight</module>
+    <module>org.openhab.binding.pilight.test</module>
     <module>org.openhab.binding.fritzaha</module>
     <module>org.openhab.binding.tinkerforge</module>
     <module>org.openhab.binding.nibeheatpump</module>


### PR DESCRIPTION
Number values received from pilight would have the decimal point in the wrong position for some devices. This fixes that and adds a testcase. It also makes sure the initial state is fetched. 