### PR TITLE
MiOS: Use formal ZWave status names.

### DIFF
--- a/bundles/binding/org.openhab.binding.mios/examples/transform/miosZWaveStatusIn.map
+++ b/bundles/binding/org.openhab.binding.mios/examples/transform/miosZWaveStatusIn.map
@@ -1,3 +1,8 @@
-1=ZWave is in the house
-0=ZWave is in the dog house
+0=Not Set
+1=OK
+2=Quitting
+3=Waiting to Quit
+4=No Dongle
+5=Running Init/Configure Scripts
+6=Failure
 -=Your guess is as good as mine!


### PR DESCRIPTION
These status's come from this document:
        http://wiki.micasaverde.com/index.php/ZWave_Status

This prevents Mapping-errors from occurring in the openHAB Logs during the nightly MiOS Heal operation.