### PR TITLE
MiOS Item file Generator tools (command-line extraction from MiOS Unit)

### DIFF
--- a/bundles/binding/org.openhab.binding.mios/examples/scripts/README.md
+++ b/bundles/binding/org.openhab.binding.mios/examples/scripts/README.md
@@ -1,0 +1,75 @@
+# MiOS Binding Tools and Utilities
+
+## MiOS openHAB Item file Generator
+
+The MiOS openHAB Item file Generator tools extract information from a live/running MiOS Unit, and convert them into an Items file suitable for use in openHAB.  These tools are intended to build a starting point Items file for the end-user, using the current-generation of the MiOS Binding.
+
+NOTE: The rules for generating the Items file may change over time.  The output of the script may change without notice, and should be reviewed prior to use.
+
+### OS Requirements
+
+These scripts are intended to be run on a Linux, Unix or MacOS X system.
+
+The MiOS openHAB Item file Generator scripts consist of:
+
+* `miosLoad.sh` - A loader script that calls a MiOS Unit, over HTTP, and extracts it's metadata in the form of a `user_data.xml` file.
+* `miosTransform.sh` - A wrapper script to transform a MiOS Unit `user_data.xml` file into the associated Items file.
+* `miosTransform.xslt` - An XSLT file containing the rules for conversion from a MiOS Unit `user_data.xml` file into an Items file.
+
+The following components are assumed installed on the system:
+
+* `bash`
+* `xsltproc` - http://xmlsoft.org/XSLT/xsltproc.html
+* `curl` - http://curl.haxx.se/
+
+### How to use
+
+To run the conversion process, the following steps should be executed:
+
+* Load (`miosLoad.sh`) - retrieves an XML version of the MiOS Device MetaData from your MiOS Unit.
+In some cases, MiOS emits _invalid_ XML, so this content may have to be hand-edited prior to feeding it into the next step.  This script takes a single parameter, which is the IP Address, or DNS name, of the MiOS Unit to call.  The output of this phase is a file called `user_data.xml`
+
+* Transform (`miosTransform.sh`) - converts the XML into a Textual openHAB Items file.
+This script takes a single parameter, which is used for both the name of the generated Items file, as well as the MiOS Unit name used in openhab.cfg (eg. "house").  
+If this completes successfully, it will have generated an output file like `house.items` which, after suitable manual review, can be used as an openHAB Items file.
+
+This is an example of what it's like to run these command line scripts in sequence:
+
+```ShellSession
+Code: [Select]
+me$ ./miosLoad.sh 192.168.1.100
+Loading MiOS Unit Metadata from 192.168.1.100...
+Metadata Loaded into user_data.xml!
+me$ ./miosTransform.sh house
+Transforming MiOS Unit Metadata from user_data.xml...
+Metadata Transformed into house.items!
+Duplicate Item names requiring manual fixes:
+  String   DownstairsDeviceStatus "Downstairs Device Status [%s]" (GDevices) {mios="unit:house,device:385/status"}
+  Number   DownstairsId "ID [%d]" (GDevices) {mios="unit:house,device:385/id"}
+  String   LivingRoomSonosPIcon "Living Room Sonos (P) Icon [%s]" (GDevices,GRoom2) {mios="unit:house,device:295/service/DeviceProperties/Icon"}
+  String   MasterBedroomSonosIcon "Master Bedroom Sonos Icon [%s]" (GDevices,GRoom7) {mios="unit:house,device:331/service/DeviceProperties/Icon"}
+  String   SceneControllerConfigured "_Scene Controller Configured [%s]" (GDevices) {mios="unit:house,device:394/service/HaDevice1/Configured"}
+  String   SceneControllerDeviceStatus "_Scene Controller Device Status [%s]" (GDevices) {mios="unit:house,device:393/status"}
+  String   SceneControllerDeviceStatus "_Scene Controller Device Status [%s]" (GDevices) {mios="unit:house,device:394/status"}
+  Number   SceneControllerId "ID [%d]" (GDevices) {mios="unit:house,device:394/id"}
+  Number   SceneControllerId "ID [%d]" (GDevices) {mios="unit:house,device:4/id"}
+  String   SceneControllerScenes "_Scene Controller Scenes [%s]" (GDevices) {mios="unit:house,device:393/service/SceneController1/Scenes"}
+  String   SceneControllerScenes "_Scene Controller Scenes [%s]" (GDevices) {mios="unit:house,device:394/service/SceneController1/Scenes"}
+  String   SceneMasterBathroom "Master Bathroom Scene" <sofa> (GScenes) {mios="unit:house,scene:34/status", autoupdate="false"}
+  String   SceneMasterBathroom "Master Bathroom Scene" <sofa> (GScenes) {mios="unit:house,scene:35/status", autoupdate="false"}
+  String   SceneTestArmed "TestArmed Scene" <sofa> (GScenes) {mios="unit:house,scene:73/status", autoupdate="false"}
+  String   SceneTestDisarmed "TestDisarmed Scene" <sofa> (GScenes) {mios="unit:house,scene:76/status", autoupdate="false"}
+  String   UpstairsDeviceStatus "Upstairs Device Status [%s]" (GDevices) {mios="unit:house,device:337/status"}
+  Number   UpstairsId "ID [%d]" (GDevices) {mios="unit:house,device:337/id"}
+  Contact  SceneMasterBathroomActive "Active [%s]" <sofa> (GScenes) {mios="unit:house,scene:34/active"}
+  Contact  SceneMasterBathroomActive "Active [%s]" <sofa> (GScenes) {mios="unit:house,scene:35/active"}
+  Contact  SceneTestArmedActive "Active [%s]" <sofa> (GScenes) {mios="unit:house,scene:79/active"}
+  Contact  SceneTestDisarmedActive "Active [%s]" <sofa> (GScenes) {mios="unit:house,scene:80/active"}
+```
+
+At this point, you'll have a _fairly_ complete `house.items` file for use in openHAB.  The conversion process takes a number of steps to aid in generating unique Item names in the generated content, but any output in the _Duplicate Item names_ section should be addressed prior to use as an openHAB Items file.
+
+The tool includes almost all of the _by-hand_ conversion rules used in other MiOS user's openHAB Configurations. MiOS UPnP State variables like `SwitchPower1/Status` become an openHAB `Switch` Item for example.   
+
+The generator tools will get you close to a working openHAB Items file, especially for commonly used MiOS Device types.  For exotic MiOS Device Types, not handled by the MiOS internal defaults, the Items file will need to be augmented with the appropriate MAP Transformations.  This involves editing the file, and adding the appropriate `in:`, `out:`, and `command:` parameters per the documentation for the MiOS Binding.
+

--- a/bundles/binding/org.openhab.binding.mios/examples/scripts/miosLoad.sh
+++ b/bundles/binding/org.openhab.binding.mios/examples/scripts/miosLoad.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ "$#" != "1" ]
+then
+    echo "Usage: $0 <VeraIpAddress>"
+    exit 1
+else
+    MIOS_IP=$1; export MIOS_IP
+    MIOS_OUT=user_data.xml; export MIOS_OUT
+fi
+
+echo "Loading MiOS Unit Metadata from ${MIOS_IP}..."
+curl --max-time 15 \
+     --output ${MIOS_OUT} \
+     --silent "http://${MIOS_IP}:49451/data_request?id=user_data&output_format=xml"
+
+if [ "$?" == "0" ]
+then
+    echo "Metadata Loaded into ${MIOS_OUT}!"
+else
+    echo "Failed to load, Check IP Address supplied."
+fi
+

--- a/bundles/binding/org.openhab.binding.mios/examples/scripts/miosTransform.sh
+++ b/bundles/binding/org.openhab.binding.mios/examples/scripts/miosTransform.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+if [ "$#" != "1" ]
+then
+    echo "Usage: $0 <openHAB-MiOSUnitName>"
+    exit 1
+else
+    MIOS_UNIT="${1}"; export MIOS_UNIT
+    MIOS_IN=user_data.xml; export MIOS_OUT
+    MIOS_ITEM_FILE="${MIOS_UNIT}.items"; export MIOS_ITEM_FILE
+fi
+
+echo "Transforming MiOS Unit Metadata from ${MIOS_IN}..."
+xsltproc --stringparam MIOS_UNIT "${MIOS_UNIT}" --output "${MIOS_ITEM_FILE}" miosTransform.xslt "${MIOS_IN}"
+
+if [ "$?" == "0" ]
+then
+    echo "Metadata Transformed into ${MIOS_ITEM_FILE}!"
+else
+    echo "Failed to Transform, Check for bogus XML in ${MIOS_IN}."
+    exit 1
+fi
+
+echo "Duplicate Item names requiring manual fixes:"
+lastItemName=""
+grep -v ^$ "${MIOS_ITEM_FILE}" | grep -v "^/" | sort -k 2 | while read -r line; do
+    read -r itemType itemName _ <<< "$line"
+
+    if [ "$itemName" = "$lastItemName" ]; then
+        echo "  $line"
+    else
+        lastItemName="$itemName"
+    fi
+done
+

--- a/bundles/binding/org.openhab.binding.mios/examples/scripts/miosTransform.xslt
+++ b/bundles/binding/org.openhab.binding.mios/examples/scripts/miosTransform.xslt
@@ -1,0 +1,560 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2015, openHAB.org and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes"/>
+
+<xsl:param name="MIOS_UNIT" select="'house'"/>
+
+<xsl:variable name="BAD_CHARS">_#-!@$%^&amp;*=+~`[]{}\\|:;&quot;&lt;\>?/.() </xsl:variable>
+
+<xsl:template match="/root">Group GAll
+Group GPersist (GAll)
+
+Group GSystem "System Information [%d]" &lt;office>
+
+Group GRooms (GAll)
+Group GScenes (GAll)
+Group GDevices (GAll)
+
+<xsl:apply-templates select="rooms"/>
+<xsl:apply-templates select="devices/device[(not(@category_num) or (@category_num!='13'))
+                             and @device_type!='urn:micasaverde-com:serialportroot'
+                             and @device_type!='urn:micasaverde-org:device:SerialPort:1'
+                             and @device_type!='urn:micasaverde-org:device:SerialPortRoot:1']"/>
+<xsl:apply-templates select="scenes"/>
+
+/* If you want more MiOS Internals, uncomment the following. */
+/* Number   SystemDataVersion "System Data Version [%d]" (GSystem) {mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,system:/DataVersion"}                               */
+/* DateTime SystemLoadTime "System Load Time [%1$ta, %1$tm/%1$te %1$tR]" &lt;calendar> (GSystem) {mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,system:/LoadTime"}    */
+/* String   SystemLocalTime "System Local Time [%s]" (GSystem) {mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,system:/LocalTime"}                                     */
+/* DateTime SystemTimeStamp "System Time Stamp [%1$ta, %1$tm/%1$te %1$tR]" &lt;calendar> (GSystem) {mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,system:/TimeStamp"} */
+/* Number   SystemUserDataDataVersion "System User Data Version [%d]" (GSystem) {mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,system:/UserData_DataVersion"}         */
+
+/* If you want Z-Wave Status, uncomment the following. */
+/* Number   SystemZWaveStatus "System ZWave Status [%d]" (GSystem) {mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,system:/ZWaveStatus"}                                            */
+/* String   SystemZWaveStatusString "System ZWave Status String [%d]" (GSystem) {mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,system:/ZWaveStatus,in:MAP(miosZWaveStatusIn.map)"} */
+</xsl:template>
+
+<xsl:template match="rooms">
+<xsl:for-each select="room">Group GRoom<xsl:value-of select="@id"/> "<xsl:value-of select="translate(@name, '&quot;', '')"/> [%d]" &lt;office> (GRooms)
+</xsl:for-each>
+</xsl:template>
+
+<xsl:template match="device">
+<xsl:variable name="DeviceName">
+<xsl:value-of select="translate(normalize-space(@name), $BAD_CHARS, '')"/>
+</xsl:variable>
+
+<xsl:variable name="DeviceNameFixed">
+<xsl:value-of select="$DeviceName"/>
+<xsl:if test="count(../device[translate(normalize-space(@name), $BAD_CHARS, '') = $DeviceName]) > 1">
+<xsl:value-of select="@id"/>
+</xsl:if>
+</xsl:variable>
+/* Device - <xsl:value-of select="@name"/> */
+Number   <xsl:value-of select="$DeviceNameFixed"/>Id "ID [%d]" (GDevices) {mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,device:<xsl:value-of select="@id"/>/id"}
+String   <xsl:value-of select="$DeviceNameFixed"/>DeviceStatus "<xsl:value-of select="@name"/> Device Status [%s]" (GDevices) {mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,device:<xsl:value-of select="@id"/>/status"}
+<xsl:for-each select="states">
+  <xsl:apply-templates select="state[not (@service='urn:micasaverde-com:serviceId:HaDevice1' and @variable='IODevice')
+                                     and not (@service='urn:micasaverde-com:serviceId:HaDevice1' and @variable='IODeviceXRef')
+                                     and not (@service='urn:micasaverde-com:serviceId:HaDevice1' and @variable='IOPortPath')
+                                     and not (@service='urn:micasaverde-com:serviceId:SwitchPower1' and @variable='Status')
+                                     and not (@service='urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='ProviderKey')
+                                     and not (@service='urn:garrettwp-com:serviceId:WPSwitch1' and @variable='username')
+                                     and not (@service='urn:garrettwp-com:serviceId:WPSwitch1' and @variable='password')
+                                     and not (@service='urn:macrho-com:serviceId:LiftMasterOpener1' and @variable='Username')
+                                     and not (@service='urn:macrho-com:serviceId:LiftMasterOpener1' and @variable='Password')
+                                     and not (@service='urn:rts-services-com:serviceId:ProgramLogicC')
+                                     and not (@service='urn:rts-services-com:serviceId:ProgramLogicEG')
+                                     and not (@service='urn:watou-com:serviceId:Nest1' and @variable='username')
+                                     and not (@service='urn:watou-com:serviceId:Nest1' and @variable='password')
+                                     and not (@service='urn:watou-com:serviceId:Nest1' and @variable='access_token')
+                                     and not (@service='urn:watou-com:serviceId:Nest1' and @variable='userid')
+                                     and not (@service='urn:upnp-org:serviceId:BatteryMonitor1' and @variable='LowDeviceList')
+                                     and not (@service='urn:upnp-org:serviceId:BatteryMonitor1' and @variable='MidDeviceList')
+                                     and not (@service='urn:upnp-org:serviceId:BatteryMonitor1' and @variable='HighDeviceList')
+                                     and not (@service='urn:upnp-org:serviceId:BatteryMonitor1' and @variable='MonitoredDeviceList')
+                                     and not (@service='urn:upnp-org:serviceId:BatteryMonitor1' and @variable='UnMonitoredDeviceList')
+                                     and not (@service='urn:upnp-org:serviceId:VSwitch1' and @variable='UI7Check')
+                                     and not (@service='urn:upnp-empuk-net:serviceId:SimpleAlarm1' and @variable='XendAppUsername')
+                                     and not (@service='urn:upnp-empuk-net:serviceId:SimpleAlarm1' and @variable='XendAppPassword')
+                                     and not (@service='urn:upnp-empuk-net:serviceId:SimpleAlarm1' and @variable='AwaySensorsDeviceList')
+                                     and not (@service='urn:upnp-empuk-net:serviceId:SimpleAlarm1' and @variable='HomeSensorsDeviceList')
+                                     and not (@service='urn:upnp-empuk-net:serviceId:SimpleAlarm1' and @variable='PanicSensorsDeviceList')
+                                    ]"/>
+</xsl:for-each>
+</xsl:template>
+
+<xsl:template match="state">
+<xsl:variable name="ServiceAlias">
+<xsl:choose>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:SwitchPower1'"                >SwitchPower1</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:Dimming1'"                    >Dimming1</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSensor1'"          >TemperatureSensor1</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:HVAC_FanOperatingMode1'"      >HVAC_FanOperatingMode1</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:HVAC_UserOperatingMode1'"     >HVAC_UserOperatingMode1</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Cool'"   >TemperatureSetpoint1_Cool</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Heat'"   >TemperatureSetpoint1_Heat</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:AVTransport'"                 >AVTransport</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:RenderingControl'"            >RenderingControl</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:DeviceProperties'"            >DeviceProperties</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:HouseStatus1'"                >HouseStatus1</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:ContentDirectory'"            >ContentDirectory</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:AudioIn'"                     >AudioIn</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:ZWaveDevice1'"         >ZWaveDevice1</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:ZWaveNetwork1'"        >ZWaveNetwork1</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'"            >HaDevice1</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:SceneControllerLED1'"  >SceneControllerLED1</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:SecuritySensor1'"      >SecuritySensor1</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HumiditySensor1'"      >HumiditySensor1</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:EnergyMetering1'"      >EnergyMetering1</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:SceneController1'"     >SceneController1</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HVAC_OperatingState1'" >HVAC_OperatingState1</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:SerialPort1'"          >SerialPort1</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'"            >DoorLock1</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:AlarmPartition2'"      >AlarmPartition2</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:Camera1'"              >Camera1</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'"         >SystemMonitor</xsl:when>
+<xsl:when test="@service = 'urn:garrettwp-com:serviceId:WPSwitch1'"              >WPSwitch1</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:Nest1'"                >Nest1</xsl:when>
+<xsl:when test="@service = 'urn:watou-com:serviceId:NestStructure1'"             >NestStructure1</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1'"        >Weather1</xsl:when>
+<xsl:when test="@service = 'urn:demo-ted-striker:serviceId:PingSensor1'"         >PingSensor1</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:Sonos1'"               >Sonos1</xsl:when>
+<xsl:when test="@service = 'rn:demo-paradox-com:serviceId:ParadoxSecurityEVO1'"  >Paradox</xsl:when>
+<xsl:when test="@service = 'urn:macrho-com:serviceId:LiftMasterOpener1'"         >LiftMasterOpener1</xsl:when>
+<xsl:when test="@service = 'urn:directv-com:serviceId:DVR1'"                     >DirecTVDVR1</xsl:when>
+<xsl:otherwise><xsl:value-of select="@service"/></xsl:otherwise>
+</xsl:choose>
+</xsl:variable>
+
+<xsl:variable name="ItemType">
+<xsl:choose>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:SwitchPower1'              and @variable = 'Status'"              >Switch</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:Dimming1'                  and @variable = 'LoadLevelStatus'"     >Dimmer</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:Dimming1'                  and @variable = 'LoadLevelTarget'"     >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSensor1'        and @variable = 'CurrentTemperature'"  >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Cool' and @variable = 'CurrentSetpoint'"     >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Heat' and @variable = 'CurrentSetpoint'"     >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:RenderingControl'          and @variable = 'Volume'"              >Dimmer</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:RenderingControl'          and @variable = 'Mute'"                >Switch</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:Camera1'            and @variable = 'AutoArchiveSeconds'"  >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:Camera1'            and @variable = 'SensorArchiveSeconds'"     >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:Camera1'            and @variable = 'AutoArchivePreserveDays'"  >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:Camera1'            and @variable = 'Timeout'"             >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'          and @variable = 'LastUpdate'"          >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'          and @variable = 'LastTimeCheck'"       >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'          and @variable = 'LastTimeOffset'"      >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'          and @variable = 'FirstConfigured'"     >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'          and @variable = 'BatteryDate'"         >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'          and @variable = 'BatteryLevel'"        >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'          and @variable = 'CommFailure'"         >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'          and @variable = 'sl_BatteryAlarm'"     >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'          and @variable = 'PollingEnabled'"      >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:SecuritySensor1'    and @variable = 'LastTrip'"            >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:SecuritySensor1'    and @variable = 'Tripped'"             >Contact</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:SecuritySensor1'    and @variable = 'Armed'"               >Switch</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:EnergyMetering1'    and @variable = 'KWHReading'"          >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:EnergyMetering1'    and @variable = 'KWH'"                 >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:EnergyMetering1'    and @variable = 'Watts'"               >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:EnergyMetering1'    and @variable = 'UserSuppliedWattage'" >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:AlarmPartition2'    and @variable = 'LastAlarmActive'"     >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:ZWaveNetwork1'      and @variable = 'LastUpdate'"          >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:ZWaveNetwork1'      and @variable = 'LastDongleBackup'"    >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:ZWaveNetwork1'      and @variable = 'LastHeal'"            >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:ZWaveNetwork1'      and @variable = 'LastRouteFailure'"    >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:MiosUpdater1'       and @variable = 'LastCheck'"           >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable ='Status'"               >Switch</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable ='MinPinSize'"           >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable ='MaxPinSize'"           >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable ='sl_CodeChanged'"       >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable ='sl_UserCode'"          >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable ='sl_LockChanged'"       >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable ='sl_LowBattery'"        >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable ='sl_LockButton'"        >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable ='sl_LockFailure'"       >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable ='sl_PinFailed'"         >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HumiditySensor1'    and @variable ='CurrentLevel'"         >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:GenericSensor1'     and @variable ='CurrentLevel'"         >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:LightSensor1'       and @variable ='CurrentLevel'"         >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:SceneController1'   and @variable ='LastSceneTime'"        >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:SceneController1'   and @variable ='LastSceneID'"          >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:SceneController1'   and @variable ='NumButtons'"           >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:SceneController1'   and @variable ='sl_SceneActivated'"    >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:SceneController1'   and @variable ='sl_SceneDeactivated'"  >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:Nest1'              and @variable ='Status'"               >Contact</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:Weather1'           and @variable = 'LastUpdate'"          >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'LastUpdate'"               >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Alert.1.StartDate'"          >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Alert.2.StartDate'"          >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Alert.3.StartDate'"          >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Alert.4.StartDate'"          >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Alert.1.EndDate'"            >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Alert.2.EndDate'"            >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Alert.3.EndDate'"            >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Alert.4.EndDate'"            >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='WindDegrees'"                >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='WindGust'"                   >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Solar'"                      >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='UV'"                         >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Pressure'"                   >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='FeelsLike'"                  >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='DewPoint'"                   >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='HeatIndex'"                  >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='WindChill'"                  >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Alerts'"                     >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecasts'"                  >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.0.HighTemperature'" >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.0.LowTemperature'"  >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.0.MaxWindSpeed'"    >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.0.MaxWindDegrees'"  >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.0.POP'"             >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.0.QPFDay'"          >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.0.QPFNight'"        >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.0.SnowDay'"         >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.0.SnowNight'"       >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.1.HighTemperature'" >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.1.LowTemperature'"  >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.1.MaxWindSpeed'"    >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.1.MaxWindDegrees'"  >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.1.POP'"             >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.1.QPFDay'"          >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.1.QPFNight'"        >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.1.SnowDay'"         >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.1.SnowNight'"       >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.2.HighTemperature'" >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.2.LowTemperature'"  >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.2.MaxWindSpeed'"    >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.2.MaxWindDegrees'"  >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.2.POP'"             >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.2.QPFDay'"          >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.2.QPFNight'"        >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.2.SnowDay'"         >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.2.SnowNight'"       >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.3.HighTemperature'" >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.3.LowTemperature'"  >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.3.MaxWindSpeed'"    >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.3.MaxWindDegrees'"  >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.3.POP'"             >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.3.QPFDay'"          >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.3.QPFNight'"        >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.3.SnowDay'"         >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable='Forecast.3.SnowNight'"       >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='systemLuupRestartUnix'"      >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='cmhLastRebootUnix'"          >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='systemVeraRestartUnix'"      >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='SamplePeriodCPU'"            >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='SamplePeriodMem'"            >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='SamplePeriodUptime'"         >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='memoryTotal'"                >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='memoryFree'"                 >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='memoryBuffers'"              >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='memoryCached'"               >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='memoryUsed'"                 >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='memoryAvailable'"            >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='cpuLoad1'"                   >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='cpuLoad5'"                   >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='cpuLoad15'"                  >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='procRunning'"                >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='procTotal'"                  >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='uptimeTotal'"                >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='uptimeIdle'"                 >Number</xsl:when>
+<xsl:when test="@service = 'urn:cd-jackson-com:serviceId:SystemMonitor'  and @variable='systemLuupRestart'"          >Number</xsl:when>
+<xsl:when test="@service = 'urn:demo-ted-striker:serviceId:PingSensor1'  and @variable='Period'"                     >Number</xsl:when>
+<xsl:when test="@service = 'urn:macrho-com:serviceId:LiftMasterOpener1'  and @variable='Timestamp'"                  >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:richardgreen:serviceId:VeraAlert1'       and @variable='LastUpdate'"                 >DateTime</xsl:when>
+<xsl:when test="@service = 'urn:intvelt-com:serviceId:HueColors1'        and @variable='ColorTemperature'"           >Number</xsl:when>
+<xsl:when test="@service = 'urn:intvelt-com:serviceId:HueColors1'        and @variable='Hue'"                        >Number</xsl:when>
+<xsl:when test="@service = 'urn:intvelt-com:serviceId:HueColors1'        and @variable='Saturation'"                 >Number</xsl:when>
+<xsl:when test="@service = 'urn:intvelt-com:serviceId:HueColors1'        and @variable='CurrentPreset'"              >Number</xsl:when>
+<xsl:when test="@service = 'urn:dcineco-com:serviceId:MSwitch1'          and @variable='Status1'"                    >Switch</xsl:when>
+<xsl:when test="@service = 'urn:dcineco-com:serviceId:MSwitch1'          and @variable='Status2'"                    >Switch</xsl:when>
+<xsl:when test="@service = 'urn:dcineco-com:serviceId:MSwitch1'          and @variable='Status3'"                    >Switch</xsl:when>
+<xsl:when test="@service = 'urn:dcineco-com:serviceId:MSwitch1'          and @variable='Status4'"                    >Switch</xsl:when>
+<xsl:when test="@service = 'urn:dcineco-com:serviceId:MSwitch1'          and @variable='Status5'"                    >Switch</xsl:when>
+<xsl:when test="@service = 'urn:dcineco-com:serviceId:MSwitch1'          and @variable='Status6'"                    >Switch</xsl:when>
+<xsl:when test="@service = 'urn:dcineco-com:serviceId:MSwitch1'          and @variable='Status7'"                    >Switch</xsl:when>
+<xsl:when test="@service = 'urn:dcineco-com:serviceId:MSwitch1'          and @variable='Status8'"                    >Switch</xsl:when>
+<xsl:otherwise>String</xsl:otherwise>
+</xsl:choose>
+</xsl:variable>
+
+<xsl:variable name="DeviceName">
+<xsl:value-of select="translate(normalize-space(../../@name), $BAD_CHARS, '')"/>
+</xsl:variable>
+
+<xsl:variable name="DeviceNameFixed">
+<xsl:value-of select="$DeviceName"/>
+<xsl:if test="count(../../../device[translate(normalize-space(@name), $BAD_CHARS, '') = $DeviceName]) > 1">
+<xsl:value-of select="../../@id"/>
+</xsl:if>
+</xsl:variable>
+
+<xsl:variable name="VariableName">
+<xsl:value-of select="translate(normalize-space(@variable), $BAD_CHARS, '')"/>
+</xsl:variable>
+
+<xsl:variable name="ItemName">
+<xsl:value-of select="$DeviceNameFixed"/>
+<xsl:value-of select="$VariableName"/>
+<!-- ** Handle duplicate UPnP Variable names by picking the winning ServiceId explicitly, and suffixing the state@id for all others.
+     ** Id and Device Status are reserved, since we use them up front in the generation process.
+     **
+     ** Some rules are for legacy ServiceId's that may have been introduced early in the Plugin Dev, but no longer used. -->
+<xsl:if test="count(../state[translate(normalize-space(@variable), $BAD_CHARS, '') = $VariableName]) > 1
+              or $VariableName = 'Id'
+              or $VariableName = 'DeviceStatus'
+             ">
+<xsl:choose>
+<xsl:when test="@variable='LastUpdate'      and @service = 'urn:micasaverde-com:serviceId:HaDevice1'"         ></xsl:when>
+<xsl:when test="@variable='ZoneName'        and @service = 'urn:upnp-org:serviceId:DeviceProperties'"         ></xsl:when>
+<xsl:when test="@variable='Target'          and @service = 'urn:upnp-org:serviceId:SwitchPower1'"             ></xsl:when>
+<xsl:when test="@variable='Status'          and @service = 'urn:upnp-org:serviceId:SwitchPower1'"             ></xsl:when>
+<xsl:when test="                                @service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Heat'" >Heat</xsl:when>
+<xsl:when test="                                @service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Cool'" >Cool</xsl:when>
+<xsl:when test="                                @service = 'urn:upnp-org:serviceId:HVAC_FanOperatingMode1'"    >Fan</xsl:when>
+<xsl:when test="                                @service = 'urn:upnp-org:serviceId:HVAC_UserOperatingMode1'"   >User</xsl:when>
+<xsl:otherwise><xsl:value-of select="@id"/></xsl:otherwise>
+</xsl:choose>
+</xsl:if>
+</xsl:variable>
+
+<xsl:variable name="ItemDescription">
+<xsl:value-of select="../../@name"/>
+<xsl:choose>
+<xsl:when test="@variable = 'BatteryLevel'"         > Battery Level</xsl:when>
+<xsl:when test="@variable = 'BatteryDate'"          > Battery Date</xsl:when>
+<xsl:when test="@variable = 'Timestamp'"            > Timestamp</xsl:when>
+<xsl:when test="@variable = 'FirstConfigured'"      > First Configured</xsl:when>
+<xsl:when test="@variable = 'LastSceneTime'"        > Last Scene Time</xsl:when>
+<xsl:when test="@variable = 'LastHeal'"             > Last Heal</xsl:when>
+<xsl:when test="@variable = 'Tripped'"              > Tripped</xsl:when>
+<xsl:when test="@variable = 'Armed'"                > Armed</xsl:when>
+<xsl:when test="@variable = 'AlarmMemory'"          > Alarm Memory</xsl:when>
+<xsl:when test="@variable = 'VendorStatusCode'"     > Vendor Status Code</xsl:when>
+<xsl:when test="@variable = 'VendorStatusData'"     > Vendor Status Data</xsl:when>
+<xsl:when test="@variable = 'VendorStatus'"         > Vendor Status</xsl:when>
+<xsl:when test="@variable = 'LastAlarmActive'"      > Last Alarm Active</xsl:when>
+<xsl:when test="@variable = 'LastUser'"             > Last User</xsl:when>
+<xsl:when test="@variable = 'ArmMode'"              > Arm Mode</xsl:when>
+<xsl:when test="@variable = 'DetailedArmMode'"      > Detailed Arm Mode</xsl:when>
+<xsl:when test="@variable = 'Alarm'"                > Alarm</xsl:when>
+<xsl:when test="@variable = 'Period'"               > Period</xsl:when>
+<xsl:when test="@variable = 'Address'"              > Address</xsl:when>
+<xsl:when test="@variable = 'PostalCode'"           > Postal Code</xsl:when>
+<xsl:when test="@variable = 'CountryCode'"          > Country Code</xsl:when>
+<xsl:when test="@variable = 'Location'"             > Location</xsl:when>
+<xsl:when test="@variable = 'DirectStreamingURL'"   > Streaming URL</xsl:when>
+<xsl:when test="@variable = 'Timeout'"              > Timeout</xsl:when>
+<xsl:when test="@variable = 'Address'"              > Address</xsl:when>
+<xsl:when test="@variable = 'Invert'"               > Invert</xsl:when>
+<xsl:when test="@variable = 'Chime'"                > Chime</xsl:when>
+<xsl:when test="@variable = 'Cycle'"                > Cycle</xsl:when>
+<xsl:when test="@variable = 'Mute'"                 > Mute</xsl:when>
+<xsl:when test="@variable = 'Mode'"                 > Mode</xsl:when>
+<xsl:when test="@variable = 'Commands'"             > Commands</xsl:when>
+<xsl:when test="@variable = 'Status'"               > Status</xsl:when>
+<xsl:when test="@variable = 'LastTrip'"             > Last Trip</xsl:when>
+<xsl:when test="@variable = 'LastError'"            > Last Error</xsl:when>
+<xsl:when test="@variable = 'LastTimeCheck'"        > Last Time Check</xsl:when>
+<xsl:when test="@variable = 'LastTimeOffset'"       > Last Time Offset</xsl:when>
+<xsl:when test="@variable = 'LastRouteFailure'"     > Last Route Failure</xsl:when>
+<xsl:when test="@variable = 'OccupancyState'"       > Occupancy State</xsl:when>
+<xsl:when test="@variable = 'StreetAddress'"        > Street Address</xsl:when>
+<xsl:when test="@variable = 'IgnoreRoom'"           > Ignore Room</xsl:when>
+<xsl:when test="@variable = 'CurrentSetpoint'"      > Current Setpoint</xsl:when>
+<xsl:when test="@variable = 'CurrentTemperature'"   > Current Temperature</xsl:when>
+<xsl:when test="@variable = 'CurrentLevel'"         > Current Level</xsl:when>
+<xsl:when test="@variable = 'SceneShortcuts'"       > Scene Shortcuts</xsl:when>
+<xsl:when test="@variable = 'ProprietaryScenes'"    > Proprietary Scenes</xsl:when>
+<xsl:when test="@variable = 'sl_SceneActivated'"    > Scene Activated</xsl:when>
+<xsl:when test="@variable = 'sl_SceneDeactivated'"  > Scene Deactivated</xsl:when>
+<xsl:when test="@variable = 'sl_LockFailure'"       > Lock Failure</xsl:when>
+<xsl:when test="@variable = 'sl_LockButton'"        > Lock Button</xsl:when>
+<xsl:when test="@variable = 'sl_PinFailed'"         > PIN Failed</xsl:when>
+<xsl:when test="@variable = 'sl_LowBattery'"        > Low Battery</xsl:when>
+<xsl:when test="@variable = 'sl_CodeChanged'"       > Code Changed</xsl:when>
+<xsl:when test="@variable = 'sl_LockChanged'"       > Lock Changed</xsl:when>
+<xsl:when test="@variable = 'sl_BatteryAlarm'"      > Battery Alarm</xsl:when>
+<xsl:when test="@variable = 'sl_UserCode'"          > User Code</xsl:when>
+<xsl:when test="@variable = 'Volume'"               > Volume</xsl:when>
+<xsl:when test="@variable = 'Input'"                > Input</xsl:when>
+<xsl:when test="@variable = 'Channel'"              > Channel</xsl:when>
+<xsl:when test="@variable = 'Title'"                > Title</xsl:when>
+<xsl:when test="@variable = 'URL'"                  > URL</xsl:when>
+<xsl:when test="@variable = 'ModeStatus'"           > Mode Status</xsl:when>
+<xsl:when test="@variable = 'FanStatus'"            > Fan Status</xsl:when>
+<xsl:when test="@variable = 'ModeState'"            > Mode State</xsl:when>
+<xsl:when test="@variable = 'ModeStateForEnergy'"   > Mode State (Energy)</xsl:when>
+<xsl:when test="@variable = 'ManageLeds'"           > Manage LEDs</xsl:when>
+<xsl:when test="@variable = 'FiresOffEvents'"       > Fires Off Events</xsl:when>
+<xsl:when test="@variable = 'MinPinSize'"           > Min Pin Size</xsl:when>
+<xsl:when test="@variable = 'MaxPinSize'"           > Max Pin Size</xsl:when>
+<xsl:when test="@variable = 'UserSuppliedWattage'"  > User Supplied Wattage</xsl:when>
+<xsl:when test="@variable = 'KWH'"                  > kWh</xsl:when>
+<xsl:when test="@variable = 'Watts'"                > Watts</xsl:when>
+<xsl:when test="@variable = 'ModeTarget'"           > Mode Target</xsl:when>
+<xsl:when test="@variable = 'CommFailure'"          > Comms Failure</xsl:when>
+<xsl:when test="@variable = 'Target'"               > Target</xsl:when>
+<xsl:when test="@variable = 'LastUpdate'"           > Last Update</xsl:when>
+<xsl:when test="@variable = 'LoadLevelTarget'"      > Load Level Target</xsl:when>
+<xsl:when test="@variable = 'LoadLevelStatus'"      > Load Level Status</xsl:when>
+<xsl:when test="@variable = 'LightSettings'"        > Light Settings</xsl:when>
+<xsl:when test="@variable = 'Scenes'"               > Scenes</xsl:when>
+<xsl:when test="@variable = 'Log'"                  > Log</xsl:when>
+<xsl:when test="@variable = 'Logging'"              > Logging</xsl:when>
+<xsl:when test="@variable = 'PollingEnabled'"       > Polling Enabled</xsl:when>
+<xsl:when test="@variable = 'PollingFrequency'"     > Polling Frequency</xsl:when>
+<xsl:when test="@variable = 'NumButtons'"           > #Buttons</xsl:when>
+<xsl:when test="@variable = 'Configured'"           > Configured</xsl:when>
+<xsl:when test="@variable = 'CurrentStatus'"        > Current Status</xsl:when>
+<xsl:when test="@variable = 'TransportState'"       > Transport State</xsl:when>
+<xsl:when test="@variable = 'TransportStatus'"      > Transport Status</xsl:when>
+<xsl:when test="@variable = 'TransportPlaySpeed'"   > Transport Play Speed</xsl:when>
+<xsl:when test="@variable = 'CurrentPlayMode'"      > Current Play Mode</xsl:when>
+<xsl:when test="@variable = 'CurrentTrackTitle'"    > Current Track Title</xsl:when>
+<xsl:when test="@variable = 'CurrentStreamTitle'"   > Current Stream Title</xsl:when>
+<xsl:when test="@variable = 'CurrentAlbumArt'"      > Current Album Art</xsl:when>
+<xsl:when test="@variable = 'CurrentTitle'"         > Current Title</xsl:when>
+<xsl:when test="@variable = 'CurrentDetails'"       > Current Details</xsl:when>
+<xsl:when test="@variable = 'CurrentArtist'"        > Current Artist</xsl:when>
+<xsl:when test="@variable = 'CurrentAlbum'"         > Current Album</xsl:when>
+<xsl:when test="@variable = 'CurrentTrack'"         > Current Track</xsl:when>
+<xsl:when test="@variable = 'CurrentTrackDuration'" > Current Track Duration</xsl:when>
+<xsl:when test="@variable = 'CurrentService'"       > Current Service</xsl:when>
+<xsl:when test="@variable = 'CurrentRadio'"         > Current Radio</xsl:when>
+<xsl:when test="@variable = 'ZoneName'"             > Zone Name</xsl:when>
+<xsl:when test="@variable = 'Icon'"                 > Icon</xsl:when>
+<xsl:when test="@variable = 'Preset1'"              > Preset 1</xsl:when>
+<xsl:when test="@variable = 'Preset2'"              > Preset 2</xsl:when>
+<xsl:when test="@variable = 'Preset3'"              > Preset 3</xsl:when>
+<xsl:when test="@variable = 'Preset4'"              > Preset 4</xsl:when>
+<xsl:when test="@variable = 'Preset5'"              > Preset 5</xsl:when>
+<xsl:when test="@variable = 'Preset6'"              > Preset 6</xsl:when>
+<xsl:when test="@variable = 'ColorTemperature'"     > Color Temperature</xsl:when>
+<xsl:when test="@variable = 'Status1'"              > Status 1</xsl:when>
+<xsl:when test="@variable = 'Status2'"              > Status 2</xsl:when>
+<xsl:when test="@variable = 'Status3'"              > Status 3</xsl:when>
+<xsl:when test="@variable = 'Status4'"              > Status 4</xsl:when>
+<xsl:when test="@variable = 'Status5'"              > Status 5</xsl:when>
+<xsl:when test="@variable = 'Status6'"              > Status 6</xsl:when>
+<xsl:when test="@variable = 'Status7'"              > Status 7</xsl:when>
+<xsl:when test="@variable = 'Status8'"              > Status 8</xsl:when>
+<xsl:when test="@variable = 'Text1'"                > Text 1</xsl:when>
+<xsl:when test="@variable = 'Text2'"                > Text 2</xsl:when>
+<xsl:when test="@variable = 'Codesets'"             > Codesets</xsl:when>
+<xsl:when test="@variable = 'Codeset'"              > Codeset</xsl:when>
+<xsl:when test="@variable = 'Hue'"                  > Hue</xsl:when>
+<xsl:when test="@variable = 'Saturation'"           > Saturation</xsl:when>
+<xsl:when test="@variable = 'LinkStatus'"           > Link Status</xsl:when>
+<xsl:when test="@variable = 'UUID'"                 > UUID</xsl:when>
+<xsl:when test="@variable = 'LowLevel'"             > LowLevel</xsl:when>
+<xsl:when test="@variable = 'MidLevel'"             > MidLevel</xsl:when>
+<xsl:when test="@variable = 'HighLevel'"            > HighLevel</xsl:when>
+<xsl:when test="@variable = 'LastRecipient'"        > Last Recipient</xsl:when>
+<xsl:when test="@variable = 'LastMsgSent'"          > Last Message Sent</xsl:when>
+<xsl:when test="@variable = 'Msg'"                  > Message</xsl:when>
+<xsl:when test="@variable = 'Debug'"                > Debug</xsl:when>
+<xsl:when test="@variable = 'State'"                > State</xsl:when>
+<xsl:when test="@variable = 'Options'"              > Options</xsl:when>
+<xsl:when test="@variable = 'Devices'"              > Devices</xsl:when>
+<xsl:when test="@variable = 'MaxLevel'"             > Maximum Level</xsl:when>
+<xsl:when test="@variable = 'MinInterval'"          > Minimum Interval</xsl:when>
+<xsl:when test="@variable = 'Remote'"               > Remote</xsl:when>
+<xsl:when test="@variable = 'MfrId'"                > Manufacturer Id</xsl:when>
+<xsl:when test="@variable = 'Last Check'"           > Last Check</xsl:when>
+<xsl:when test="../../@id = '1'"                    ><xsl:value-of select="concat(' ', @variable)"/></xsl:when>
+<xsl:otherwise                                      > FIXME <xsl:value-of select="@variable"/></xsl:otherwise>
+</xsl:choose>
+</xsl:variable>
+
+<xsl:variable name="ItemFormat">
+<xsl:choose>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSensor1' and @variable = 'CurrentTemperature'"           > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Cool' and @variable = 'CurrentSetpoint'"       > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Heat' and @variable = 'CurrentSetpoint'"       > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'FeelsLike'"                  > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'HeatIndex'"                  > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'DewPoint'"                   > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'WindChill'"                  > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'Forecast.0.LowTemperature'"  > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'Forecast.0.HighTemperature'" > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'Forecast.1.LowTemperature'"  > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'Forecast.1.HighTemperature'" > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'Forecast.2.LowTemperature'"  > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'Forecast.2.HighTemperature'" > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'Forecast.3.LowTemperature'"  > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'Forecast.3.HighTemperature'" > [%.1f F]</xsl:when>
+<xsl:when test="normalize-space($ItemType) = 'Number'"                                                                 > [%d]</xsl:when>
+<xsl:when test="normalize-space($ItemType) = 'DateTime'"                                                               > [%1$ta, %1$tm/%1$te %1$tR]</xsl:when>
+<xsl:when test="normalize-space($ItemType) = 'Contact'"                                                                > [%s]</xsl:when>
+<xsl:when test="normalize-space($ItemType) = 'Switch'"                                                                 ></xsl:when>
+<xsl:when test="normalize-space($ItemType) = 'Dimmer'"                                                                 > [%d] %</xsl:when>
+<xsl:otherwise                                                                                                         > [%s]</xsl:otherwise>
+</xsl:choose>
+</xsl:variable>
+
+<xsl:variable name="ItemIcon">
+<xsl:choose>
+<xsl:when test="normalize-space($ItemType) = 'DateTime'">&lt;calendar> </xsl:when>
+<xsl:when test="normalize-space($ItemType) = 'Contact'" >&lt;contact> </xsl:when>
+</xsl:choose>
+</xsl:variable>
+
+<xsl:variable name="ItemGroups">
+<xsl:choose>
+<xsl:when test="../../@room != '0'"><xsl:value-of select="concat('(GDevices,GRoom', ../../@room, ') ')"/></xsl:when>
+<xsl:otherwise>(GDevices) </xsl:otherwise>
+</xsl:choose>
+</xsl:variable>
+
+<xsl:if test="@variable != ''
+              and @service != 'urn:micasaverde-com:serviceId:ZWaveDevice1'
+              and @service != 'urn:schemas-upnp-org:service:RenderingControl:1'
+              and @service != 'urn:schemas-micasaverde-com:device:avmisc:1'
+              and @service != 'urn:micasaverde-com:serviceId:AlarmPartition1'
+              and @service != 'urn:demo-paradox-com:serviceId:AlarmPartition1'">
+<xsl:value-of select="substring(concat($ItemType, '         '), 1, 9)"/>
+<xsl:value-of select="$ItemName"/> &quot;<xsl:value-of select="$ItemDescription"/>
+<xsl:value-of select="$ItemFormat"/>&quot; <xsl:value-of select="$ItemIcon"/><xsl:value-of select="$ItemGroups"/>{mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,device:<xsl:value-of select="../../@id"/>/service/<xsl:value-of select="$ServiceAlias"/>/<xsl:value-of select="@variable"/>"}
+</xsl:if>
+</xsl:template>
+
+<xsl:template match="scenes">
+<xsl:for-each select="scene">
+<xsl:apply-templates select="."/>
+</xsl:for-each>
+</xsl:template>
+
+<xsl:template match="scene">
+<xsl:variable name="SceneName">
+<xsl:value-of select="translate(normalize-space(@name), $BAD_CHARS, '')"/>
+</xsl:variable>
+
+<xsl:variable name="SceneNameFixed">
+<xsl:value-of select="$SceneName"/>
+<xsl:if test="count(../scene[translate(normalize-space(@name), $BAD_CHARS, '') = $SceneName]) > 1">
+<xsl:value-of select="@id"/>
+</xsl:if>
+</xsl:variable>
+
+<xsl:variable name="SceneGroups">
+<xsl:choose>
+<xsl:when test="@room != '0'">(GScenes,GRoom<xsl:value-of select="@room"/>)</xsl:when>
+<xsl:otherwise>(GScenes)</xsl:otherwise>
+</xsl:choose>
+</xsl:variable>
+/* Scene - <xsl:value-of select="@name"/> */
+String   Scene<xsl:value-of select="$SceneNameFixed"/> "<xsl:value-of select="@name"/> Scene" &lt;sofa> <xsl:value-of select="$SceneGroups"/> {mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,scene:<xsl:value-of select="@id"/>/status", autoupdate="false"}
+Contact  Scene<xsl:value-of select="$SceneNameFixed"/>Active "Active [%s]" &lt;sofa> <xsl:value-of select="$SceneGroups"/> {mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,scene:<xsl:value-of select="@id"/>/active"}
+</xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
This is the initial checkin for a Tool that can extract Metadata from a live MiOS Unit, and generate an appropriate openHAB Items file.  It uses various rules, in the form of an XSLT file, to perform the common translations.

`README.md` included for usage information.

This tool is a formalization of the work at:
* http://forum.micasaverde.com/index.php/topic,30367.0.html

It's gone through several rounds of tuning, and is now being used to build working Items files of 1500-5000 Items from running MiOS systems.