### PR TITLE
Added support for Swiid ZCS-1 Cord Switch to the db

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -1780,5 +1780,18 @@
 			<ConfigFile>yale/yrd210.xml</ConfigFile>
 		</Product>
 	</Manufacturer>
+	<Manufacturer>
+                <Id>0166</Id>
+                <Name>Swiid</Name>
+                <Product>
+                        <Reference>
+                                <Type>0100</Type>
+                                <Id>0100</Id>
+                        </Reference>
+                        <Model>SW-ZCS-1</Model>
+                        <Label lang="en">Cord Switch</Label>
+                        <ConfigFile>swiid/swiidinter.xml</ConfigFile>
+                </Product>
+        </Manufacturer>
 	
 </Manufacturers>

--- a/bundles/binding/org.openhab.binding.zwave/database/swiid/SW-ZCS-1.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/swiid/SW-ZCS-1.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+    <Model>SwiidInter</Model>
+    <Label lang="en">Z-Wave Cord Switch</Label>
+    <CommandClasses>
+    	<Class><id>0x20</id></Class>
+    	<Class><id>0x25</id></Class>
+    	<Class><id>0x27</id></Class>
+    	<Class><id>0x72</id></Class>
+    	<Class><id>0x85</id></Class>
+    	<Class><id>0x86</id></Class>
+    </CommandClasses>
+    <Configuration>
+    	<Parameter>
+    		<Index>1</Index>
+    		<Type>list</Type>
+    		<Default>00</Default>
+    		<Size>1</Size>
+			<Label lang="en">Selects the switch mode. The value 255 is normal mode (switch on and off) and default operation.</Label>    			<Item>
+    			<Value>0</Value>
+    			<Label lang="en">Disabled</Label>
+    		</Item>
+    		<Item>
+				<Value>1</Value>
+    			<Label lang="en">Switch off only</Label>
+    		</Item>
+			<Item>
+    			<Value>2</Value>
+    			<Label lang="en">Switch off only</Label>
+    		</Item>
+    		<Help lang="en"></Help>
+    	</Parameter>
+    </Configuration>
+    <Associations>
+    	<Group>
+    		<Index>1</Index>
+    		<Maximum>5</Maximum>
+    		<Label lang="en">Group 1</Label>
+    	</Group>
+    	<Group>
+    		<Index>2</Index>
+    		<Maximum>5</Maximum>
+    		<Label lang="en">Group 2</Label>
+    	</Group>
+    </Associations>
+</Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/swiid/SW-ZCS-1.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/swiid/SW-ZCS-1.xml
@@ -14,21 +14,25 @@
     	<Parameter>
     		<Index>1</Index>
     		<Type>list</Type>
-    		<Default>00</Default>
+    		<Default>255</Default>
     		<Size>1</Size>
-			<Label lang="en">Selects the switch mode. The value 255 is normal mode (switch on and off) and default operation.</Label>    			<Item>
+			<Label lang="en">Switch All</Label>
+			<Item>
     			<Value>0</Value>
     			<Label lang="en">Disabled</Label>
     		</Item>
     		<Item>
 				<Value>1</Value>
-    			<Label lang="en">Switch off only</Label>
+    			<Label lang="en">Switch on only</Label>
     		</Item>
 			<Item>
     			<Value>2</Value>
     			<Label lang="en">Switch off only</Label>
     		</Item>
-    		<Help lang="en"></Help>
+    		<Item>
+    			<Value>255</Value>
+    			<Label lang="en">Fully enabled (Default)</Label>
+    		</Item>
     	</Parameter>
     </Configuration>
     <Associations>
@@ -41,6 +45,7 @@
     		<Index>2</Index>
     		<Maximum>5</Maximum>
     		<Label lang="en">Group 2</Label>
+    		<SetToController>true</SetToController>
     	</Group>
     </Associations>
 </Product>


### PR DESCRIPTION
Added definition for the Swiid ZCS-1 Cord Switch to the product database.