### PR TITLE
AlarmDecoder binding: handle hexadecimal zone code

### DIFF
--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBinding.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBinding.java
@@ -360,7 +360,12 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
 					parts.get(0).length());
 		}
 		try {
-			int numeric = Integer.parseInt(parts.get(1));
+			int numeric = 0;
+			try {
+				numeric = Integer.parseInt(parts.get(1));
+			} catch (NumberFormatException e) {
+				numeric = Integer.parseInt(parts.get(1), 16);
+			}
 			int upper = Integer.parseInt(parts.get(0).substring(1,6), 2);
 			int nbeeps = Integer.parseInt(parts.get(0).substring(6,7));
 			int lower = Integer.parseInt(parts.get(0).substring(7,17), 2);


### PR DESCRIPTION
Handle the case when the numeric zone code is a hex number.