### PR TITLE
Restore interrupted status to keep state

### DIFF
--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBusReaderScheduler.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBusReaderScheduler.java
@@ -108,6 +108,7 @@ public class KNXBusReaderScheduler {
 				}
 			} catch (InterruptedException e) {
 				sLogger.debug("Schedule executor restart failed: interrupted while waiting for termination.");
+				Thread.currentThread().interrupt();
 			}
 			mScheduledExecutorService = Executors.newScheduledThreadPool(KNXConnection.getNumberOfThreads());
 			sLogger.debug("Schedule executor restart: started.");


### PR DESCRIPTION
Currently, the interrupted thread status is cleared and swallowed for no reason.

When that catch block is executed (and it is sometimes on my machine), e.g., by the Calimero Link Notifier thread, it causes https://github.com/calimero-project/calimero/issues/14. 