### PR TITLE
zwave: add missing imports (for bundled jar files)

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.zwave/META-INF/MANIFEST.MF
@@ -24,7 +24,12 @@ Import-Package: gnu.io,
  org.osgi.service.cm,
  org.osgi.service.component,
  org.osgi.service.event,
- org.slf4j
+ org.slf4j,
+ javax.security.auth,
+ javax.xml.namespace,
+ javax.xml.stream,
+ javax.xml.transform,
+ javax.xml.transform.stream
 Export-Package: org.openhab.binding.zwave,org.openhab.binding.zwave.in
  ternal.config
 Bundle-DocURL: http://www.openhab.org


### PR DESCRIPTION
The OSGi specification mandates that a bundle declare all package
depenencies using either Import-Package or Require-Bundle. The one
exception to this rule is the java.* packages which is always delegated
to the boot classpath. All other packages dependencies must be declared
in the bundle's manifest file.

This OSGi bundle bundles a xstream jar file that is added to the
classpath. So the MANIFEST.MF of the xstream jar is not evaluated by the
OSGi framework. We have to add the packages, that are necessary for the used
xstream functionality to the import section of the MANIFEST.MF of this bundle.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>