### PR TITLE
InsteonPLM: 2845-222 Add support to battery level reading

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
@@ -494,7 +494,7 @@ public abstract class MessageHandler {
 				int cmd2 = (int) (msg.getByte("command2") & 0xff);
 				switch (cmd2) {
 				case 0x00: // this is a product data response message
-					int batteryLevel = msg.getByte("userData04") & 0xff;
+					int batteryLevel = msg.getByte("userData4") & 0xff;
 					logger.debug("{} got battery level {}", dev.getAddress(), batteryLevel);
 					m_feature.publish(new DecimalType(batteryLevel), StateChangeType.CHANGED);
 					break;

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
@@ -183,6 +183,15 @@
 	<command-handler command="OnOffType">NoOpCommandHandler</command-handler>
 	<poll-handler>NoPollHandler</poll-handler>
 </feature>
+<feature name="HiddenDoorBatteryLevel">
+	<message-dispatcher>GreedyDispatcher</message-dispatcher>
+	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x11" group="1">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x13" group="1">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x2e">HiddenDoorBatteryReplyHandler</message-handler>
+	<command-handler command="OnOffType">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
 <feature name="GenericContact">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
@@ -125,7 +125,8 @@ Example entry:
  <device productKey="F00.00.03">
      <model>2845-222</model>
      <description>Hidden Door Sensor</description>
-     <feature name="contact">GenericContact</feature>
+     <feature name="contact">WirelessMotionSensorContact</feature>
+     <feature name="batterylevel">HiddenDoorBatteryLevel</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 


### PR DESCRIPTION
This is a minor addition to the Insteon PLM binding (originally maintained by Bernd Pfrommer).

The new handler addition is based on an existing one and just change the userData field from where to extract the information. This was compiled and tested locally as logs below:

2015-02-12 00:02:37 DEBUG o.o.b.i.i.device.DeviceFeature[:210]- XX.XX.XX:GenericLastTime publishing: 2015-02-12T00:02:37
2015-02-12 00:02:38 DEBUG o.o.b.i.InsteonPLMActiveBinding[:511]- got msg: IN:Cmd:0x51|fromAddress:XX.XX.XX|toAddress:MM.MM.MM|messageFlags:0x1B=DIRECT:3:2|command1:0x2E|command2:0x00|userData1:0x01|userData2:0x01|userData3:0x21|userData4:0x55|userData5:0xFF|userData6:0x0C|userData7:0x40|userData8:0x00|userData9:0x00|userData10:0x00|userData11:0x00|userData12:0x00|userData13:0x00|userData14:0xD2|
2015-02-12 00:02:38 DEBUG o.o.b.i.i.d.MessageHandler[:227]- NoOpMsgHandler ignore msg 0x2E: IN:Cmd:0x51|fromAddress:XX.XX.XX|toAddress:MM.MM.MM|messageFlags:0x1B=DIRECT:3:2|command1:0x2E|command2:0x00|userData1:0x01|userData2:0x01|userData3:0x21|userData4:0x55|userData5:0xFF|userData6:0x0C|userData7:0x40|userData8:0x00|userData9:0x00|userData10:0x00|userData11:0x00|userData12:0x00|userData13:0x00|userData14:0xD2|
2015-02-12 00:02:38 DEBUG o.o.b.i.i.d.MessageHandler[:498]- XX.XX.XX got battery level 85
2015-02-12 00:02:38 DEBUG o.o.b.i.i.device.DeviceFeature[:210]- XX.XX.XX:HiddenDoorBatteryLevel publishing: 85


Since this does not change any existing feature and only adds up to a device already working I believe it is safe to merge.

@berndpfrommer what do you thing about this pull request? Do you have objections, suggestions or changes required before integration?

