### PR TITLE
Add system property `disableHtmlCache`

### DIFF
--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/AbstractWidgetRenderer.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/AbstractWidgetRenderer.java
@@ -51,7 +51,9 @@ abstract public class AbstractWidgetRenderer implements WidgetRenderer {
 	protected static final String SNIPPET_LOCATION = "snippets/";
 
 	/* a local cache so we do not have to read the snippets over and over again from the bundle */
-	protected static final Map<String, String> snippetCache = new HashMap<String, String>(); 
+	protected static final Map<String, String> snippetCache = new HashMap<String, String>();
+	
+	protected boolean useSnippetCache = true;
 
 	public void setItemUIRegistry(ItemUIRegistry itemUIRegistry) {
 		this.itemUIRegistry = itemUIRegistry;
@@ -66,6 +68,7 @@ abstract public class AbstractWidgetRenderer implements WidgetRenderer {
 	}
 
 	protected void activate(ComponentContext context) {
+		useSnippetCache = !Boolean.valueOf(System.getProperty("disableHtmlCache", "false"));
 	}
 
 	protected void deactivate(ComponentContext context) {
@@ -87,7 +90,9 @@ abstract public class AbstractWidgetRenderer implements WidgetRenderer {
 			if(entry!=null) {
 				try {
 					snippet = IOUtils.toString(entry.openStream());
-					snippetCache.put(elementType, snippet);
+					if (useSnippetCache) {
+						snippetCache.put(elementType, snippet);	
+					}
 				} catch (IOException e) {
 					logger.warn("Cannot load snippet for element type '{}'", elementType, e);
 				}


### PR DESCRIPTION
With JVM argument `-DdisableHtmlCache` or `-DdisableHtmlCache=true` you can disable the HTML snippet cache. This is very useful for developing the web parts. Otherwise you always have to restart the runtime to see the changes on html files.