### PR TITLE
Support for changing operation mode of novelanheatpump

### DIFF
--- a/bundles/binding/org.openhab.binding.novelanheatpump/OSGI-INF/heatpumpbinding.xml
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/OSGI-INF/heatpumpbinding.xml
@@ -14,7 +14,9 @@
    
    <service>
       <provide interface="org.osgi.service.cm.ManagedService"/>
+      <provide interface="org.osgi.service.event.EventHandler"/>      
    </service>
+   <property name="event.topics" type="String" value="openhab/command/*"/>   
    <property name="service.pid" type="String" value="org.openhab.novelanheatpump"/>
    
    <reference bind="setEventPublisher" cardinality="1..1" interface="org.openhab.core.events.EventPublisher" name="EventPublisher" policy="dynamic" unbind="unsetEventPublisher"/>

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/HeatpumpCommandType.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/HeatpumpCommandType.java
@@ -304,7 +304,37 @@ public enum HeatpumpCommandType {
 			command = "temperature_solar_storage";
 			itemClass = NumberItem.class;
 		}
+	},
+	
+	//in german Heizung Betriebsart
+	TYPE_HEATING_OPERATION_MODE {
+		{
+			command = "heating_operation_mode";
+			itemClass = NumberItem.class;
+		}
+	},	
+	//in german Heizung Temperatur (Parallelverschiebung)
+	TYPE_HEATING_TEMPERATURE {
+		{
+			command = "heating_temperatur";
+			itemClass = NumberItem.class;
+		}
+	},	
+	//in german Warmwasser Betriebsart
+	TYPE_WARMWATER_OPERATION_MODE {
+		{
+			command = "warmwater_operation_mode";
+			itemClass = NumberItem.class;
+		}
+	},	
+	//in german Warmwasser Temperatur
+	TYPE_WARMWATER_TEMPERATURE {
+		{
+			command = "warmwater_temperatur";
+			itemClass = NumberItem.class;
+		}
 	};
+	
 
 	
 	/** Represents the heatpump command as it will be used in *.items configuration */

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/HeatpumpOperationMode.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/HeatpumpOperationMode.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.novelanheatpump;
+
+public enum HeatpumpOperationMode {
+	// in german Automatik
+	AUTOMATIC(0),
+	// in german Aus
+	OFF(4),
+	// in german Party
+	PARTY(2),
+	// in german Urlaub
+	HOLIDAY(3),
+	// in german Zuzeizer
+	AUXILIARY_HEATER(1);
+	
+	private int value;
+	
+	private HeatpumpOperationMode(int value){
+		this.value = value;
+	}
+	
+	public int getValue(){
+		return value;
+	}
+	
+	public static HeatpumpOperationMode fromValue(int value){
+		for(HeatpumpOperationMode mode : HeatpumpOperationMode.values()){
+			if(mode.value == value){
+				return mode;
+			}
+		}
+		return null;
+	}
+	
+
+}

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
@@ -49,6 +49,11 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
 	public static int PARAM_HEATING_OPERATION_MODE = 3;
 	/** Parameter code for heating temperature */
 	public static int PARAM_HEATING_TEMPERATURE = 1;
+	/** Parameter code for warmwater operation mode */
+	public static int PARAM_WARMWATER_OPERATION_MODE = 4;
+	/** Parameter code for warmwater temperature */
+	public static int PARAM_WARMWATER_TEMPERATURE = 2;
+	
 
 	/** Default refresh interval (currently 1 minute) */
 	private long refreshInterval = 60000L;
@@ -148,6 +153,8 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
 
 			handleEventType(new DecimalType((double) heatpumpParams[PARAM_HEATING_TEMPERATURE] / 10), HeatpumpCommandType.TYPE_HEATING_TEMPERATURE);
 			handleEventType(new DecimalType(heatpumpParams[PARAM_HEATING_OPERATION_MODE]), HeatpumpCommandType.TYPE_HEATING_OPERATION_MODE);
+			handleEventType(new DecimalType((double) heatpumpParams[PARAM_WARMWATER_TEMPERATURE] / 10), HeatpumpCommandType.TYPE_WARMWATER_TEMPERATURE);
+			handleEventType(new DecimalType(heatpumpParams[PARAM_WARMWATER_OPERATION_MODE]), HeatpumpCommandType.TYPE_WARMWATER_OPERATION_MODE);
 			
 
 		} catch (UnknownHostException e) {
@@ -352,6 +359,33 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
 						}
 					}else{
 						logger.warn("Headpump heating temperature item " + itemName + " must be from type:" + DecimalType.class.getSimpleName());						
+					}
+					break;
+				case TYPE_WARMWATER_OPERATION_MODE:
+					if(command instanceof DecimalType){
+						int value = ((DecimalType)command).intValue();
+						HeatpumpOperationMode mode = HeatpumpOperationMode.fromValue(value);
+						if(mode != null){
+							if(sendParamToHeatpump(PARAM_WARMWATER_OPERATION_MODE, mode.getValue())){
+								logger.info("Heatpump warmwater operation mode set to " + mode.name());
+							}
+							
+						}else{
+							logger.warn("Headpump warmwater operation mode with value " + value + " is unknown.");
+						}
+					}else{
+						logger.warn("Headpump warmwater operation mode item " + itemName + " must be from type:" + DecimalType.class.getSimpleName());						
+					}
+					break;
+				case TYPE_WARMWATER_TEMPERATURE:
+					if(command instanceof DecimalType){
+						float temperature = ((DecimalType)command).floatValue();
+						int value = (int)(temperature * 10.);
+						if(sendParamToHeatpump(PARAM_WARMWATER_TEMPERATURE, value)){
+							logger.info("Heatpump warmwater temeprature set to " + temperature);							
+						}
+					}else{
+						logger.warn("Headpump warmwater temperature item " + itemName + " must be from type:" + DecimalType.class.getSimpleName());						
 					}
 					break;
 				default:

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
@@ -13,14 +13,19 @@ import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Dictionary;
+import java.util.Iterator;
 
+import org.apache.commons.collections.IteratorUtils;
 import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.novelanheatpump.HeatPumpBindingProvider;
 import org.openhab.binding.novelanheatpump.HeatpumpCommandType;
+import org.openhab.binding.novelanheatpump.HeatpumpOperationMode;
 import org.openhab.binding.novelanheatpump.i18n.Messages;
+import org.openhab.binding.novelanheatpump.internal.HeatPumpGenericBindingProvider.HeatPumpBindingConfig;
 import org.openhab.core.binding.AbstractActiveBinding;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.Command;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 import org.slf4j.Logger;
@@ -39,6 +44,11 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
 	
 	private static final Logger logger = LoggerFactory.getLogger(HeatPumpBinding.class);
 	private static final SimpleDateFormat sdateformat = new SimpleDateFormat("dd.MM.yy HH:mm"); //$NON-NLS-1$
+	
+	/** Parameter code for heating operation mode */
+	public static int PARAM_HEATING_OPERATION_MODE = 3;
+	/** Parameter code for heating temperature */
+	public static int PARAM_HEATING_TEMPERATURE = 1;
 
 	/** Default refresh interval (currently 1 minute) */
 	private long refreshInterval = 60000L;
@@ -131,6 +141,14 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
 			handleEventType(new StringType(heatpumpState), HeatpumpCommandType.TYPE_HEATPUMP_STATE);
 			String heatpumpExtendedState = getExtendeStateString(heatpumpValues) + ": " + formatHours(heatpumpValues[120]); //$NON-NLS-1$
 			handleEventType(new StringType(heatpumpExtendedState), HeatpumpCommandType.TYPE_HEATPUMP_EXTENDED_STATE);
+
+
+			//read all parameters
+			int[] heatpumpParams = connector.getParams();
+
+			handleEventType(new DecimalType((double) heatpumpParams[PARAM_HEATING_TEMPERATURE] / 10), HeatpumpCommandType.TYPE_HEATING_TEMPERATURE);
+			handleEventType(new DecimalType(heatpumpParams[PARAM_HEATING_OPERATION_MODE]), HeatpumpCommandType.TYPE_HEATING_OPERATION_MODE);
+			
 
 		} catch (UnknownHostException e) {
 			logger.warn("the given hostname '{}' of the Novela heatpump is unknown", ip);
@@ -301,5 +319,84 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
 	protected String getName() {
 		return "Heatpump Refresh Service";
 	}
+	
+	@Override
+	protected void internalReceiveCommand(String itemName, Command command){
+		HeatPumpGenericBindingProvider provider = findFirstProvider();
+		if(provider != null){
+			HeatPumpBindingConfig bindingConfig = provider.getHeatPumpBindingConfig(itemName);
+			HeatpumpCommandType commandType =bindingConfig.getType();
+			switch(commandType){
+				case TYPE_HEATING_OPERATION_MODE:
+					if(command instanceof DecimalType){
+						int value = ((DecimalType)command).intValue();
+						HeatpumpOperationMode mode = HeatpumpOperationMode.fromValue(value);
+						if(mode != null){
+							if(sendParamToHeatpump(PARAM_HEATING_OPERATION_MODE, mode.getValue())){
+								logger.info("Heatpump heating operation mode set to " + mode.name());
+							}
+							
+						}else{
+							logger.warn("Headpump heating operation mode with value " + value + " is unknown.");
+						}
+					}else{
+						logger.warn("Headpump heating operation mode item " + itemName + " must be from type:" + DecimalType.class.getSimpleName());						
+					}
+					break;
+				case TYPE_HEATING_TEMPERATURE:
+					if(command instanceof DecimalType){
+						float temperature = ((DecimalType)command).floatValue();
+						int value = (int)(temperature * 10.);
+						if(sendParamToHeatpump(PARAM_HEATING_TEMPERATURE, value)){
+							logger.info("Heatpump heating temeprature set to " + temperature);							
+						}
+					}else{
+						logger.warn("Headpump heating temperature item " + itemName + " must be from type:" + DecimalType.class.getSimpleName());						
+					}
+					break;
+				default:
+			}
+		}
+		
+	}
+
+	/**
+	 * Set a parameter on the Novela heatpump.
+	 * 
+	 * @param param
+	 * @param value
+	 */
+	private boolean sendParamToHeatpump(int param, int value) {
+		HeatpumpConnector connector = new HeatpumpConnector(ip);
+		try {
+			connector.connect();
+			return connector.setParam(param, value);
+		} catch (UnknownHostException e) {
+			logger.warn("the given hostname '{}' of the Novela heatpump is unknown", ip);
+			return false;
+		} catch (IOException e) {
+			logger.warn("couldn't establish network connection [host '{}']", ip);
+			return false;
+		} finally {
+			if (connector != null) {
+				connector.disconnect();
+			}
+		}
+	}
+
+	/**
+	 * Finds the binding provider.
+	 * @return
+	 */
+	private HeatPumpGenericBindingProvider findFirstProvider() {
+		Iterator<HeatPumpBindingProvider> it = providers.iterator();
+		while(it.hasNext()){
+			HeatPumpBindingProvider provider = it.next();
+			if(provider instanceof HeatPumpGenericBindingProvider){
+				return (HeatPumpGenericBindingProvider)provider; 
+			}
+		}
+		return null;
+	}	
 
 }

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpGenericBindingProvider.java
@@ -109,6 +109,10 @@ public class HeatPumpGenericBindingProvider extends AbstractGenericBindingProvid
 		return itemNames.toArray(new String[itemNames.size()]);
 	}
 	
+	public HeatPumpBindingConfig getHeatPumpBindingConfig(String itemName){
+		return (HeatPumpBindingConfig)bindingConfigs.get(itemName);
+	}	
+	
 	
 	static class HeatPumpBindingConfig implements BindingConfig {
 		

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatpumpConnector.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatpumpConnector.java
@@ -57,6 +57,62 @@ public class HeatpumpConnector {
 	}
 
 	/**
+	 * read the parameters of the heatpump
+	 * @return
+	 * @throws IOException
+	 */
+	public int[] getParams() throws IOException {
+		int[] heatpump_values = null;
+		while (datain.available() > 0){
+			datain.readByte();
+		}
+		dataout.writeInt(3003);
+		dataout.writeInt(0);
+		dataout.flush();
+		if (datain.readInt() != 3003) {
+			return null;
+		}
+		//int stat = datain.readInt();
+		int arraylength = datain.readInt();
+		heatpump_values = new int[arraylength];
+
+		
+		for (int i = 0; i < arraylength; i++)
+			heatpump_values[i] = datain.readInt();
+		return heatpump_values;
+	}	
+	
+	/**
+	 * set a parameter of the heatpump
+	 * @param param
+	 * @param value
+	 * @return
+	 * @throws IOException
+	 */
+	public boolean setParam(int param, int value) throws IOException {
+		while (datain.available() > 0){
+			datain.readByte();
+		}
+		dataout.writeInt(3002);
+		dataout.writeInt(param);
+		dataout.writeInt(value);
+		dataout.flush();
+
+		int cmd = datain.readInt();
+		int resp = datain.readInt();
+		if (cmd != 3002) {
+			logger.error("can't write parameter " + param + " with value " + value +" to heatpump.");
+			return false;
+		}else{
+			if(logger.isDebugEnabled()){
+				logger.debug("successful parameter" + param + " with value " + value +" to heatpump written.");
+			}
+			return true;
+		}
+
+	}		
+	
+	/**
 	 * read the internal state of the heatpump
 	 * @return a array with all internal data of the heatpump
 	 * @throws IOException indicate that no data can be read from the heatpump


### PR DESCRIPTION
I added for the binding 'org.openhab.binding.novelanheatpump' the feature for changing the operation mode for heating and warmwater. The items are:
    
    Number heatpump_heating_operation_mode   "Heizung Betriebsart [%.0f]"  (gHeatpump) { novelanheatpump="heating_operation_mode" }
    Number heatpump_heating_temperatur   "Heizung Temperatur [%.1f]"  (gHeatpump) { novelanheatpump="heating_temperatur" }
    Number heatpump_warmwater_operation_mode   "Warmwasser Betriebsart [%.0f]"  (gHeatpump) { novelanheatpump="warmwater_operation_mode" }
    Number heatpump_warmwater_temperatur   "Warmwasser Temperatur [%.1f]"  (gHeatpump) { novelanheatpump="warmwater_temperatur" }

I'm new heare. Where can I update the documentation?

Best regards
Michael