### PR TITLE
Parameter 121 for doorsensor incorrectly defined as byte

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/aeon/doorsensor.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/aeon/doorsensor.xml
@@ -66,9 +66,9 @@
                 </Parameter>
                 <Parameter>
                         <Index>121</Index>
-                        <Type>byte</Type>
-                        <Default>256</Default>
-                        <Size>1</Size>
+                        <Type>int</Type>
+                        <Default>4</Default>
+                        <Size>4</Size>
                         <Label lang="en">Send those commands to associated devices on open/close/tamper events</Label>
 						<Help lang="en"><![CDATA[Bit mapped<BR/>
 						0	   ->  	Battery report<BR/>


### PR DESCRIPTION
Fixing as length 4 int (see: http://www.pepper1.net/zwavedb/device/120)