### PR TITLE
Treat thermostat mode SET as a REPORT

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatModeCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatModeCommandClass.java
@@ -95,12 +95,15 @@ ZWaveCommandClassDynamicState {
 		logger.debug("NODE {}: Received Thermostat Mode Request", this.getNode().getNodeId());
 		int command = serialMessage.getMessagePayloadByte(offset);
 		switch (command) {
-		case THERMOSTAT_MODE_SET:
 		case THERMOSTAT_MODE_GET:
 		case THERMOSTAT_MODE_SUPPORTED_GET:
 			logger.warn("NODE {}: Command {} not implemented.", 
 				this.getNode().getNodeId(), command);
 			return;
+		case THERMOSTAT_MODE_SET:
+			logger.trace("NODE {}: Process Thermostat Mode Get as Report", this.getNode().getNodeId());
+			processThermostatModeReport(serialMessage, offset, endpoint);
+			break;
 		case THERMOSTAT_MODE_SUPPORTED_REPORT:
 			logger.debug("NODE {}: Process Thermostat Supported Mode Report", this.getNode().getNodeId());
 


### PR DESCRIPTION
This treats a SET as a REPORT. This can happen on the HRT4 systems that have a separate
thermostat controller that controls a boiler controller. The thermostat is sending the SET MODE
command to the boiler, and by handling this command here we find out as well.
https://github.com/openhab/openhab/issues/2170