### PR TITLE
Hue Binding throws NPE on invalid IP

### DIFF
--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBinding.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBinding.java
@@ -94,6 +94,10 @@ public class HueBinding extends AbstractActiveBinding<HueBindingProvider> implem
 			// Observation : If the power of a hue lamp is removed, the status is not updated in hue hub.
 			// The heartbeat functionality should fix this, but 
 			HueSettings settings = activeBridge.getSettings();
+			if (settings == null) {
+				logger.debug("Hue settings were null, maybe misconfigured bridge IP.");
+				return;
+			}
 			for (int i = 1; i <= settings.getCount(); i++) {
 				HueBulb bulb = bulbCache.get(i);
 				if (bulb == null) {


### PR DESCRIPTION
If openhab.cfg has a wrong IP set for Hue bridge, openHAB tries to fetch the json, which is null. The HueBinding::execute did not handle this correctly.
