### PR TITLE
MiOS Binding: Bugfix for #2117 (Reduce logs/change events)

### DIFF
--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosBinding.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosBinding.java
@@ -468,9 +468,8 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 						// unnecessary manner.
 						//
 						if (incremental) {
-							logger.debug(
-									"internalPropertyUpdate: Updating (Incremental) itemName '{}' with value '{}'",
-									itemName, value);
+							logger.debug("internalPropertyUpdate: BOUND (Incr) Updating '{} {mios=\"{}\"}' to '{}'",
+									itemName, property, value);
 
 							eventPublisher.postUpdate(itemName, value);
 						} else {
@@ -481,14 +480,14 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 									|| (UnDefType.UNDEF.equals(oldValue) && !UnDefType.UNDEF.equals(value))
 									|| !oldValue.equals(value)) {
 								logger.debug(
-										"internalPropertyUpdate: Updating (Full) itemName '{}' with value '{}', oldValue '{}'",
-										new Object[] { itemName, value, oldValue });
+										"internalPropertyUpdate: BOUND (Full) Updating '{} {mios=\"{}\"}' to '{}', was '{}'",
+										new Object[] { itemName, property, value, oldValue });
 
 								eventPublisher.postUpdate(itemName, value);
 							} else {
 								logger.trace(
-										"internalPropertyUpdate: Ignoring (Full) itemName '{}' with value '{}', oldValue '{}'",
-										new Object[] { itemName, value, oldValue });
+										"internalPropertyUpdate: BOUND (Full) Ignoring '{} {mios=\"{}\"}' to '{}', was '{}'",
+										new Object[] { itemName, property, value, oldValue });
 							}
 						}
 						bound++;
@@ -503,7 +502,7 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 		if (bound == 0) {
 			logger.trace("internalPropertyUpdate: NOT BOUND {mios=\"{}\"}, value={}", property, value);
 		} else {
-			logger.debug("internalPropertyUpdate: BOUND {mios=\"{}\"}, value={}, bound {} time(s)", new Object[] {
+			logger.trace("internalPropertyUpdate: BOUND {mios=\"{}\"}, value={}, bound {} time(s)", new Object[] {
 					property, value, bound });
 		}
 	}


### PR DESCRIPTION
Bug fix for issue #2117 MiOS Binding - Reduce # of changed Items per MiOS Long-poll response

Only emit the Device Id IF at least one state-variable has been changed on the MiOS Device _and_ move the Device Id "device:nnnn/id" to the end of the list of attributes changed, in a given batch of changes for a Device.  This allows users to process Rules off the "batch of changes" as needed.  This can be handy if cross-Item validation Rules are present.

Reduce the # of log lines emitted during Debug mode, making the logs easier to read.

There are cases that MiOS sends out Device change records that contain no UPnP State Variable changes, they're effectively empty with the exception of the "device:nnnn/status" entry.  These are generating noise in the log files.

Use local Device and Scene caches for "status" attribute to avoid duplicate changes in openHAB.  MiOS has a bug where it'll repeatedly send the same "status" value for Devices and Scenes, even when they haven't changed.  This will result in many (many!) duplicate values being published into openHAB, and the resulting Rule executions and Log output.  This change addresses that problem by retaining local Device and Scene caches for the "status" attribute (only).  We cannot use openHAB/ItemRegistry here, since values are applied async, and we could get ourselves into an inconsistent state.  The reduction in Log output (events.log) alone is about 85% in my system, which greatly reduces the IO write contention on rPi and Odroid Flash filesystems.