### PR TITLE
MiOS Binding - Add support for Color Item for Device Bindings (Bugfix #2116 )

### DIFF
--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/DeviceBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/DeviceBindingConfig.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
 
 import org.openhab.binding.mios.internal.MiosActivator;
 import org.openhab.core.items.Item;
+import org.openhab.core.library.items.ColorItem;
 import org.openhab.core.transform.TransformationException;
 import org.openhab.core.transform.TransformationHelper;
 import org.openhab.core.transform.TransformationService;
@@ -460,5 +461,15 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 		}
 
 		return result;
+	}
+
+	@Override
+	public void validateItemType(Item item) throws BindingConfigParseException {
+		Class<? extends Item> t = getItemType();
+
+		// Add support for Color Device Items.
+		if (!(t == ColorItem.class)) {
+			super.validateItemType(item);
+		}
 	}
 }

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/MiosBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/MiosBindingConfig.java
@@ -15,6 +15,7 @@ import java.util.regex.Pattern;
 import org.openhab.binding.mios.internal.MiosActivator;
 import org.openhab.core.binding.BindingConfig;
 import org.openhab.core.items.Item;
+import org.openhab.core.library.items.ColorItem;
 import org.openhab.core.library.items.ContactItem;
 import org.openhab.core.library.items.DateTimeItem;
 import org.openhab.core.library.items.DimmerItem;
@@ -24,6 +25,7 @@ import org.openhab.core.library.items.StringItem;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.library.types.PercentType;
@@ -352,6 +354,8 @@ public abstract class MiosBindingConfig implements BindingConfig {
 				} catch (NumberFormatException nfe) {
 					result = DateTimeType.valueOf(value);
 				}
+			} else if (itemType.isAssignableFrom(ColorItem.class)) {
+				result = HSBType.valueOf(value);
 			} else {
 				result = StringType.valueOf(value);
 			}


### PR DESCRIPTION
For the most part, this was removing the restriction that would error/exception when users Bound MiOS StateVariables against a Color Item.

This is the bugfix for #2116