### PR TITLE
Set lastEventTime to actual time when restarting

### DIFF
--- a/bundles/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicCommunicator.java
+++ b/bundles/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicCommunicator.java
@@ -87,8 +87,10 @@ public class HomematicCommunicator implements HomematicCallbackReceiver {
 
 				homematicCallbackServer.start();
 				homematicClient.registerCallback();
-
+				
 				scheduleFirstRefresh();
+
+				lastEventTime = System.currentTimeMillis();
 			} catch (Exception e) {
 				logger.error("Could not start Homematic communicator: " + e.getMessage(), e);
 				stop();

--- a/bundles/binding/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/HttpBinding.java
+++ b/bundles/binding/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/HttpBinding.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.http.HttpBindingProvider;
 import org.openhab.core.binding.AbstractActiveBinding;
+import org.openhab.core.binding.BindingProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.ContactItem;
 import org.openhab.core.library.items.DateTimeItem;
@@ -88,6 +89,24 @@ public class HttpBinding extends AbstractActiveBinding<HttpBindingProvider> impl
 	public HttpBinding() {
 	}
 	
+	@Override
+	public void bindingChanged(BindingProvider provider, String itemName) {
+		lastUpdateMap.remove(itemName);
+		synchronized(itemCacheLock) {
+		   itemCache.remove(itemName);
+		}
+		super.bindingChanged(provider, itemName);
+	}
+
+	@Override
+	public void allBindingsChanged(BindingProvider provider) {
+		lastUpdateMap.clear();
+		synchronized(itemCacheLock) {
+			itemCache.clear();
+		}
+		super.allBindingsChanged(provider);
+	}
+
 	/**
      * @{inheritDoc}
      */


### PR DESCRIPTION
Set lastEventTime when restarting, so the binding is only restarted every alive.interval. Without this fix it will be restarted every 60 seconds in configurations with only a few components and low communication.

I currently only have one 4-channel switch and no sensors, so there is not a lot of communication/events. 
Without that fix, communication is restarted every 60 seconds after the first alive interval is over. 

I think it is good to reset the time interval when reconnecting, because we know we just had a successful connection/communication with the CCU even if there were no new events.

also see:
https://groups.google.com/forum/#!searchin/openhab/homematic$2060/openhab/dmAh25FyA98/IcO5jwWbw7MJ


