### PR TITLE
reset lastUpdateMap and itemCache on binding change

### DIFF
--- a/bundles/binding/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/HttpBinding.java
+++ b/bundles/binding/org.openhab.binding.http/src/main/java/org/openhab/binding/http/internal/HttpBinding.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.http.HttpBindingProvider;
 import org.openhab.core.binding.AbstractActiveBinding;
+import org.openhab.core.binding.BindingProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.ContactItem;
 import org.openhab.core.library.items.DateTimeItem;
@@ -88,6 +89,24 @@ public class HttpBinding extends AbstractActiveBinding<HttpBindingProvider> impl
 	public HttpBinding() {
 	}
 	
+	@Override
+	public void bindingChanged(BindingProvider provider, String itemName) {
+		lastUpdateMap.remove(itemName);
+		synchronized(itemCacheLock) {
+		   itemCache.remove(itemName);
+		}
+		super.bindingChanged(provider, itemName);
+	}
+
+	@Override
+	public void allBindingsChanged(BindingProvider provider) {
+		lastUpdateMap.clear();
+		synchronized(itemCacheLock) {
+			itemCache.clear();
+		}
+		super.allBindingsChanged(provider);
+	}
+
 	/**
      * @{inheritDoc}
      */


### PR DESCRIPTION
implement bindingChanged and allBindingsChanged to reset lastUpdateMap and itemCache

Background: I have a http binding with a long refresh interval (only refreshing once a day), if i change any items file, my http items get reset to "undefined" state and may stay in this state for one more day. 

With this fix items get scheduled for immediate refresh when the the item model is reloaded/changed so the items get re-populated faster
