### PR TITLE
Set lastEventTime to actual time when restarting

### DIFF
--- a/bundles/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicCommunicator.java
+++ b/bundles/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/communicator/HomematicCommunicator.java
@@ -87,8 +87,10 @@ public class HomematicCommunicator implements HomematicCallbackReceiver {
 
 				homematicCallbackServer.start();
 				homematicClient.registerCallback();
-
+				
 				scheduleFirstRefresh();
+
+				lastEventTime = System.currentTimeMillis();
 			} catch (Exception e) {
 				logger.error("Could not start Homematic communicator: " + e.getMessage(), e);
 				stop();


### PR DESCRIPTION
Set lastEventTime when restarting, so the binding is only restarted every alive.interval. Without this fix it will be restarted every 60 seconds in configurations with only a few components and low communication.

I currently only have one 4-channel switch and no sensors, so there is not a lot of communication/events.
Without that fix, communication is restarted every 60 seconds after the first alive interval is over.

I think it is good to reset the time interval when reconnecting, because we know we just had a successful connection/communication with the CCU even if there were no new events.

also see:
https://groups.google.com/forum/#!searchin/openhab/homematic$2060/openhab/dmAh25FyA98/IcO5jwWbw7MJ