### PR TITLE
DSC alarm now sends user code over serial interface

### DIFF
--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmActiveBinding.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmActiveBinding.java
@@ -495,7 +495,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
     	switch (connectorType) {
 	    	case SERIAL:
 	     		if (api == null) {
-	    			api = new API(serialPort, baudRate);
+	    			api = new API(serialPort, baudRate, userCode);
 	    		}
 	     		break;
 	    	case TCP:

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
@@ -78,13 +78,20 @@ public class API {
 	 * @param sPort
 	 * @param baud
 	 */	
-	public API(String sPort, int baud) {
+	public API(String sPort, int baud, String userCode) {
 		if (StringUtils.isNotBlank(sPort)) {
 			serialPort = sPort;
 		}
 
 		if(isValidBaudRate(baud))
 			baudRate = baud;
+		
+		if (StringUtils.isNotBlank(userCode)) {
+			this.dscAlarmUserCode = userCode;
+		}
+		
+		//The IT-100 requires 6 digit codes. Shorter codes are right padded with 0.
+		this.dscAlarmUserCode = StringUtils.rightPad(dscAlarmUserCode, 6, '0');
 
 		connectorType = DSCAlarmConnectorType.SERIAL;
 	}


### PR DESCRIPTION
When communicating with a DSC alarm system over the IT-100 interface, a user code is required to disarm the system. This user code was being sent when using an envisalink connection to DSC, and we reuse that code for the serial connection with this change. The code is also padded to 6 digits per the IT-100 Developer Guide.

This fixes #2202