### PR TITLE
Proposal for an Item created event in rules

### DIFF
--- a/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/Rules.xtext
+++ b/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/Rules.xtext
@@ -27,6 +27,7 @@ EventTrigger:
 	UpdateEventTrigger |
 	CommandEventTrigger |
 	ChangedEventTrigger |
+	CreatedEventTrigger |
 	TimerTrigger |
 	SystemTrigger
 ;
@@ -41,7 +42,11 @@ UpdateEventTrigger:
 
 ChangedEventTrigger:
 	'Item' item=ItemName 'changed' ('from' oldState=ValidState)? ('to' newState=ValidState)?
-;		
+;
+
+CreatedEventTrigger:
+	'Item' item=ItemName 'created'
+;			
 
 TimerTrigger:
 	'Time' 'cron' cron=STRING |

--- a/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/internal/engine/RuleEngine.java
+++ b/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/internal/engine/RuleEngine.java
@@ -15,6 +15,7 @@ import static org.openhab.model.rule.internal.engine.RuleTriggerManager.TriggerT
 import static org.openhab.model.rule.internal.engine.RuleTriggerManager.TriggerTypes.SHUTDOWN;
 import static org.openhab.model.rule.internal.engine.RuleTriggerManager.TriggerTypes.STARTUP;
 import static org.openhab.model.rule.internal.engine.RuleTriggerManager.TriggerTypes.UPDATE;
+import static org.openhab.model.rule.internal.engine.RuleTriggerManager.TriggerTypes.CREATE;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -200,6 +201,10 @@ public class RuleEngine implements EventHandler, ItemRegistryChangeListener, Sta
 			if (item instanceof GenericItem) {
 				GenericItem genericItem = (GenericItem) item;
 				genericItem.addStateChangeListener(this);
+				if(triggerManager!=null) {
+					Iterable<Rule> rules = triggerManager.getRules(CREATE, item);
+					executeRules(rules);
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR aims to bring a solution for initializing items in introducing a "Item created" trigger in rules.
The target is to provide an alternate way to go to avoid "System started" rules as discussed in google groups.

Sample usage : 
rule "test"
when Item sys_start created
then
   sys_start.postUpdate(now.toString)
end