### PR TITLE
Schlage zwave configs

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Manufacturers>
 	<Manufacturer>
 		<Id>0000</Id>
@@ -1971,6 +1971,19 @@
 			<Model>ZCOMBO</Model>
 			<Label lang="en">Smoke and Carbon Monoxide Alarm</Label>
 			<ConfigFile>brk/zcombo.xml</ConfigFile>
+		</Product>
+	</Manufacturer>
+	<Manufacturer>
+		<Id>003b</Id>
+		<Name>Schlage</Name>
+		<Product>
+			<Reference>
+				<Type>6349</Type>
+				<Id>5044</Id>
+			</Reference>
+			<Model>BE468</Model>
+			<Label lang="en">Touchscreen Deadbolt</Label>
+			<ConfigFile>schlage/be468.xml</ConfigFile>
 		</Product>
 	</Manufacturer>
 </Manufacturers>

--- a/bundles/binding/org.openhab.binding.zwave/database/schlage/be468.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/schlage/be468.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+    <Model>PA-100</Model>
+    <Label lang="en">Plug-in On/Off Switch</Label>
+    <CommandClasses>
+        <Class><id>0x20</id></Class>
+        <Class><id>0x22</id></Class>
+        <Class><id>0x62</id></Class>
+        <Class><id>0x63</id></Class>
+        <Class><id>0x70</id></Class>
+        <Class><id>0x71</id></Class>
+        <Class><id>0x72</id></Class>
+        <Class><id>0x80</id></Class>
+        <Class><id>0x84</id></Class>
+        <Class><id>0x85</id></Class>
+        <Class><id>0x86</id></Class>
+        <Class><id>0x98</id></Class>
+    </CommandClasses>
+
+    <Configuration>
+        <Parameter>
+            <Index>3</Index>
+            <Type>list</Type>
+            <Default>255</Default>
+            <Size>1</Size>
+            <Label lang="en">Beeper</Label>
+            <Help lang="en">Audio feedback when keypad pressed during normal operation</Help>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">Disable</Label>
+            </Item>
+            <Item>
+                <Value>255</Value>
+                <Label lang="en">Enable</Label>
+            </Item>
+        </Parameter>
+        <Parameter>
+            <Index>4</Index>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Size>1</Size>
+            <Label lang="en">Vacation Mode</Label>
+            <Help lang="en">Prevents all user codes from unlocking the deadbolt</Help>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">Disable</Label>
+            </Item>
+            <Item>
+                <Value>255</Value>
+                <Label lang="en">Enable</Label>
+            </Item>
+        </Parameter>
+        <Parameter>
+            <Index>5</Index>
+            <Type>list</Type>
+            <Default>255</Default>
+            <Size>1</Size>
+            <Label lang="en">Lock &amp; Leave</Label>
+            <Help lang="en">Press the Schlage button to lock the deadbolt</Help>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">Disable</Label>
+            </Item>
+            <Item>
+                <Value>255</Value>
+                <Label lang="en">Enable</Label>
+            </Item>
+        </Parameter>
+        <Parameter>
+            <Index>15</Index>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Size>1</Size>
+            <Label lang="en">Auto Lock</Label>
+            <Help lange="en">Automatically locks 30 seconds after unlocking</Help>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">Disable</Label>
+            </Item>
+            <Item>
+                <Value>255</Value>
+                <Label lang="en">Enable</Label>
+            </Item>
+        </Parameter>
+        <Parameter>
+            <Index>16</Index>
+            <Type>byte</Type>
+            <Default>4</Default>
+            <Size>1</Size>
+            <Minimum>4</Minimum>
+            <Maximum>8</Maximum>
+            <Label lange="en">User Code PIN Length</Label>
+            <Help lang="en">User codes can be 4-8 digits. Changing length will delete all existing codes.</Help>
+        </Parameter>
+    </Configuration>
+
+    <Associations>
+        <Group>
+            <Index>1</Index>
+            <Maximum>2</Maximum>
+            <Label lang="en">Group 1</Label>
+        </Group>
+        <Group>
+            <Index>2</Index>
+            <Maximum>3</Maximum>
+            <Label lang="en">Group 2</Label>
+        </Group>
+    </Associations>
+</Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/schlage/be468.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/schlage/be468.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Product>
-    <Model>PA-100</Model>
-    <Label lang="en">Plug-in On/Off Switch</Label>
+    <Model>BE-468</Model>
+    <Label lang="en">Touchscreen Deadbolt</Label>
     <CommandClasses>
         <Class><id>0x20</id></Class>
         <Class><id>0x22</id></Class>
@@ -99,11 +99,7 @@
             <Index>1</Index>
             <Maximum>2</Maximum>
             <Label lang="en">Group 1</Label>
-        </Group>
-        <Group>
-            <Index>2</Index>
-            <Maximum>3</Maximum>
-            <Label lang="en">Group 2</Label>
+            <SetToController>true</SetToController>
         </Group>
     </Associations>
 </Product>


### PR DESCRIPTION
Note that this is more or less untested, as the Schlage lock seems to require the Security command class to do much of anything, which is not yet implemented in OpenHAB.  Configuration values come from the manufacturer datasheet:
http://www.schlage.com/content/dam/sch-us/documents/pdf/installation-manuals/24352403.pdf