### PR TITLE
New option for networkhealth binding: cachePeriod.

### DIFF
--- a/bundles/binding/org.openhab.binding.networkhealth/src/main/java/org/openhab/binding/networkhealth/internal/NetworkHealthBinding.java
+++ b/bundles/binding/org.openhab.binding.networkhealth/src/main/java/org/openhab/binding/networkhealth/internal/NetworkHealthBinding.java
@@ -11,6 +11,8 @@ package org.openhab.binding.networkhealth.internal;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.openhab.binding.networkhealth.NetworkHealthBindingProvider;
 import org.openhab.core.binding.AbstractActiveBinding;
@@ -41,7 +43,15 @@ public class NetworkHealthBinding extends AbstractActiveBinding<NetworkHealthBin
 	/** the refresh interval which is used to poll the vitality of the given hosts (defaults to 60000ms) */
 	private long refreshInterval = 60000;
 	
-	
+	/** The states will be cached for this period (in minutes, defaults to 0 = off). */
+	private int cachePeriod = 0;
+
+	/** If {@link #cachePeriod} is larger than 0, this field holds the time of the last cache purge. */
+	private long lastCachePurge = System.currentTimeMillis();
+
+	/** Cached state of all devices for which a binding exists.*/
+	private final Map<String, Boolean> cachedStates = new HashMap<String, Boolean>();
+
 	@Override
 	protected String getName() {
 		return "NetworkHealth Refresh Service";
@@ -80,13 +90,50 @@ public class NetworkHealthBinding extends AbstractActiveBinding<NetworkHealthBin
 				catch (IOException ioe) {
 					logger.debug("couldn't establish network connection [host '{}' port '{}' timeout '{}']", new Object[] {hostname, port, timeout});
 				}
-				if(eventPublisher!=null) {
-					eventPublisher.postUpdate(itemName, success ? OnOffType.ON : OnOffType.OFF);
+				if (eventPublisher != null) {
+
+					// check cached state and update only if state differs
+					if (shouldPostUpdate(hostname, port, success)) {
+						eventPublisher.postUpdate(itemName, success ? OnOffType.ON : OnOffType.OFF);
+					}
 				}
 			}
 		}
 	}
-	
+
+	/**
+	 * Whether or not to post the new state to the event bus.
+	 * 
+	 * @param hostname
+	 *            The hostname that was checked.
+	 * @param port
+	 *            The port.
+	 * @param newState
+	 *            The state whether the host is reachable or not.
+	 * @return <code>true</code> if the event changed or it is not cached;
+	 *         <code>false</code> if the state is already cached and did not
+	 *         change.
+	 */
+	private boolean shouldPostUpdate(String hostname, int port, boolean newState) {
+		if (cachePeriod <= 0)
+			return true; // caching disabled
+		long now = System.currentTimeMillis();
+
+		// clear cache after <cachePeriod> minutes
+		if (lastCachePurge + (cachePeriod * 60000) < now) {
+			cachedStates.clear();
+			lastCachePurge = now;
+		}
+		// post update only if state changed (and caching is enabled) to avoid
+		// spamming the bus
+		final Boolean cachedState = cachedStates.get(hostname + port);
+		if (cachedState == null || newState != cachedState.booleanValue()) {
+			cachedStates.put(hostname + port, newState);
+			return true;
+		}
+		return false;
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -102,6 +149,12 @@ public class NetworkHealthBinding extends AbstractActiveBinding<NetworkHealthBin
 			if (refreshIntervalString != null && !refreshIntervalString.isEmpty()) {
 				refreshInterval = Long.parseLong(refreshIntervalString);
 			}			
+			
+			// read cache period from configuration
+			String cachePeriodString = (String) config.get("cachePeriod");
+			if (cachePeriodString != null && !cachePeriodString.isEmpty()) {
+				cachePeriod = Integer.parseInt(cachePeriodString);
+			}
 		}
 		setProperlyConfigured(true);
 	}

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -596,6 +596,12 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 # refresh interval in milliseconds (optional, default to 60000)
 #networkhealth:refresh=
 
+# Cache the state for n minutes so only changes are posted (optional, defaults to 0 = disabled)
+# Example: if period is 60, once per hour the online states are posted to the event bus;
+#          changes are always and immediately posted to the event bus.
+# The recommended value is 60 minutes.
+#networkhealth:cachePeriod=60
+
 ############################### HTTP Binding ##########################################
 #
 # timeout in milliseconds for the http requests (optional, defaults to 5000)


### PR DESCRIPTION
The online state of all devices is cached for a certain period of time so that non-changing status updates are not sent every 'refresh' seconds. If a device state changes, this changes is immediately sent to the event bus. Default is 0 (off), so that existing behavior is unchanged if this option is not set.