### PR TITLE
Only listen to changed events, not updates.

### DIFF
--- a/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/listeners/ResourceStateChangeListener.java
+++ b/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/listeners/ResourceStateChangeListener.java
@@ -130,7 +130,7 @@ abstract public class ResourceStateChangeListener {
 		stateChangeListener = new StateChangeListener() {
 			// don't react on update events
 			public void stateUpdated(Item item, State state) {
-				broadcaster.broadcast(item);
+//				broadcaster.broadcast(item);
 				// if the group has a base item and thus might calculate its state
 				// as a DecimalType or other, we also consider it to be necessary to
 				// send an update to the client as the label of the item might have changed,


### PR DESCRIPTION
The rest code was broadcasting both update and changed events, we only want to push changed message. Note, i did no cleanup or formatting changes as the already commented out code may prove useful as a guide for later debugging.  This was in reference to PR #2233 and a conversation around caching.