### PR TITLE
[InsteonPLM] Correcting misspelled device feature name I've introduced by mistake

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
@@ -180,7 +180,7 @@
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x11" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x13" group="1">NoOpMsgHandler</message-handler>
-	<message-handler cmd="0x2e">HiddenDooorSensorDataReplyHandler</message-handler>
+	<message-handler cmd="0x2e">HiddenDoorSensorDataReplyHandler</message-handler>
 	<command-handler command="OnOffType">NoOpCommandHandler</command-handler>
 	<poll-handler>NoPollHandler</poll-handler>
 </feature>


### PR DESCRIPTION
This PR intends to correct a misspelled device feature name on InsteonPLM binding.

I've introduced this error on another PR and as reported by Charles Spirakis (https://groups.google.com/forum/#!category-topic/openhab/insteon/tVq1CmLYD-U) it is causing errors.

