### PR TITLE
ZWave configs for Dragon Tech products PA-100, WD-100, WS-100

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/dragontech/pa100.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/dragontech/pa100.xml
@@ -45,6 +45,7 @@
             <Index>1</Index>
             <Maximum>5</Maximum>
             <Label lang="en">Group 1</Label>
+            <SetToController>true</SetToController>
         </Group>
     </Associations>
 </Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/dragontech/pa100.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/dragontech/pa100.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+    <Model>PA-100</Model>
+    <Label lang="en">Plug-in On/Off Switch</Label>
+    <CommandClasses>
+        <Class><id>0x20</id></Class>
+        <Class><id>0x25</id></Class>
+        <Class><id>0x27</id></Class>
+        <Class><id>0x59</id></Class>
+        <Class><id>0x5a</id></Class>
+        <Class><id>0x5e</id></Class>
+        <Class><id>0x70</id></Class>
+        <Class><id>0x72</id></Class>
+        <Class><id>0x73</id></Class>
+        <Class><id>0x7a</id></Class>
+        <Class><id>0x85</id></Class>
+        <Class><id>0x86</id></Class>
+    </CommandClasses>
+
+    <Configuration>
+        <Parameter>
+            <Index>3</Index>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Size>1</Size>
+            <Label lang="en">LED Indicator</Label>
+            <Help lang="en">Controls LED behavior when switch state is on/off</Help>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">off/on</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">on/off</Label>
+            </Item>
+            <Item>
+                <Value>2</Value>
+                <Label lang="en">off</Label>
+            </Item>
+        </Parameter>
+    </Configuration>
+
+    <Associations>
+        <Group>
+            <Index>1</Index>
+            <Maximum>5</Maximum>
+            <Label lang="en">Group 1</Label>
+        </Group>
+    </Associations>
+</Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/dragontech/wd100.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/dragontech/wd100.xml
@@ -57,6 +57,7 @@
             <Index>1</Index>
             <Maximum>5</Maximum>
             <Label lang="en">Group 1</Label>
+            <SetToController>true</SetToController>
         </Group>
     </Associations>
 </Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/dragontech/wd100.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/dragontech/wd100.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+    <Model>WD-100</Model>
+    <Label lang="en">Wall Dimmer Switch</Label>
+    <CommandClasses>
+        <Class><id>0x20</id></Class>
+        <Class><id>0x26</id></Class>
+        <Class><id>0x27</id></Class>
+        <Class><id>0x2b</id></Class>
+        <Class><id>0x59</id></Class>
+        <Class><id>0x5a</id></Class>
+        <Class><id>0x5e</id></Class>
+        <Class><id>0x70</id></Class>
+        <Class><id>0x72</id></Class>
+        <Class><id>0x73</id></Class>
+        <Class><id>0x7a</id></Class>
+        <Class><id>0x85</id></Class>
+        <Class><id>0x86</id></Class>
+    </CommandClasses>
+
+    <Configuration>
+        <Parameter>
+            <Index>4</Index>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Size>1</Size>
+            <Label lang="en">Orientation</Label>
+            <Help lang="en">Controls the on/off orientation of the rocker switch</Help>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">Normal</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">Inverted</Label>
+            </Item>
+        </Parameter>
+        <Parameter>
+            <Index>9</Index>
+            <Type>byte</Type>
+            <Default>1</Default>
+            <Size>1</Size>
+            <Label lang="en">Dim Level Increment</Label>
+            <Help lang="en">Indicates the number of levels (1-99) to change dimming each step</Help>
+        </Parameter>
+        <Parameter>
+            <Index>10</Index>
+            <Type>byte</Type>
+            <Default>3</Default>
+            <Label>Step Duration</Label>
+            <Help lang="en">The number of tens of milliseconds (1-255) to delay on each dimming step.</Help>
+        </Parameter>
+    </Configuration>
+
+    <Associations>
+        <Group>
+            <Index>1</Index>
+            <Maximum>5</Maximum>
+            <Label lang="en">Group 1</Label>
+        </Group>
+    </Associations>
+</Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/dragontech/ws100.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/dragontech/ws100.xml
@@ -62,6 +62,7 @@
             <Index>1</Index>
             <Maximum>5</Maximum>
             <Label lang="en">Group 1</Label>
+            <SetToController>true</SetToController>
         </Group>
     </Associations>
 </Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/dragontech/ws100.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/dragontech/ws100.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+    <Model>WS-100</Model>
+    <Label lang="en">Wall On/Off Switch</Label>
+    <CommandClasses>
+        <Class><id>0x20</id></Class>
+        <Class><id>0x25</id></Class>
+        <Class><id>0x27</id></Class>
+        <Class><id>0x2b</id></Class>
+        <Class><id>0x59</id></Class>
+        <Class><id>0x5a</id></Class>
+        <Class><id>0x5e</id></Class>
+        <Class><id>0x70</id></Class>
+        <Class><id>0x72</id></Class>
+        <Class><id>0x73</id></Class>
+        <Class><id>0x7a</id></Class>
+        <Class><id>0x85</id></Class>
+        <Class><id>0x86</id></Class>
+    </CommandClasses>
+
+    <Configuration>
+        <Parameter>
+            <Index>3</Index>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Size>1</Size>
+            <Label lang="en">LED Indicator</Label>
+            <Help lang="en">Controls LED behavior when switch state is on/off</Help>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">off/on</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">on/off</Label>
+            </Item>
+            <Item>
+                <Value>2</Value>
+                <Label lang="en">off</Label>
+            </Item>
+        </Parameter>
+        <Parameter>
+            <Index>4</Index>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Size>1</Size>
+            <Label lang="en">Orientation</Label>
+            <Help lang="en">Controls the on/off orientation of the rocker switch</Help>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">Normal</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">Inverted</Label>
+            </Item>
+        </Parameter>
+    </Configuration>
+
+    <Associations>
+        <Group>
+            <Index>1</Index>
+            <Maximum>5</Maximum>
+            <Label lang="en">Group 1</Label>
+        </Group>
+    </Associations>
+</Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Manufacturers>
 	<Manufacturer>
 		<Id>0000</Id>
@@ -2008,4 +2008,35 @@
 			<ConfigFile>schlage/be468.xml</ConfigFile>
 		</Product>
 	</Manufacturer>
+    <Manufacturer>
+        <Id>0184</Id>
+        <Name>Dragon Tech Industrial, Ltd.</Name>
+        <Product>
+            <Reference>
+                <Type>4447</Type>
+                <Id>3031</Id>
+            </Reference>
+            <Model>PA-100</Model>
+            <Label lang="en">Plug-in On/Off Switch</Label>
+            <ConfigFile>dragontech/pa100.xml</ConfigFile>
+        </Product>
+        <Product>
+            <Reference>
+                <Type>4447</Type>
+                <Id>3033</Id>
+            </Reference>
+            <Model>WS-100</Model>
+            <Label lang="en">Wall On/Off Switch</Label>
+            <ConfigFile>dragontech/ws100.xml</ConfigFile>
+        </Product>
+        <Product>
+            <Reference>
+                <Type>4447</Type>
+                <Id>3034</Id>
+            </Reference>
+            <Model>WD-100</Model>
+            <Label lang="en">Wall Dimmer Switch</Label>
+            <ConfigFile>dragontech/wd100.xml</ConfigFile>
+        </Product>
+    </Manufacturer>
 </Manufacturers>


### PR DESCRIPTION
I think the BOM on the products.xml file is actually needed by some tool I use, so I put it back with this change.  It should not be needed (as per the unicode spec), but I was getting very weird conflicts on utf8 characters,  and will probably affect others, so backing out that part of my previous change.