### PR TITLE
Change wakeup logic during initialisation

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeStageAdvancer.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeStageAdvancer.java
@@ -674,15 +674,18 @@ public class ZWaveNodeStageAdvancer implements ZWaveEventListener {
 					break;
 				}
 
+				int value = 3600;
 				if (wakeupCommandClass.getInterval() == 0) {
-					logger.debug("NODE {}: Node advancer: SET_WAKEUP - Interval is currently 0. Skipping stage", node.getNodeId(), controller.getOwnNodeId());
-					break;
+					logger.debug("NODE {}: Node advancer: SET_WAKEUP - Interval is currently 0. Set to 3600", node.getNodeId());
+				}
+				else {
+					value = wakeupCommandClass.getInterval();
 				}
 
-				logger.debug("NODE {}: Node advancer: SET_WAKEUP - Set wakeup node to controller ({})", node.getNodeId(), controller.getOwnNodeId());
+				logger.debug("NODE {}: Node advancer: SET_WAKEUP - Set wakeup node to controller ({}), period {}", node.getNodeId(), controller.getOwnNodeId(), value);
 
 				// Set the wake-up interval, and request an update
-				addToQueue(wakeupCommandClass.setInterval(wakeupCommandClass.getInterval()));
+				addToQueue(wakeupCommandClass.setInterval(value));
 				addToQueue(wakeupCommandClass.getIntervalMessage());
 				break;
 


### PR DESCRIPTION
If the <SetToController> tag is set to true, and the value is set to 0, and it's not set to the controller
then we set it to 1 hour (3600 seconds).
This covers an initialisation case where the wakeup interval is defaulted to 0