### PR TITLE
Ecobee-Binding, KNX-Binding, Nest-Binding: Fix ignoreEventList concurrency risk

### DIFF
--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
@@ -10,6 +10,7 @@ package org.openhab.binding.ecobee.internal;
 
 import java.math.BigDecimal;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.Enumeration;
@@ -165,7 +166,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 	/**
 	 * used to store events that we have sent ourselves; we need to remember them for not reacting to them
 	 */
-	private Set<String> ignoreEventSet = new HashSet<String>();
+	private Set<String> ignoreEventSet = Collections.synchronizedSet(new HashSet<String>());
 
 	/**
 	 * The most recently received list of revisions, or an empty Map if none have been retrieved yet.
@@ -500,8 +501,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 
 	private boolean isEcho(String itemName, State state) {
 		String ignoreEventSetKey = itemName + state.toString();
-		if (ignoreEventSet.contains(ignoreEventSetKey)) {
-			ignoreEventSet.remove(ignoreEventSetKey);
+		if (ignoreEventSet.remove(ignoreEventSetKey)) {
 			logger.trace(
 					"We received this event (item='{}', state='{}') from Ecobee, so we don't send it back again -> ignore!",
 					itemName, state.toString());

--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
@@ -9,6 +9,7 @@
 package org.openhab.binding.ecobee.internal;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -166,7 +167,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 	/**
 	 * used to store events that we have sent ourselves; we need to remember them for not reacting to them
 	 */
-	private Set<String> ignoreEventSet = Collections.synchronizedSet(new HashSet<String>());
+	private List<String> ignoreEventList = Collections.synchronizedList(new ArrayList<String>());
 
 	/**
 	 * The most recently received list of revisions, or an empty Map if none have been retrieved yet.
@@ -382,7 +383,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 						 * we need to make sure that we won't send out this event to Ecobee again, when receiving it on
 						 * the openHAB bus
 						 */
-						ignoreEventSet.add(itemName + newState.toString());
+						ignoreEventList.add(itemName + newState.toString());
 						logger.trace("Added event (item='{}', newState='{}') to the ignore event list", itemName,
 								newState);
 						this.eventPublisher.postUpdate(itemName, newState);
@@ -500,8 +501,8 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 	}
 
 	private boolean isEcho(String itemName, State state) {
-		String ignoreEventSetKey = itemName + state.toString();
-		if (ignoreEventSet.remove(ignoreEventSetKey)) {
+		String ignoreEventListKey = itemName + state.toString();
+		if (ignoreEventList.remove(ignoreEventListKey)) {
 			logger.trace(
 					"We received this event (item='{}', state='{}') from Ecobee, so we don't send it back again -> ignore!",
 					itemName, state.toString());

--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBinding.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBinding.java
@@ -61,7 +61,7 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements
 	/**
 	 * used to store events that we have sent ourselves; we need to remember them for not reacting to them
 	 */
-	private Set<String> ignoreEventSet = Collections.synchronizedSet(new HashSet<String>());
+	private List<String> ignoreEventList = Collections.synchronizedList(new ArrayList<String>());
 
 	private KNXBusReaderScheduler mKNXBusReaderScheduler = new KNXBusReaderScheduler();
 
@@ -117,8 +117,8 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements
 	}
 
 	private boolean isEcho(String itemName, Type type) {
-		String ignoreEventSetKey = itemName + type.toString();
-		if (ignoreEventSet.remove(ignoreEventSetKey)) {
+		String ignoreEventListKey = itemName + type.toString();
+		if (ignoreEventList.remove(ignoreEventListKey)) {
 			logger.trace("We received this event (item='{}', state='{}') from KNX, so we don't send it back again -> ignore!", itemName, type.toString());
 			return true;
 		}
@@ -196,7 +196,7 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements
 						if (type!=null) {
 							// we need to make sure that we won't send out this event to
 							// the knx bus again, when receiving it on the openHAB bus
-							ignoreEventSet.add(itemName + type.toString());
+							ignoreEventList.add(itemName + type.toString());
 							logger.trace("Added event (item='{}', type='{}') to the ignore event list", itemName, type.toString());
 
 							if (type instanceof Command && isCommandGA(destination)) {

--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBinding.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBinding.java
@@ -10,6 +10,7 @@ package org.openhab.binding.knx.internal.bus;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -60,7 +61,7 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements
 	/**
 	 * used to store events that we have sent ourselves; we need to remember them for not reacting to them
 	 */
-	private List<String> ignoreEventList = new ArrayList<String>();
+	private Set<String> ignoreEventSet = Collections.synchronizedSet(new HashSet<String>());
 
 	private KNXBusReaderScheduler mKNXBusReaderScheduler = new KNXBusReaderScheduler();
 
@@ -116,9 +117,8 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements
 	}
 
 	private boolean isEcho(String itemName, Type type) {
-		String ignoreEventListKey = itemName + type.toString();
-		if (ignoreEventList.contains(ignoreEventListKey)) {
-			ignoreEventList.remove(ignoreEventListKey);
+		String ignoreEventSetKey = itemName + type.toString();
+		if (ignoreEventSet.remove(ignoreEventSetKey)) {
 			logger.trace("We received this event (item='{}', state='{}') from KNX, so we don't send it back again -> ignore!", itemName, type.toString());
 			return true;
 		}
@@ -196,7 +196,7 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements
 						if (type!=null) {
 							// we need to make sure that we won't send out this event to
 							// the knx bus again, when receiving it on the openHAB bus
-							ignoreEventList.add(itemName + type.toString());
+							ignoreEventSet.add(itemName + type.toString());
 							logger.trace("Added event (item='{}', type='{}') to the ignore event list", itemName, type.toString());
 
 							if (type instanceof Command && isCommandGA(destination)) {

--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
@@ -10,6 +10,7 @@ package org.openhab.binding.nest.internal;
 
 import java.math.BigDecimal;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.Enumeration;
@@ -76,7 +77,7 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider> impl
 	/**
 	 * used to store events that we have sent ourselves; we need to remember them for not reacting to them
 	 */
-	private Set<String> ignoreEventSet = new HashSet<String>();
+	private Set<String> ignoreEventSet = Collections.synchronizedSet(new HashSet<String>());
 
 	/**
 	 * The most recently received data model, or <code>null</code> if none have been retrieved yet.
@@ -283,8 +284,7 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider> impl
 
 	private boolean isEcho(String itemName, State state) {
 		String ignoreEventSetKey = itemName + state.toString();
-		if (ignoreEventSet.contains(ignoreEventSetKey)) {
-			ignoreEventSet.remove(ignoreEventSetKey);
+		if (ignoreEventSet.remove(ignoreEventSetKey)) {
 			logger.debug(
 					"We received this event (item='{}', state='{}') from Nest, so we don't send it back again -> ignore!",
 					itemName, state);

--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
@@ -9,15 +9,15 @@
 package org.openhab.binding.nest.internal;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.prefs.Preferences;
 
 import org.openhab.binding.nest.NestBindingProvider;
@@ -77,7 +77,7 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider> impl
 	/**
 	 * used to store events that we have sent ourselves; we need to remember them for not reacting to them
 	 */
-	private Set<String> ignoreEventSet = Collections.synchronizedSet(new HashSet<String>());
+	private List<String> ignoreEventList = Collections.synchronizedList(new ArrayList<String>());
 
 	/**
 	 * The most recently received data model, or <code>null</code> if none have been retrieved yet.
@@ -178,8 +178,8 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider> impl
 					 * we need to make sure that we won't send out this event to Nest again, when receiving it on the
 					 * openHAB bus
 					 */
-					ignoreEventSet.add(itemName + newState.toString());
-					logger.trace("Added event (item='{}', newState='{}') to the ignore event set", itemName, newState);
+					ignoreEventList.add(itemName + newState.toString());
+					logger.trace("Added event (item='{}', newState='{}') to the ignore event list", itemName, newState);
 					this.eventPublisher.postUpdate(itemName, newState);
 				}
 			}
@@ -283,8 +283,8 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider> impl
 	}
 
 	private boolean isEcho(String itemName, State state) {
-		String ignoreEventSetKey = itemName + state.toString();
-		if (ignoreEventSet.remove(ignoreEventSetKey)) {
+		String ignoreEventListKey = itemName + state.toString();
+		if (ignoreEventList.remove(ignoreEventListKey)) {
 			logger.debug(
 					"We received this event (item='{}', state='{}') from Nest, so we don't send it back again -> ignore!",
 					itemName, state);


### PR DESCRIPTION
All three bindings were using an unsynchronized collection to track events to ignore, between the `execute()` thread and a different thread.  This presented the possibility that the collection would fail to properly track events to ignore.  The bindings in this pull request use `Collections.synchronizedList(new ArrayList<String>())` to avoid concurrency problems, and use a single synchronized `remove` call instead of `contains` followed by `remove`.  This has the added benefit of requiring a single linear search instead of two linear searches.

Additionally, the Ecobee and Nest bindings were incorrectly using a `Set` to track item updates to ignore, missing the possibility that multiple of the same item updates could be outstanding and all needing to be ignored.