### PR TITLE
Nest Enh: item binding for last time binding received from Nest API servers

### DIFF
--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/DataModel.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/DataModel.java
@@ -11,6 +11,7 @@ package org.openhab.binding.nest.internal.messages;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URLDecoder;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -146,6 +147,8 @@ public class DataModel extends AbstractMessagePart {
 	private Map<String, Structure> structures_by_id;
 	@JsonIgnore
 	private Map<String, Structure> structures_by_name;
+	@JsonIgnore
+	Date last_connection;
 
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public static class Devices extends AbstractMessagePart implements DataModelElement {
@@ -367,6 +370,23 @@ public class DataModel extends AbstractMessagePart {
 	 */
 	public void setStructures_by_name(final Map<String, Structure> structures_by_name) {
 		this.structures_by_name = structures_by_name;
+	}
+
+	/**
+	 * @param last_connection
+	 *            the last time we obtained the data model from the Nest API
+	 */
+	@JsonIgnore
+	public void setLast_connection(final Date last_connection) {
+		this.last_connection = last_connection;
+	}
+
+	/**
+	 * @return the last_connection
+	 */
+	@JsonIgnore
+	public Date getLast_connection() {
+		return this.last_connection;
 	}
 
 	/**

--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/DataModelRequest.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/DataModelRequest.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.nest.internal.messages;
 
+import java.util.Date;
+
 import org.apache.commons.httpclient.util.URIUtil;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.codehaus.jackson.annotate.JsonIgnore;
@@ -52,6 +54,9 @@ public class DataModelRequest extends AbstractRequest {
 			json = executeQuery(url);
 
 			final DataModelResponse response = JSON.readValue(json, DataModelResponse.class);
+
+			// note the time we received the data model
+			response.setLast_connection(new Date());
 
 			// sync the returned data model so its internal pointers are pointing
 			response.sync();


### PR DESCRIPTION
Added last_connection property to Nest binding to retrieve when binding last communicated with Nest API servers.  The binding configuration string is 
```
{ nest="<[last_connection]" }
```