### PR TITLE
DSCAlarm Binding Features and Fixes

### DIFF
--- a/bundles/binding/org.openhab.binding.dscalarm/.classpath
+++ b/bundles/binding/org.openhab.binding.dscalarm/.classpath
@@ -4,5 +4,6 @@
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="/org.openhab.core.scheduler/lib/quartz-all-2.1.7.jar"/>
+	<classpathentry kind="lib" path="/org.openhab.io.transport.serial/lib/nrjavaserial-3.8.8.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/binding/org.openhab.binding.dscalarm/.classpath
+++ b/bundles/binding/org.openhab.binding.dscalarm/.classpath
@@ -4,6 +4,6 @@
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="/org.openhab.core.scheduler/lib/quartz-all-2.1.7.jar"/>
-	<classpathentry kind="lib" path="/org.openhab.io.transport.serial/lib/nrjavaserial-3.8.8.jar"/>
+	<classpathentry kind="lib" path="/org.openhab.io.transport.serial/lib/nrjavaserial-3.9.3.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/binding/org.openhab.binding.dscalarm/README.md
+++ b/bundles/binding/org.openhab.binding.dscalarm/README.md
@@ -72,7 +72,9 @@ The DSCAlarmItemType maps the binding to an openHAB item type.  Here are the sup
     <tr><td>panel_connection</td><td>Number</td><td>Panel connection status.</td></tr>
     <tr><td>panel_message</td><td>String</td><td>Event messages received from the DSC Alarm system.</td></tr>
     <tr><td>panel_system_error</td><td>String</td><td>DSC Alarm system error.</td></tr>
-    <tr><td>panel_time_date</td><td>DateTime</td><td>DSC Alarm system time and date.</td></tr>
+    <tr><td>panel_time</td><td>DateTime</td><td>DSC Alarm system time and date.</td></tr>
+    <tr><td>panel_time_stamp</td><td>Switch</td><td>Turn DSC Alarm message time stamping ON/OFF.</td></tr>
+    <tr><td>panel_time_broadcast</td><td>Switch</td><td>Turn DSC Alarm time broadcasting ON/OFF.</td></tr>
     <tr><td>panel_fire_key_alarm</td><td>Switch</td><td>A fire key alarm has happened.</td></tr>
     <tr><td>panel_panic_key_alarm</td><td>Switch</td><td>A panic key alarm has happened.</td></tr>
     <tr><td>panel_aux_key_alarm</td><td>Switch</td><td>An auxiliary key alarm has happened.</td></tr>
@@ -163,6 +165,10 @@ Number PANEL_CONNECTION "Panel Connected: [%d]" (DSCAlarmPanel) {dscalarm="panel
 Number PANEL_COMMAND "Panel Commands" (DSCAlarmPanel) {dscalarm="panel:panel_command"}
 String PANEL_MESSAGE "Panel Message: [%s]" <"shield-1"> (DSCAlarmPanel) {dscalarm="panel:panel_message"}
 String PANEL_SYSTEM_ERROR "Panel System Error: [%s]" <"shield-1"> (DSCAlarmPanel) {dscalarm="panel:panel_system_error"}
+
+DateTime PANEL_TIME "Panel Time [%1$tA, %1$tm/%1$td/%1$tY %1tT]" <calendar> (DSCAlarmPanel) {dscalarm="panel:panel_time"}
+Switch PANEL_TIME_STAMP (DSCAlarmPanel) {dscalarm="panel:panel_time_stamp"}
+Switch PANEL_TIME_BROADCAST (DSCAlarmPanel) {dscalarm="panel:panel_time_broadcast"}
 
 Switch PANEL_FIRE_KEY_ALARM (DSCAlarmPanel) {dscalarm="panel:panel_fire_key_alarm"}
 Switch PANEL_PANIC_KEY_ALARM (DSCAlarmPanel) {dscalarm="panel:panel_panic_key_alarm"}
@@ -290,6 +296,10 @@ Frame label="Alarm System" {
 			Switch item=PANEL_CONNECTION label="Panel Connection" icon="shield-1" mappings=[1="Connected", 0="Disconnected"]
 			Text item=PANEL_MESSAGE icon="shield-1"
 			Selection item=PANEL_COMMAND icon="shield-1" mappings=[0="Poll", 1="Status Report", 2="Labels Request (Serial Only)", 8="Dump Zone Timers (TCP Only)", 10="Set Time/Date", 200="Send User Code"]
+			Text item=PANEL_TIME {
+				Switch item=PANEL_TIME_STAMP label="Panel Time Stamp"
+				Switch item=PANEL_TIME_BROADCAST label="Panel Time Broadcast"
+			}
 		}
 
 		Frame label="Partitions" {

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmItemType.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmItemType.java
@@ -23,7 +23,10 @@ public enum DSCAlarmItemType{
 	PANEL_MESSAGE("panel_message"),
 	PANEL_COMMAND("panel_command"),
 	PANEL_SYSTEM_ERROR("panel_system_error"),
-	PANEL_TIME_DATE("panel_time_date"),
+
+	PANEL_TIME("panel_time"),
+	PANEL_TIME_STAMP("panel_time_stamp"),
+	PANEL_TIME_BROADCAST("panel_time_broadcast"),
 
 	PANEL_FIRE_KEY_ALARM("panel_fire_key_alarm"),
 	PANEL_PANIC_KEY_ALARM("panel_panic_key_alarm"),

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmItemUpdate.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmItemUpdate.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.openhab.binding.dscalarm.DSCAlarmBindingConfig;
+import org.openhab.binding.dscalarm.internal.model.DSCAlarmDeviceProperties;
 import org.openhab.binding.dscalarm.internal.model.DSCAlarmDeviceType;
 import org.openhab.binding.dscalarm.internal.model.Panel;
 import org.openhab.binding.dscalarm.internal.model.Partition;
@@ -224,4 +225,56 @@ public class DSCAlarmItemUpdate {
 			}
 		}
 	}
+	
+	/**
+	 * Get DSC Alarm Device Properties
+	 * 
+	 * @param item
+	 * @param config
+	 */
+	public synchronized DSCAlarmDeviceProperties getDeviceProperties(Item item, DSCAlarmBindingConfig config) {
+		logger.debug("updateDeviceProperties(): Item Name: {}", item.getName());
+		
+		DSCAlarmDeviceProperties dscAlarmDeviceProperties = null;
+
+	
+		if( config != null) {
+			DSCAlarmDeviceType dscAlarmDeviceType = config.getDeviceType();
+			int panelId = 1;
+			int partitionId;
+			int zoneId;
+			int keypadId = 1;
+			
+			switch (dscAlarmDeviceType) {
+				case PANEL:
+					Panel panel = panelMap.get(panelId);
+					if(panel != null) {
+						dscAlarmDeviceProperties = panel.panelProperties;
+					}
+					break;					
+				case PARTITION:
+					partitionId = config.getPartitionId();
+					Partition partition = partitionMap.get(partitionId);
+					if(partition != null)
+						dscAlarmDeviceProperties = partition.partitionProperties;
+					break;
+				case ZONE:
+					partitionId = config.getPartitionId();
+					zoneId = config.getZoneId();
+					Zone zone = zoneMap.get(zoneId);
+					if(zone != null)
+						dscAlarmDeviceProperties = zone.zoneProperties;
+					break;
+				case KEYPAD:
+					Keypad keypad = keypadMap.get(keypadId);
+					if(keypad != null)
+						dscAlarmDeviceProperties = keypad.keypadProperties;
+					break;
+				default:
+					break;
+			}
+		}
+
+		return dscAlarmDeviceProperties;
+	}	
 }

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/DSCAlarmDeviceProperties.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/DSCAlarmDeviceProperties.java
@@ -27,7 +27,9 @@ public class DSCAlarmDeviceProperties {
 	private int systemConnection = 0;
 	private String systemConnectionDescription = "";
 	private String systemMessage = "";
-	private Date systemTimeDate;
+	private Date systemTime = new Date(0);
+	private boolean systemTimeStamp = false;
+	private boolean systemTimeBroadcast = false;
 	private int systemCommand = -1;
 	private int systemError = 0;
 	private int systemErrorCode = 0;
@@ -85,7 +87,6 @@ public class DSCAlarmDeviceProperties {
 	
 	enum StateType{
 		CONNECTION_STATE,
-		TIME_DATE,
 		GENERAL_STATE,
 		ARM_STATE,
 		ALARM_STATE,
@@ -133,9 +134,18 @@ public class DSCAlarmDeviceProperties {
 		return systemMessage;
 	}
 	
-	public String getTimeDate() {
-		SimpleDateFormat tm = new SimpleDateFormat("HH:mm MM/dd/YY");
-		return tm.format(systemTimeDate);
+	public String getSystemTime() {
+		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+		
+		return sdf.format(systemTime);
+	}
+
+	public boolean getSystemTimeStamp() {
+		return systemTimeStamp;
+	}
+
+	public boolean getSystemTimeBroadcast() {
+		return systemTimeBroadcast;
 	}
 
 	public int getSystemCommand() {
@@ -364,13 +374,25 @@ public class DSCAlarmDeviceProperties {
 		this.systemMessage = systemMessage;
 	}
 
-	public void setTimeDate(String timeDate) {
-		SimpleDateFormat tm = new SimpleDateFormat("HH:MM MM/DD/YY");
+	public void setSystemTime(String time) {
+		SimpleDateFormat sdf = new SimpleDateFormat("HHmmMMddyy");
+		Date date = null;
+		
 		try {
-			systemTimeDate = tm.parse(timeDate);
-		} catch (ParseException parseException) {
-			logger.error("setTimeDate(): parse error {} ", parseException);
+			date = sdf.parse(time);
+		} catch (ParseException e) {
+			logger.error("setTimeDate(): Parse Exception occured while trying parse date string - {}. ",e);
 		}
+		
+		this.systemTime = date;
+	}
+
+	public void setSystemTimeStamp(boolean systemTimeStamp) {
+		this.systemTimeStamp = systemTimeStamp;
+	}
+
+	public void setSystemTimeBroadcast(boolean systemTimeBroadcast) {
+		this.systemTimeBroadcast = systemTimeBroadcast;
 	}
 
 	public void setSystemError(int systemError) {

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Keypad.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Keypad.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 public class Keypad extends DSCAlarmDevice{
 	private static final Logger logger = LoggerFactory.getLogger(Keypad.class);
 
-	DSCAlarmDeviceProperties keypadProperties = new DSCAlarmDeviceProperties();
+	public DSCAlarmDeviceProperties keypadProperties = new DSCAlarmDeviceProperties();
 
 	/**
 	 * Constructor

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Panel.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Panel.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 public class Panel extends DSCAlarmDevice{
 	private static final Logger logger = LoggerFactory.getLogger(Panel.class);
 
-	DSCAlarmDeviceProperties panelProperties = new DSCAlarmDeviceProperties();
+	public DSCAlarmDeviceProperties panelProperties = new DSCAlarmDeviceProperties();
 
 	/**
 	 * Constructor
@@ -52,6 +52,7 @@ public class Panel extends DSCAlarmDevice{
 		int state;
 		String str = "";
 		boolean trigger;
+		boolean boolState;
 		OnOffType onOffType;
 
 		if(config != null) {
@@ -69,9 +70,19 @@ public class Panel extends DSCAlarmDevice{
 						str = String.format("%03d", panelProperties.getSystemErrorCode()) + ": " + panelProperties.getSystemErrorDescription();
 						publisher.postUpdate(item.getName(), new StringType(str));
 						break;
-					case PANEL_TIME_DATE:
-						str = panelProperties.getTimeDate();
-						publisher.postUpdate(item.getName(), new StringType(str));
+					case PANEL_TIME:
+						str = panelProperties.getSystemTime();
+						publisher.postUpdate(item.getName(), new DateTimeType(str));
+						break;
+					case PANEL_TIME_STAMP:
+						boolState = panelProperties.getSystemTimeStamp();
+						onOffType = boolState ? OnOffType.ON : OnOffType.OFF;
+						publisher.postUpdate(item.getName(), onOffType);
+						break;
+					case PANEL_TIME_BROADCAST:
+						boolState = panelProperties.getSystemTimeBroadcast();
+						onOffType = boolState ? OnOffType.ON : OnOffType.OFF;
+						publisher.postUpdate(item.getName(), onOffType);
 						break;
 					case PANEL_COMMAND:
 						state = panelProperties.getSystemCommand();
@@ -141,100 +152,16 @@ public class Panel extends DSCAlarmDevice{
 							if(apiMessage != null) {
 								systemErrorCode = Integer.parseInt(apiMessage.getAPIData());
 								panelProperties.setSystemErrorCode(systemErrorCode);
+								panelProperties.setSystemErrorDescription(apiMessage.getError());
+								str = String.format("%03d", panelProperties.getSystemErrorCode()) + ": " + panelProperties.getSystemErrorDescription();
+								publisher.postUpdate(item.getName(), new StringType(str));
 							}
-							
-							switch(systemErrorCode) {
-								case 1:
-									panelProperties.setSystemErrorDescription("Receive Buffer Overrun");
-									break;
-								case 2:
-									panelProperties.setSystemErrorDescription("Receive Buffer Overflow");
-									break;
-								case 3:
-									panelProperties.setSystemErrorDescription("Transmit Buffer Overflow");
-									break;
-								case 10:
-									panelProperties.setSystemErrorDescription("Keybus Transmit Buffer Overrun");
-									break;
-								case 11:
-									panelProperties.setSystemErrorDescription("Keybus Transmit Time Timeout");
-									break;
-								case 12:
-									panelProperties.setSystemErrorDescription("Keybus Transmit Mode Timeout");
-									break;
-								case 13:
-									panelProperties.setSystemErrorDescription("Keybus Transmit Keystring Timeout");
-									break;
-								case 14:
-									panelProperties.setSystemErrorDescription("Keybus Interface Not Functioning");
-									break;
-								case 15:
-									panelProperties.setSystemErrorDescription("Keybus Busy - Attempting to Disarm or Arm with user code");
-									break;
-								case 16:
-									panelProperties.setSystemErrorDescription("Keybus Busy – Lockout");
-									break;
-								case 17:
-									panelProperties.setSystemErrorDescription("Keybus Busy – Installers Mode");
-									break;
-								case 18:
-									panelProperties.setSystemErrorDescription("Keybus Busy - General Busy");
-									break;
-								case 20:
-									panelProperties.setSystemErrorDescription("API Command Syntax Error");
-									break;
-								case 21:
-									panelProperties.setSystemErrorDescription("API Command Partition Error - Requested Partition is out of bounds");
-									break;
-								case 22:
-									panelProperties.setSystemErrorDescription("API Command Not Supported");
-									break;
-								case 23:
-									panelProperties.setSystemErrorDescription("API System Not Armed - Sent in response to a disarm command");
-									break;
-								case 24:
-									panelProperties.setSystemErrorDescription("API System Not Ready to Arm - System is either not-secure, in exit-delay, or already armed");
-									break;
-								case 25:
-									panelProperties.setSystemErrorDescription("API Command Invalid Length");
-									break;
-								case 26:
-									panelProperties.setSystemErrorDescription("API User Code not Required");
-									break;
-								case 27:
-									panelProperties.setSystemErrorDescription("API Invalid Characters in Command - No alpha characters are allowed except for checksum");
-									break;
-								case 28:
-									panelProperties.setSystemErrorDescription("API Virtual Keypad is Disabled");
-									break;
-								case 29:
-									panelProperties.setSystemErrorDescription("API Not Valid Parameter");
-									break;
-								case 30:
-									panelProperties.setSystemErrorDescription("API Keypad Does Not Come Out of Blank Mode");
-									break;
-								case 31:
-									panelProperties.setSystemErrorDescription("API IT-100 is Already in Thermostat Menu");
-									break;
-								case 32:
-									panelProperties.setSystemErrorDescription("API IT-100 is NOT in Thermostat Menu");
-									break;
-								case 33:
-									panelProperties.setSystemErrorDescription("API No Response From Thermostat or Escort Module");
-									break;
-								case 0:
-								default:
-									panelProperties.setSystemErrorDescription("No Error");
-									break;
-							}
-							str = String.format("%03d", panelProperties.getSystemErrorCode()) + ": " + panelProperties.getSystemErrorDescription();
-							publisher.postUpdate(item.getName(), new StringType(str));
 							break;
-						case PANEL_TIME_DATE:
+						case PANEL_TIME:
 							if(apiMessage != null) {
-								panelProperties.setTimeDate(apiMessage.getAPIData());
+								panelProperties.setSystemTime(apiMessage.getAPIData());
+								str = panelProperties.getSystemTime();
 								publisher.postUpdate(item.getName(), new DateTimeType(str));
-								str = apiMessage.getAPIData();
 							}
 							break;
 						default:
@@ -253,6 +180,7 @@ public class Panel extends DSCAlarmDevice{
 		logger.debug("updateProperties(): Panel Item Name: {}", item.getName());
 		
 		boolean trigger = state != 0 ? true : false;
+		boolean boolState = state != 0 ? true : false;
 
 		if(config != null) {
 			if(config.getDSCAlarmItemType() != null) {
@@ -278,10 +206,15 @@ public class Panel extends DSCAlarmDevice{
 					case PANEL_AUX_INPUT_ALARM:
 						panelProperties.setTrigger(TriggerType.AUX_INPUT_ALARM, trigger);
 						break;
-					/*case PANEL_TIME_DATE:
-						panelProperties.setState(StateType.TIME_DATE, state, description);
-						logger.debug("updateProperties(): Panel property updated: {}", item.getName());
-						break;*/
+					case PANEL_TIME:
+						panelProperties.setSystemTime(description);
+						break;
+					case PANEL_TIME_STAMP:
+						panelProperties.setSystemTimeStamp(boolState);
+						break;
+					case PANEL_TIME_BROADCAST:
+						panelProperties.setSystemTimeBroadcast(boolState);
+						break;
 					default: 
 						logger.debug("updateProperties(): Panel property not updated.");
 						break;

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Partition.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Partition.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 public class Partition extends DSCAlarmDevice{
 	private static final Logger logger = LoggerFactory.getLogger(Partition.class);
 
-	DSCAlarmDeviceProperties partitionProperties = new DSCAlarmDeviceProperties();
+	public DSCAlarmDeviceProperties partitionProperties = new DSCAlarmDeviceProperties();
 
 	/**
 	 * Constructor
@@ -123,13 +123,11 @@ public class Partition extends DSCAlarmDevice{
 								case 650:
 								case 653:
 									state = 1;
-									partitionProperties.setState(StateType.GENERAL_STATE, state, strStatus);
 									break;
 								case 651:
 								case 672:
 								case 673:
 									state = 0;
-									partitionProperties.setState(StateType.GENERAL_STATE, 0, strStatus);
 									break;
 								case 654:
 									partitionProperties.setState(StateType.ALARM_STATE, 1, strStatus);

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Zone.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Zone.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 public class Zone extends DSCAlarmDevice{
 	private static final Logger logger = LoggerFactory.getLogger(Zone.class);
 
-	DSCAlarmDeviceProperties zoneProperties = new DSCAlarmDeviceProperties();
+	public DSCAlarmDeviceProperties zoneProperties = new DSCAlarmDeviceProperties();
 	
 	/**
 	 * Constructor

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
@@ -85,11 +85,11 @@ public class API {
 
 		if(isValidBaudRate(baud))
 			baudRate = baud;
-		
+
 		if (StringUtils.isNotBlank(userCode)) {
 			this.dscAlarmUserCode = userCode;
 		}
-		
+
 		//The IT-100 requires 6 digit codes. Shorter codes are right padded with 0.
 		this.dscAlarmUserCode = StringUtils.rightPad(dscAlarmUserCode, 6, '0');
 
@@ -101,9 +101,9 @@ public class API {
 	 * 
 	 * @param ip
 	 * @param password
-	 * @param dscAlarmUserCode
+	 * @param userCode
 	 */
-	public API(String ip, String password, String dscAlarmUserCode) {
+	public API(String ip, String password, String userCode) {
 		if (StringUtils.isNotBlank(ip)) {
 			ipAddress = ip;
 		}
@@ -112,8 +112,8 @@ public class API {
 			this.password = password;
 		}
 
-		if (StringUtils.isNotBlank(dscAlarmUserCode)) {
-			this.dscAlarmUserCode = dscAlarmUserCode;
+		if (StringUtils.isNotBlank(userCode)) {
+			this.dscAlarmUserCode = userCode;
 		}
 
 		connectorType = DSCAlarmConnectorType.TCP;
@@ -396,7 +396,7 @@ public class API {
  			apiCommand.setAPICommand(command, data);
     		dscAlarmConnector.write(apiCommand.toString());
     		successful = true;
-    		logger.debug("sendCommand(): Command Sent - {}",apiCommand.toString());
+    		logger.debug("sendCommand(): '{}' Command Sent - {}",apiCode,apiCommand);
     	}
     	else
     		logger.error("sendCommand(): Command Not Sent - Invalid!");

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/APICode.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/APICode.java
@@ -145,7 +145,9 @@ public enum APICode {
     SoftwareVersion("908"),
     CommandOutputPressed("912"),
     MasterCodeRequired("921"),
-    InstallersCodeRequired("922");
+    InstallersCodeRequired("922"),
+
+    UnknownCode("-1");
 
 	private String code;
 
@@ -188,9 +190,17 @@ public enum APICode {
 	 * @return enum value
 	 */
 	public static APICode getAPICodeValue(String code) {
+		APICode apiCode;
+		
 		if (codeToAPICodeValue == null) {
 			initMapping();
 		}
-		return codeToAPICodeValue.get(code);
+		
+		apiCode = codeToAPICodeValue.get(code);
+		
+		if(apiCode == null)
+			apiCode = UnknownCode;
+		
+		return apiCode;
 	}
 }

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/APIMessage.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/APIMessage.java
@@ -36,11 +36,13 @@ public class APIMessage {
 	private String apiDescription = "";
 	private String apiCodeReceived = "";
 	private APIMessageType apiMessageType = APIMessageType.PANEL_EVENT;
+	private String timeStamp = "";
 	private int partition = 0;
 	private int zone = 0;
 	private String data = "";
 	private String mode= "";
 	private String user = "";
+	private String error = "";
 
 	/**
 	 * Constructor. Creates a new instance of the APIMessage class.
@@ -60,6 +62,7 @@ public class APIMessage {
 		if (apiMessage.length() > 3) {
 			try {
 				if(apiMessage.length() >= 8 && apiMessage.charAt(2) == ':'  && apiMessage.charAt(5) == ':') {
+					timeStamp = apiMessage.substring(0,8);
 					apiMessage = apiMessage.substring(9, apiMessage.length() - 2);					
 				}
 				else { 
@@ -77,7 +80,9 @@ public class APIMessage {
 	        	apiCodeReceived = "000";
 			}
 		   	 
-			if(APICode.getAPICodeValue(apiCodeReceived) != null) {
+			APICode apiCode = APICode.getAPICodeValue(apiCodeReceived);
+
+			if(apiCode != null) {
 				
 				switch (APICode.getAPICodeValue(apiCodeReceived)) {
 					case CommandAcknowledge: /*500*/
@@ -91,6 +96,92 @@ public class APIMessage {
 					case SystemError: /*502*/
 						apiName = "System Error";
 						apiDescription = apiCodeReceived + ": An error has been detected.";
+						int systemErrorCode = 0;
+						systemErrorCode = Integer.parseInt(data);
+						switch(systemErrorCode) {
+							case 1:
+								error = "Receive Buffer Overrun";
+								break;
+							case 2:
+								error = "Receive Buffer Overflow";
+								break;
+							case 3:
+								error = "Transmit Buffer Overflow";
+								break;
+							case 10:
+								error = "Keybus Transmit Buffer Overrun";
+								break;
+							case 11:
+								error = "Keybus Transmit Time Timeout";
+								break;
+							case 12:
+								error = "Keybus Transmit Mode Timeout";
+								break;
+							case 13:
+								error = "Keybus Transmit Keystring Timeout";
+								break;
+							case 14:
+								error = "Keybus Interface Not Functioning";
+								break;
+							case 15:
+								error = "Keybus Busy - Attempting to Disarm or Arm with user code";
+								break;
+							case 16:
+								error = "Keybus Busy – Lockout";
+								break;
+							case 17:
+								error = "Keybus Busy – Installers Mode";
+								break;
+							case 18:
+								error = "Keybus Busy - General Busy";
+								break;
+							case 20:
+								error = "API Command Syntax Error";
+								break;
+							case 21:
+								error = "API Command Partition Error - Requested Partition is out of bounds";
+								break;
+							case 22:
+								error = "API Command Not Supported";
+								break;
+							case 23:
+								error = "API System Not Armed - Sent in response to a disarm command";
+								break;
+							case 24:
+								error = "API System Not Ready to Arm - System is either not-secure, in exit-delay, or already armed";
+								break;
+							case 25:
+								error = "API Command Invalid Length";
+								break;
+							case 26:
+								error = "API User Code not Required";
+								break;
+							case 27:
+								error = "API Invalid Characters in Command - No alpha characters are allowed except for checksum";
+								break;
+							case 28:
+								error = "API Virtual Keypad is Disabled";
+								break;
+							case 29:
+								error = "API Not Valid Parameter";
+								break;
+							case 30:
+								error = "API Keypad Does Not Come Out of Blank Mode";
+								break;
+							case 31:
+								error = "API IT-100 is Already in Thermostat Menu";
+								break;
+							case 32:
+								error = "API IT-100 is NOT in Thermostat Menu";
+								break;
+							case 33:
+								error = "API No Response From Thermostat or Escort Module";
+								break;
+							case 0:
+							default:
+								error = "No Error";
+								break;
+						}
 						break;
 					case LoginResponse: /*505*/
 						apiName = "Login Interaction";
@@ -109,7 +200,7 @@ public class APIMessage {
 					case TimeDateBroadcast: /*550*/
 						apiName = "Time-Date Broadcast";
 						apiDescription = apiCodeReceived + ": The current security system time.";
-						data = apiMessage.substring(4);
+						data = apiMessage.substring(3);
 						break;
 					case RingDetected: /*560*/
 						apiName = "Ring Detected";
@@ -588,6 +679,11 @@ public class APIMessage {
 		sb.append(apiDescription);
 		sb.append("\"");
 
+		if (timeStamp != "") {
+			sb.append(", Time Stamp: ");
+			sb.append(timeStamp);
+		}
+
 		if (partition != 0) {
 			sb.append(", Partition: ");
 			sb.append(partition);
@@ -611,6 +707,11 @@ public class APIMessage {
 		if (user != "") {
 			sb.append(", user: ");
 			sb.append(user);
+		}
+
+		if (error != "") {
+			sb.append(", error: ");
+			sb.append(error);
 		}
 
 		return sb.toString();
@@ -705,5 +806,23 @@ public class APIMessage {
 	 */
 	public String getUser() {
 		return user;
+	}
+
+	/**
+	 * Returns the error string from the API message
+	 * 
+	 * @return user
+	 */
+	public String getError() {
+		return error;
+	}
+
+	/**
+	 * Returns the time stamp if available
+	 * 
+	 * @return timeStamp
+	 */
+	public String getTimeStamp() {
+		return timeStamp;
 	}
 }


### PR DESCRIPTION
*Features
-Renamed item 'panel_time_date' to 'panel_time'
-Added item 'panel_time_stamp' to allow the receiving of time stamped messages from the DSC Alarm system.
-Added item 'panel_time_broadcast' to allow the reception of DSC Alarm system time broadcasts for viewing.

*Fixes
-Item 'panel_time_date' (renamed to 'panel_time') was not working.
-Added several methods to binding class to eliminate extra 'for' loop in message receive thread.
-Merged user code fix for the IT-100 serial interface from @beowulfe.
