### PR TITLE
MiOS Tools - For Percentages, the %% should be inside the String/Format of the Item

### DIFF
--- a/bundles/binding/org.openhab.binding.mios/examples/scripts/miosTransform.xslt
+++ b/bundles/binding/org.openhab.binding.mios/examples/scripts/miosTransform.xslt
@@ -502,7 +502,7 @@ String   <xsl:value-of select="$DeviceNameFixed"/>DeviceStatus "<xsl:value-of se
 <xsl:when test="normalize-space($ItemType) = 'DateTime'"                                                               > [%1$ta, %1$tm/%1$te %1$tR]</xsl:when>
 <xsl:when test="normalize-space($ItemType) = 'Contact'"                                                                > [MAP(en.map):%s]</xsl:when>
 <xsl:when test="normalize-space($ItemType) = 'Switch'"                                                                 ></xsl:when>
-<xsl:when test="normalize-space($ItemType) = 'Dimmer'"                                                                 > [%d] %</xsl:when>
+<xsl:when test="normalize-space($ItemType) = 'Dimmer'"                                                                 > [%d %%]</xsl:when>
 <xsl:otherwise                                                                                                         > [%s]</xsl:otherwise>
 </xsl:choose>
 </xsl:variable>


### PR DESCRIPTION
The double-percent (`%%`) characters need to go inside the square-brackets of the Item's label (`"... [    %%]"`) instead of outside.

If they're outside, they mess up the rendering on iPhone/iPad apps.  This happens for Humidity Items that are carried over from the MiOS system.