### PR TITLE
Zwave device version comparisson

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
@@ -66,6 +66,8 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 
 	private TimerTask timerTask = null;
 	
+	private final String MAX_VERSION = "255.255";
+	
 	private PendingConfiguration PendingCfg = new PendingConfiguration();
 
 	/**
@@ -143,7 +145,7 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 				break;
 			case 4:
 				// Get product
-				if (database.FindProduct(Integer.parseInt(splitDomain[1]), Integer.parseInt(splitDomain[2]), Integer.parseInt(splitDomain[3]), Double.MAX_VALUE) == false) {
+				if (database.FindProduct(Integer.parseInt(splitDomain[1]), Integer.parseInt(splitDomain[2]), Integer.parseInt(splitDomain[3]), MAX_VERSION) == false) {
 					break;
 				}
 
@@ -162,7 +164,7 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 				break;
 			case 5:
 				// Get product
-				if (database.FindProduct(Integer.parseInt(splitDomain[1]), Integer.parseInt(splitDomain[2]), Integer.parseInt(splitDomain[3]), Double.MAX_VALUE) == false) {
+				if (database.FindProduct(Integer.parseInt(splitDomain[1]), Integer.parseInt(splitDomain[2]), Integer.parseInt(splitDomain[3]), MAX_VERSION) == false) {
 					break;
 				}
 
@@ -491,7 +493,7 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 						record.value = "Unknown";
 					}
 					else {
-						record.value = Double.toString(versionCommandClass.getProtocolVersion());
+						record.value = versionCommandClass.getProtocolVersion();
 					}
 					records.add(record);
 
@@ -500,7 +502,7 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 						record.value = "Unknown";
 					}
 					else {
-						record.value = Double.toString(versionCommandClass.getApplicationVersion());
+						record.value = versionCommandClass.getApplicationVersion();
 					}
 					records.add(record);
 				}

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbProduct.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbProduct.java
@@ -42,12 +42,12 @@ public class ZWaveDbProduct {
 		String Filename;
 	}
 
-	public String getConfigFile(Double version) {
+	public String getConfigFile(String version) {
 		if(ConfigFile == null) {
 			return null;
 		}
 
-		Version vIn = new Version(Double.toString(version));
+		Version vIn = new Version(version);
 		String filename = null;
 		// Check for a version'ed file
 		// There are multiple permutations of the file that we need to account for -:

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveProductDatabase.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveProductDatabase.java
@@ -42,7 +42,7 @@ public class ZWaveProductDatabase {
 	ZWaveDbProduct selProduct = null;
 
 	ZWaveDbProductFile productFile = null;
-	double productVersion;
+	String productVersion;
 
 	public ZWaveProductDatabase() {
 		loadDatabase();
@@ -194,7 +194,7 @@ public class ZWaveProductDatabase {
 	 *            The product ID
 	 * @return true if the product was found
 	 */
-	public boolean FindProduct(int manufacturerId, int productType, int productId, double version) {
+	public boolean FindProduct(int manufacturerId, int productType, int productId, String version) {
 		if (FindManufacturer(manufacturerId) == false) {
 			return false;
 		}
@@ -212,7 +212,7 @@ public class ZWaveProductDatabase {
 	 *            The product ID
 	 * @return true if the product was found
 	 */
-	public boolean FindProduct(int productType, int productId, double version) {
+	public boolean FindProduct(int productType, int productId, String version) {
 		if (selManufacturer == null) {
 			return false;
 		}

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -404,16 +404,16 @@ public class ZWaveNode {
 	 * Gets the node application firmware version
 	 * @return the version
 	 */
-	public double getApplicationVersion() {
+	public String getApplicationVersion() {
 		ZWaveVersionCommandClass versionCmdClass = (ZWaveVersionCommandClass) this.getCommandClass(CommandClass.VERSION);
 		if(versionCmdClass == null) {
-			return 0.0;
+			return "0.0";
 		}
 
-		Double appVersion = versionCmdClass.getApplicationVersion();
+		String appVersion = versionCmdClass.getApplicationVersion();
 		if(appVersion == null) {
 			logger.trace("NODE {}: App version requested but version is unknown", this.getNodeId());
-			return 0.0;			
+			return "0.0";
 		}
 		
 		return appVersion;

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveVersionCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveVersionCommandClass.java
@@ -45,8 +45,8 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
 	public static final int VERSION_COMMAND_CLASS_REPORT = 0x14;
 	
 	private LibraryType libraryType = LibraryType.LIB_UNKNOWN;
-	private Double protocolVersion;
-	private Double applicationVersion;
+	private String protocolVersion;
+	private String applicationVersion;
 	
 	/**
 	 * Creates a new instance of the ZWaveVersionCommandClass class.
@@ -85,10 +85,10 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
 			case VERSION_REPORT:
 				logger.debug("NODE {}: Process Version Report", this.getNode().getNodeId());
 				libraryType = LibraryType.getLibraryType(serialMessage.getMessagePayloadByte(offset + 1));
-				protocolVersion = (double)serialMessage.getMessagePayloadByte(offset + 2) +
-					    ((double)serialMessage.getMessagePayloadByte(offset + 3) / 10);
-				applicationVersion = serialMessage.getMessagePayloadByte(offset + 4) +
-						((double)serialMessage.getMessagePayloadByte(offset + 5) / 10);
+				protocolVersion = Integer.toString(serialMessage.getMessagePayloadByte(offset + 2)) + "." +
+					    Integer.toString(serialMessage.getMessagePayloadByte(offset + 3));
+				applicationVersion = Integer.toString(serialMessage.getMessagePayloadByte(offset + 4)) + "." +
+						Integer.toString(serialMessage.getMessagePayloadByte(offset + 5));
 				
 				logger.debug(String.format("NODE %d: Library Type = 0x%02x", this.getNode().getNodeId(), libraryType.key));
 				logger.debug(String.format("NODE %d: Protocol Version = %.1f", this.getNode().getNodeId(), protocolVersion));
@@ -209,7 +209,7 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
 	 * Returns the version of the protocol used by the device
 	 * @return Protocol version as double (version . subversion) 
 	 */
-	public Double getProtocolVersion() {
+	public String getProtocolVersion() {
 		return protocolVersion;
 	}
 	
@@ -217,7 +217,7 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
 	 * Returns the version of the firmware used by the device
 	 * @return Application version as double (version . subversion) 
 	 */
-	public Double getApplicationVersion() {
+	public String getApplicationVersion() {
 		return applicationVersion;
 	}
 	


### PR DESCRIPTION
This changes the version comparison from a double to a string. The double was previously used when it was thought that the version was a simple number - it's not - the minor and major parts need to be considered separately and here the double causes problems.
This converts all usage of versions to strings. The actual string comparison hasn't changed as that used the OSGi version classes since the minor/major issue was discovered.