### PR TITLE
Issue#2362 Core-Rules: Rule threading/Context corruption issue (Thread Safety)

### DIFF
--- a/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/internal/engine/RuleEngine.java
+++ b/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/internal/engine/RuleEngine.java
@@ -46,281 +46,283 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 
-
 /**
- * This class is the core of the openHAB rule engine.
- * It listens to changes to the rules folder, evaluates the trigger conditions of the rules and
- * schedules them for execution dependent on their triggering conditions.
+ * This class is the core of the openHAB rule engine. It listens to changes to the rules folder, evaluates the trigger
+ * conditions of the rules and schedules them for execution dependent on their triggering conditions.
  * 
  * @author Kai Kreuzer
  * @since 0.9.0
- *
+ * 
  */
 @SuppressWarnings("restriction")
-public class RuleEngine implements EventHandler, ItemRegistryChangeListener, StateChangeListener, ModelRepositoryChangeListener {
+public class RuleEngine implements EventHandler, ItemRegistryChangeListener, StateChangeListener,
+		ModelRepositoryChangeListener {
 
-		static private final Logger logger = LoggerFactory.getLogger(RuleEngine.class);
-		
-		private ItemRegistry itemRegistry;
-		private ModelRepository modelRepository;
-		private ScriptEngine scriptEngine;
+	static private final Logger logger = LoggerFactory.getLogger(RuleEngine.class);
 
-		private RuleTriggerManager triggerManager;
-						
-		public void activate() {
-			triggerManager = new RuleTriggerManager();
+	private ItemRegistry itemRegistry;
+	private ModelRepository modelRepository;
+	private ScriptEngine scriptEngine;
 
-			if(!isEnabled()) {
-				logger.info("Rule engine is disabled.");
-				return;
+	private RuleTriggerManager triggerManager;
+
+	public void activate() {
+		triggerManager = new RuleTriggerManager();
+
+		if (!isEnabled()) {
+			logger.info("Rule engine is disabled.");
+			return;
+		}
+
+		logger.debug("Started rule engine");
+
+		// read all rule files
+		Iterable<String> ruleModelNames = modelRepository.getAllModelNamesOfType("rules");
+		ArrayList<String> clonedList = Lists.newArrayList(ruleModelNames);
+		for (String ruleModelName : clonedList) {
+			EObject model = modelRepository.getModel(ruleModelName);
+			if (model instanceof RuleModel) {
+				RuleModel ruleModel = (RuleModel) model;
+				triggerManager.addRuleModel(ruleModel);
 			}
-			
-			logger.debug("Started rule engine");		
-			
-			// read all rule files
-			Iterable<String> ruleModelNames = modelRepository.getAllModelNamesOfType("rules");
-			ArrayList<String> clonedList = Lists.newArrayList(ruleModelNames);
-			for(String ruleModelName : clonedList) {
-				EObject model = modelRepository.getModel(ruleModelName);
-				if(model instanceof RuleModel) {
-					RuleModel ruleModel = (RuleModel) model;
-					triggerManager.addRuleModel(ruleModel);
-				}
-			}
-			
-			// register us on all items which are already available in the registry
-			for(Item item : itemRegistry.getItems()) {
-				internalItemAdded(item);
-			}
-			runStartupRules();
-		}
-		
-		public void deactivate() {
-			// execute all scripts that were registered for system shutdown
-			executeRules(triggerManager.getRules(SHUTDOWN));
-			triggerManager.clearAll();
-			triggerManager = null;
-		}
-		
-		public void setItemRegistry(ItemRegistry itemRegistry) {
-			this.itemRegistry = itemRegistry;
-			itemRegistry.addItemRegistryChangeListener(this);
-		}
-		
-		public void unsetItemRegistry(ItemRegistry itemRegistry) {
-			itemRegistry.removeItemRegistryChangeListener(this);
-			this.itemRegistry = null;
-		}
-		
-		public void setModelRepository(ModelRepository modelRepository) {
-			this.modelRepository = modelRepository;
-			modelRepository.addModelRepositoryChangeListener(this);
 		}
 
-		public void unsetModelRepository(ModelRepository modelRepository) {
-			modelRepository.removeModelRepositoryChangeListener(this);
-			this.modelRepository = null;
-		}
-		
-		public void setScriptEngine(ScriptEngine scriptEngine) {
-			this.scriptEngine = scriptEngine;
-		}
-
-		public void unsetScriptEngine(ScriptEngine scriptEngine) {
-			this.scriptEngine = null;
-		}
-
-		/**
-		 * {@inheritDoc}
-		 */
-		public void allItemsChanged(Collection<String> oldItemNames) {
-			// add the current items again
-			Collection<Item> items = itemRegistry.getItems();
-			for(Item item : items) {
-				internalItemAdded(item);
-			}
-			runStartupRules();
-		}
-
-		/**
-		 * {@inheritDoc}
-		 */
-		public void itemAdded(Item item) {
+		// register us on all items which are already available in the registry
+		for (Item item : itemRegistry.getItems()) {
 			internalItemAdded(item);
-			runStartupRules();
 		}
+		runStartupRules();
+	}
 
-		/**
-		 * {@inheritDoc}
-		 */
-		public void itemRemoved(Item item) {
-			if (item instanceof GenericItem) {
-				GenericItem genericItem = (GenericItem) item;
-				genericItem.removeStateChangeListener(this);
-			}
+	public void deactivate() {
+		// execute all scripts that were registered for system shutdown
+		executeRules(triggerManager.getRules(SHUTDOWN));
+		triggerManager.clearAll();
+		triggerManager = null;
+	}
+
+	public void setItemRegistry(ItemRegistry itemRegistry) {
+		this.itemRegistry = itemRegistry;
+		itemRegistry.addItemRegistryChangeListener(this);
+	}
+
+	public void unsetItemRegistry(ItemRegistry itemRegistry) {
+		itemRegistry.removeItemRegistryChangeListener(this);
+		this.itemRegistry = null;
+	}
+
+	public void setModelRepository(ModelRepository modelRepository) {
+		this.modelRepository = modelRepository;
+		modelRepository.addModelRepositoryChangeListener(this);
+	}
+
+	public void unsetModelRepository(ModelRepository modelRepository) {
+		modelRepository.removeModelRepositoryChangeListener(this);
+		this.modelRepository = null;
+	}
+
+	public void setScriptEngine(ScriptEngine scriptEngine) {
+		this.scriptEngine = scriptEngine;
+	}
+
+	public void unsetScriptEngine(ScriptEngine scriptEngine) {
+		this.scriptEngine = null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public void allItemsChanged(Collection<String> oldItemNames) {
+		// add the current items again
+		Collection<Item> items = itemRegistry.getItems();
+		for (Item item : items) {
+			internalItemAdded(item);
 		}
+		runStartupRules();
+	}
 
-		/**
-		 * {@inheritDoc}
-		 */
-		public void stateChanged(Item item, State oldState, State newState) {			
-			if(triggerManager!=null) {
-				Iterable<Rule> rules = triggerManager.getRules(CHANGE, item, oldState, newState);
-				RuleEvaluationContext context = new RuleEvaluationContext();
+	/**
+	 * {@inheritDoc}
+	 */
+	public void itemAdded(Item item) {
+		internalItemAdded(item);
+		runStartupRules();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public void itemRemoved(Item item) {
+		if (item instanceof GenericItem) {
+			GenericItem genericItem = (GenericItem) item;
+			genericItem.removeStateChangeListener(this);
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public void stateChanged(Item item, State oldState, State newState) {
+		if (triggerManager != null) {
+			RuleEvaluationContext context;
+			Iterable<Rule> rules = triggerManager.getRules(CHANGE, item, oldState, newState);
+
+			for (Rule rule : rules) {
+				context = new RuleEvaluationContext();
 				context.newValue(QualifiedName.create(RuleContextHelper.VAR_PREVIOUS_STATE), oldState);
-				executeRules(rules, context);
-			}
-		}
-
-		/**
-		 * {@inheritDoc}
-		 */
-		public void stateUpdated(Item item, State state) {
-			if(triggerManager!=null) {
-				Iterable<Rule> rules = triggerManager.getRules(UPDATE, item, state);
-				executeRules(rules);
-			}
-		}
-
-		public void receiveCommand(String itemName, Command command) {
-			if(triggerManager!=null && itemRegistry!=null) {
-				try {
-					Item item = itemRegistry.getItem(itemName);
-					Iterable<Rule> rules = triggerManager.getRules(COMMAND, item, command);
-					RuleEvaluationContext context = new RuleEvaluationContext();
-					context.newValue(QualifiedName.create(RuleContextHelper.VAR_RECEIVED_COMMAND), command);
-					executeRules(rules, context);
-				} catch (ItemNotFoundException e) {
-					// ignore commands for non-existent items
-				}
-			}
-		}
-		
-		private void internalItemAdded(Item item) {
-			if (item instanceof GenericItem) {
-				GenericItem genericItem = (GenericItem) item;
-				genericItem.addStateChangeListener(this);
-			}
-		}
-
-		/**
-		 * {@inheritDoc}
-		 */
-		public void handleEvent(Event event) {  
-			String itemName = (String) event.getProperty("item");
-			
-			String topic = event.getTopic();
-			String[] topicParts = topic.split(TOPIC_SEPERATOR);
-			
-			if(!(topicParts.length > 2) || !topicParts[0].equals(TOPIC_PREFIX)) {
-				return; // we have received an event with an invalid topic
-			}
-			String operation = topicParts[1];
-			
-			if(operation.equals(EventType.COMMAND.toString())) {
-				Command command = (Command) event.getProperty("command");
-				if(command!=null) receiveCommand(itemName, command);
-			}
-		}
-
-		public void modelChanged(String modelName, org.openhab.model.core.EventType type) {
-			if (triggerManager != null) {
-				if(isEnabled() && modelName.endsWith("rules")) {
-					RuleModel model = (RuleModel) modelRepository.getModel(modelName);
-	
-					// remove the rules from the trigger sets
-					if(type == org.openhab.model.core.EventType.REMOVED ||
-							type == org.openhab.model.core.EventType.MODIFIED) {
-						triggerManager.removeRuleModel(model);
-					}
-	
-					// add new and modified rules to the trigger sets
-					if(model!=null && 
-							(type == org.openhab.model.core.EventType.ADDED 
-							|| type == org.openhab.model.core.EventType.MODIFIED)) {
-						triggerManager.addRuleModel(model);
-						// now execute all rules that are meant to trigger at startup
-						runStartupRules();
-					}
-				}
-			}
-		}
-
-		private void runStartupRules() {
-			if (triggerManager!=null) {
-				Iterable<Rule> startupRules = triggerManager.getRules(STARTUP);
-				List<Rule> executedRules = Lists.newArrayList();
-				
-				for(Rule rule : startupRules) {
-					try {
-						Script script = scriptEngine.newScriptFromXExpression(rule.getScript());						
-						logger.debug("Executing startup rule '{}'", rule.getName());
-						RuleEvaluationContext context = new RuleEvaluationContext();
-						context.setGlobalContext(RuleContextHelper.getContext(rule));
-						script.execute(context);
-						executedRules.add(rule);
-					} catch (ScriptExecutionException e) {
-						String causeMessage = getCauseMessage(e);
-						if (e.getCause() instanceof ItemNotFoundException
-								|| causeMessage.contains("cannot be resolved to an item or type")) {
-							logger.debug("Not all required items in place yet for rule {}, trying again later: {}",
-									new Object[] { rule.getName(), causeMessage });
-							// we do not seem to have all required items in place yet
-							// so we keep the rule in the list and try it again later
-						} else {
-							logger.error("Error during the execution of startup rule '{}': {}",
-									new Object[] { rule.getName(), causeMessage });
-							executedRules.add(rule);
-						}
-					}
-				}
-				for(Rule rule : executedRules) {
-					triggerManager.removeRule(STARTUP, rule);
-				}
-			}
-		}
-		
-		private String getCauseMessage(Throwable t) {
-			String message = "";
-			if (t.getCause() != null && t.getCause().getMessage() != null) {
-				message = t.getCause().getMessage();
-			}
-			return message;
-		}
-
-		protected synchronized void executeRule(Rule rule) {
-			executeRule(rule, new RuleEvaluationContext());
-		}
-			
-		protected synchronized void executeRule(Rule rule, RuleEvaluationContext context) {
-			Script script = scriptEngine.newScriptFromXExpression(rule.getScript());
-			
-			logger.debug("Executing rule '{}'", rule.getName());
-			
-			context.setGlobalContext(RuleContextHelper.getContext(rule));
-			
-			ScriptExecutionThread thread = new ScriptExecutionThread(rule.getName(), script, context);
-			thread.start();
-		}
-
-		protected synchronized void executeRules(Iterable<Rule> rules) {
-			executeRules(rules, new RuleEvaluationContext());
-		}
-		
-		protected synchronized void executeRules(Iterable<Rule> rules, RuleEvaluationContext context) {
-			for(Rule rule : rules) {
 				executeRule(rule, context);
 			}
 		}
-				
-		/**
-		 * we need to be able to deactivate the rule execution, otherwise the openHAB designer
-		 * would also execute the rules.
-		 * 
-		 * @return true, if rules should be executed, false otherwise
-		 */
-		private boolean isEnabled() {
-			return !"true".equalsIgnoreCase(System.getProperty("noRules"));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public void stateUpdated(Item item, State state) {
+		if (triggerManager != null) {
+			Iterable<Rule> rules = triggerManager.getRules(UPDATE, item, state);
+			executeRules(rules);
 		}
-		
+	}
+
+	public void receiveCommand(String itemName, Command command) {
+		if (triggerManager != null && itemRegistry != null) {
+			try {
+				RuleEvaluationContext context;
+				Item item = itemRegistry.getItem(itemName);
+				Iterable<Rule> rules = triggerManager.getRules(COMMAND, item, command);
+
+				for (Rule rule : rules) {
+					context = new RuleEvaluationContext();
+					context.newValue(QualifiedName.create(RuleContextHelper.VAR_RECEIVED_COMMAND), command);
+					executeRule(rule, context);
+				}
+			} catch (ItemNotFoundException e) {
+				// ignore commands for non-existent items
+			}
+		}
+	}
+
+	private void internalItemAdded(Item item) {
+		if (item instanceof GenericItem) {
+			GenericItem genericItem = (GenericItem) item;
+			genericItem.addStateChangeListener(this);
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public void handleEvent(Event event) {
+		String itemName = (String) event.getProperty("item");
+
+		String topic = event.getTopic();
+		String[] topicParts = topic.split(TOPIC_SEPERATOR);
+
+		if (!(topicParts.length > 2) || !topicParts[0].equals(TOPIC_PREFIX)) {
+			return; // we have received an event with an invalid topic
+		}
+		String operation = topicParts[1];
+
+		if (operation.equals(EventType.COMMAND.toString())) {
+			Command command = (Command) event.getProperty("command");
+			if (command != null)
+				receiveCommand(itemName, command);
+		}
+	}
+
+	public void modelChanged(String modelName, org.openhab.model.core.EventType type) {
+		if (triggerManager != null) {
+			if (isEnabled() && modelName.endsWith("rules")) {
+				RuleModel model = (RuleModel) modelRepository.getModel(modelName);
+
+				// remove the rules from the trigger sets
+				if (type == org.openhab.model.core.EventType.REMOVED
+						|| type == org.openhab.model.core.EventType.MODIFIED) {
+					triggerManager.removeRuleModel(model);
+				}
+
+				// add new and modified rules to the trigger sets
+				if (model != null
+						&& (type == org.openhab.model.core.EventType.ADDED || type == org.openhab.model.core.EventType.MODIFIED)) {
+					triggerManager.addRuleModel(model);
+					// now execute all rules that are meant to trigger at startup
+					runStartupRules();
+				}
+			}
+		}
+	}
+
+	private void runStartupRules() {
+		if (triggerManager != null) {
+			Iterable<Rule> startupRules = triggerManager.getRules(STARTUP);
+			List<Rule> executedRules = Lists.newArrayList();
+
+			for (Rule rule : startupRules) {
+				try {
+					Script script = scriptEngine.newScriptFromXExpression(rule.getScript());
+					logger.debug("Executing startup rule '{}'", rule.getName());
+					RuleEvaluationContext context = new RuleEvaluationContext();
+					context.setGlobalContext(RuleContextHelper.getContext(rule));
+					script.execute(context);
+					executedRules.add(rule);
+				} catch (ScriptExecutionException e) {
+					String causeMessage = getCauseMessage(e);
+					if (e.getCause() instanceof ItemNotFoundException
+							|| causeMessage.contains("cannot be resolved to an item or type")) {
+						logger.debug("Not all required items in place yet for rule {}, trying again later: {}",
+								new Object[] { rule.getName(), causeMessage });
+						// we do not seem to have all required items in place yet
+						// so we keep the rule in the list and try it again later
+					} else {
+						logger.error("Error during the execution of startup rule '{}': {}",
+								new Object[] { rule.getName(), causeMessage });
+						executedRules.add(rule);
+					}
+				}
+			}
+			for (Rule rule : executedRules) {
+				triggerManager.removeRule(STARTUP, rule);
+			}
+		}
+	}
+
+	private String getCauseMessage(Throwable t) {
+		String message = "";
+		if (t.getCause() != null && t.getCause().getMessage() != null) {
+			message = t.getCause().getMessage();
+		}
+		return message;
+	}
+
+	protected synchronized void executeRule(Rule rule) {
+		executeRule(rule, new RuleEvaluationContext());
+	}
+
+	protected synchronized void executeRule(Rule rule, RuleEvaluationContext context) {
+		Script script = scriptEngine.newScriptFromXExpression(rule.getScript());
+
+		logger.debug("Executing rule '{}'", rule.getName());
+
+		context.setGlobalContext(RuleContextHelper.getContext(rule));
+
+		ScriptExecutionThread thread = new ScriptExecutionThread(rule.getName(), script, context);
+		thread.start();
+	}
+
+	protected synchronized void executeRules(Iterable<Rule> rules) {
+		for (Rule rule : rules) {
+			executeRule(rule);
+		}
+	}
+
+	/**
+	 * we need to be able to deactivate the rule execution, otherwise the openHAB designer would also execute the rules.
+	 * 
+	 * @return true, if rules should be executed, false otherwise
+	 */
+	private boolean isEnabled() {
+		return !"true".equalsIgnoreCase(System.getProperty("noRules"));
+	}
+
 }


### PR DESCRIPTION
See Issue #2362 for details.

I unravel any sharing of contexts, occurring within the file, so a unique `RuleEvaluationContext` is used in all cases.  Changes mostly relate to changing `executeRules(...)` calls, so they don't take a [shared] `RuleEvaluationContext`

The rest of the diffs are due to formatting changes (use of newer Eclipse openHAB profile)

After the change, the testcase from Issue #2362 is running correctly (tweaked TC to run every second instead of every 10)
```log
10:53:26.005 DEBUG o.o.m.r.i.e.ExecuteRuleJob[:53]- Executing scheduled rule 'context trigger'
10:53:26.005 INFO  o.o.m.script.context-trigger[:53]- Beforecontext trigger
10:53:26.006 INFO  o.o.m.script.context-trigger[:53]- Aftercontext trigger
10:53:26.006 DEBUG o.o.m.r.i.engine.RuleEngine[:305]- Executing rule 'context a'
10:53:26.007 DEBUG o.o.m.r.i.engine.RuleEngine[:305]- Executing rule 'context b'
10:53:26.007 INFO  o.o.model.script.context-a[:53]- context a
10:53:26.007 INFO  o.o.model.script.context-b[:53]- context b
10:53:27.005 DEBUG o.o.m.r.i.e.ExecuteRuleJob[:53]- Executing scheduled rule 'context trigger'
10:53:27.005 INFO  o.o.m.script.context-trigger[:53]- Beforecontext trigger
10:53:27.006 INFO  o.o.m.script.context-trigger[:53]- Aftercontext trigger
10:53:27.007 DEBUG o.o.m.r.i.engine.RuleEngine[:305]- Executing rule 'context a'
10:53:27.007 DEBUG o.o.m.r.i.engine.RuleEngine[:305]- Executing rule 'context b'
10:53:27.007 INFO  o.o.model.script.context-a[:53]- context a
10:53:27.008 INFO  o.o.model.script.context-b[:53]- context b
10:53:28.005 DEBUG o.o.m.r.i.e.ExecuteRuleJob[:53]- Executing scheduled rule 'context trigger'
10:53:28.006 INFO  o.o.m.script.context-trigger[:53]- Beforecontext trigger
10:53:28.007 INFO  o.o.m.script.context-trigger[:53]- Aftercontext trigger
10:53:28.007 DEBUG o.o.m.r.i.engine.RuleEngine[:305]- Executing rule 'context a'
10:53:28.007 DEBUG o.o.m.r.i.engine.RuleEngine[:305]- Executing rule 'context b'
10:53:28.008 INFO  o.o.model.script.context-a[:53]- context a
10:53:28.008 INFO  o.o.model.script.context-b[:53]- context b
10:53:29.005 DEBUG o.o.m.r.i.e.ExecuteRuleJob[:53]- Executing scheduled rule 'context trigger'
10:53:29.006 INFO  o.o.m.script.context-trigger[:53]- Beforecontext trigger
10:53:29.007 INFO  o.o.m.script.context-trigger[:53]- Aftercontext trigger
10:53:29.008 DEBUG o.o.m.r.i.engine.RuleEngine[:305]- Executing rule 'context a'
10:53:29.008 DEBUG o.o.m.r.i.engine.RuleEngine[:305]- Executing rule 'context b'
10:53:29.008 INFO  o.o.model.script.context-a[:53]- context a
10:53:29.009 INFO  o.o.model.script.context-b[:53]- context b
10:53:30.005 DEBUG o.o.m.r.i.e.ExecuteRuleJob[:53]- Executing scheduled rule 'context trigger'
10:53:30.005 INFO  o.o.m.script.context-trigger[:53]- Beforecontext trigger
10:53:30.006 INFO  o.o.m.script.context-trigger[:53]- Aftercontext trigger
10:53:30.006 DEBUG o.o.m.r.i.engine.RuleEngine[:305]- Executing rule 'context a'
10:53:30.007 DEBUG o.o.m.r.i.engine.RuleEngine[:305]- Executing rule 'context b'
10:53:30.007 INFO  o.o.model.script.context-a[:53]- context a
10:53:30.008 INFO  o.o.model.script.context-b[:53]- context b
10:53:31.005 DEBUG o.o.m.r.i.e.ExecuteRuleJob[:53]- Executing scheduled rule 'context trigger'
10:53:31.005 INFO  o.o.m.script.context-trigger[:53]- Beforecontext trigger
10:53:31.006 INFO  o.o.m.script.context-trigger[:53]- Aftercontext trigger
10:53:31.006 DEBUG o.o.m.r.i.engine.RuleEngine[:305]- Executing rule 'context a'
10:53:31.007 DEBUG o.o.m.r.i.engine.RuleEngine[:305]- Executing rule 'context b'
10:53:31.007 INFO  o.o.model.script.context-a[:53]- context a
10:53:31.008 INFO  o.o.model.script.context-b[:53]- context b
```