### PR TITLE
Add support for ecobee3 remote sensors + bug fixes

### DIFF
--- a/bundles/binding/org.openhab.binding.ecobee/OSGI-INF/binding.xml
+++ b/bundles/binding/org.openhab.binding.ecobee/OSGI-INF/binding.xml
@@ -23,9 +23,6 @@
 	<reference bind="setEventPublisher" cardinality="1..1"
 		interface="org.openhab.core.events.EventPublisher" name="EventPublisher"
 		policy="dynamic" unbind="unsetEventPublisher" />
-	<reference bind="setItemRegistry" cardinality="1..1" 
-		interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" 
-		policy="dynamic" unbind="unsetItemRegistry" />
 	<reference bind="addBindingProvider" cardinality="1..n"
 		interface="org.openhab.binding.ecobee.EcobeeBindingProvider" name="EcobeeBindingProvider"
 		policy="dynamic" unbind="removeBindingProvider" />

--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
@@ -51,7 +51,6 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 import org.openhab.core.binding.AbstractActiveBinding;
 import org.openhab.core.binding.BindingProvider;
-import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
@@ -169,36 +168,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 	 */
 	private List<String> ignoreEventList = Collections.synchronizedList(new ArrayList<String>());
 
-	/**
-	 * The most recently received list of revisions, or an empty Map if none have been retrieved yet.
-	 */
-	private Map<String, Revision> lastRevisionMap = new HashMap<String, Revision>();
-
-	// Injected by the OSGi Container through the setItemRegistry and
-	// unsetItemRegistry methods.
-	private ItemRegistry itemRegistry;
-
 	public EcobeeBinding() {
-	}
-
-	/**
-	 * Invoked by the OSGi Framework.
-	 * 
-	 * This method is invoked by OSGi during the initialization of the EcobeeBinding, so we have subsequent access to
-	 * the ItemRegistry (needed to get values from Items in openHAB)
-	 */
-	public void setItemRegistry(ItemRegistry itemRegistry) {
-		this.itemRegistry = itemRegistry;
-	}
-
-	/**
-	 * Invoked by the OSGi Framework.
-	 * 
-	 * This method is invoked by OSGi during the initialization of the EcobeeBinding, so we have subsequent access to
-	 * the ItemRegistry (needed to get values from Items in openHAB)
-	 */
-	public void unsetItemRegistry(ItemRegistry itemRegistry) {
-		this.itemRegistry = null;
 	}
 
 	/**
@@ -309,7 +279,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 		Set<String> thermostatIdentifiers = new HashSet<String>();
 
 		for (Revision newRevision : newRevisionMap.values()) {
-			Revision lastRevision = this.lastRevisionMap.get(newRevision.getThermostatIdentifier());
+			Revision lastRevision = oauthCredentials.getLastRevisionMap().get(newRevision.getThermostatIdentifier());
 
 			// If this thermostat's values have changed,
 			// add it to the list for full retrieval
@@ -324,8 +294,8 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 			boolean changed = false;
 
 			changed = changed
-					|| (newRevision.hasRuntimeChanged(lastRevision) && (selection.includeRuntime() || selection
-							.includeExtendedRuntime()));
+					|| (newRevision.hasRuntimeChanged(lastRevision) && (selection.includeRuntime()
+							|| selection.includeExtendedRuntime() || selection.includeSensors()));
 			changed = changed
 					|| (newRevision.hasThermostatChanged(lastRevision) && (selection.includeSettings() || selection
 							.includeProgram()));
@@ -336,7 +306,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 		}
 
 		// Remember the new revisions for the next execute() call.
-		this.lastRevisionMap = newRevisionMap;
+		oauthCredentials.setLastRevisionMap(newRevisionMap);
 
 		if (0 == thermostatIdentifiers.size()) {
 			logger.debug("No changes detected.");
@@ -369,28 +339,18 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 		// Iterate through bindings and update all inbound values.
 		for (final EcobeeBindingProvider provider : this.providers) {
 			for (final String itemName : provider.getItemNames()) {
-				if (provider.isInBound(itemName)) {
+				if (provider.isInBound(itemName) && credentialsMatch(provider, itemName, oauthCredentials)) {
 					final State newState = getState(provider, thermostats, itemName);
-					State oldState = (itemRegistry == null) ? null : itemRegistry.getItem(itemName).getState();
 
-					if ((oldState == null && newState != null)
-							|| (UnDefType.UNDEF.equals(oldState) && !UnDefType.UNDEF.equals(newState))
-							|| !oldState.equals(newState)) {
-						logger.debug("readEcobee: Updating itemName '{}' with newState '{}', oldState '{}'", itemName,
-								newState, oldState);
+					logger.debug("readEcobee: Updating itemName '{}' with newState '{}'", itemName, newState);
 
-						/*
-						 * we need to make sure that we won't send out this event to Ecobee again, when receiving it on
-						 * the openHAB bus
-						 */
-						ignoreEventList.add(itemName + newState.toString());
-						logger.trace("Added event (item='{}', newState='{}') to the ignore event list", itemName,
-								newState);
-						this.eventPublisher.postUpdate(itemName, newState);
-					} else {
-						logger.trace("readEcobee: Ignoring item='{}' with newState='{}', oldState='{}'", itemName,
-								newState, oldState);
-					}
+					/*
+					 * we need to make sure that we won't send out this event to Ecobee again, when receiving it on the
+					 * openHAB bus
+					 */
+					ignoreEventList.add(itemName + newState.toString());
+					logger.trace("Added event (item='{}', newState='{}') to the ignore event list", itemName, newState);
+					this.eventPublisher.postUpdate(itemName, newState);
 				}
 			}
 		}
@@ -461,6 +421,8 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 			}
 		} else if (Temperature.class.isAssignableFrom(dataType)) {
 			return new DecimalType(((Temperature) propertyValue).toLocalTemperature());
+		} else if (State.class.isAssignableFrom(dataType)) {
+			return (State) propertyValue;
 		} else {
 			return new StringType(propertyValue.toString());
 		}
@@ -537,7 +499,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 		} else {
 			final Selection selection = new Selection(selectionMatch);
 			List<AbstractFunction> functions = null;
-			logger.debug("Selection for update: {}", selection);
+			logger.trace("Selection for update: {}", selection);
 
 			String property = provider.getProperty(itemName);
 
@@ -548,7 +510,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 
 				thermostat.setProperty(property, newState);
 
-				logger.debug("Thermostat for update: {}", thermostat);
+				logger.trace("Thermostat for update: {}", thermostat);
 
 				OAuthCredentials oauthCredentials = getOAuthCredentials(provider.getUserid(itemName));
 
@@ -591,7 +553,8 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 		// Forget prior revisions because we may be concerned with
 		// different thermostats or properties than before.
 		if (provider instanceof EcobeeBindingProvider) {
-			this.lastRevisionMap.clear();
+			String userid = ((EcobeeBindingProvider) provider).getUserid(itemName);
+			getOAuthCredentials(userid).getLastRevisionMap().clear();
 		}
 	}
 
@@ -603,7 +566,9 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 		// Forget prior revisions because we may be concerned with
 		// different thermostats or properties than before.
 		if (provider instanceof EcobeeBindingProvider) {
-			this.lastRevisionMap.clear();
+			for (String userid : this.credentialsCache.keySet()) {
+				getOAuthCredentials(userid).getLastRevisionMap().clear();
+			}
 		}
 	}
 
@@ -715,6 +680,23 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 	}
 
 	/**
+	 * Return true if the given itemName pertains to the given OAuthCredentials. Since there is a single userid-based
+	 * mapping of credential objects for the binding, if the credentials object is the same object as the one in the
+	 * userid-based map, then we know that this item pertains to these credentials.
+	 * 
+	 * @param provider
+	 *            the binding provider
+	 * @param itemName
+	 *            the item name
+	 * @param oauthCredentials
+	 *            the OAuthCredentials to compare
+	 * @return true if the given itemName pertains to the given OAuthCredentials.
+	 */
+	private boolean credentialsMatch(EcobeeBindingProvider provider, String itemName, OAuthCredentials oauthCredentials) {
+		return oauthCredentials == getOAuthCredentials(provider.getUserid(itemName));
+	}
+
+	/**
 	 * Creates the necessary {@link Selection} object to request all information required from the Ecobee API for all
 	 * thermostats and sub-objects that have a binding, per set of credentials configured in openhab.cfg. One
 	 * {@link ThermostatRequest} can then query all information in one go.
@@ -741,8 +723,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 				 * We are also only concerned with items that can be reached by the given credentials.
 				 */
 
-				if (!provider.isInBound(itemName)
-						|| oauthCredentials != getOAuthCredentials(provider.getUserid(itemName))) {
+				if (!provider.isInBound(itemName) || !credentialsMatch(provider, itemName, oauthCredentials)) {
 					continue;
 				}
 
@@ -786,6 +767,8 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 					selection.setIncludePrivacy(true);
 				} else if (property.startsWith("version")) {
 					selection.setIncludeVersion(true);
+				} else if (property.startsWith("remoteSensors")) {
+					selection.setIncludeSensors(true);
 				}
 			}
 		}
@@ -894,6 +877,11 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 		 */
 		private String accessToken;
 
+		/**
+		 * The most recently received list of revisions, or an empty Map if none have been retrieved yet.
+		 */
+		private Map<String, Revision> lastRevisionMap = new HashMap<String, Revision>();
+
 		public OAuthCredentials(String userid) {
 
 			try {
@@ -902,6 +890,14 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 			} catch (Exception e) {
 				throw new EcobeeException("Cannot create OAuthCredentials.", e);
 			}
+		}
+
+		public Map<String, Revision> getLastRevisionMap() {
+			return this.lastRevisionMap;
+		}
+
+		public void setLastRevisionMap(final Map<String, Revision> lastRevisionMap) {
+			this.lastRevisionMap = lastRevisionMap;
 		}
 
 		private Preferences getPrefsNode() {

--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/messages/Selection.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/messages/Selection.java
@@ -87,6 +87,7 @@ public class Selection extends AbstractMessagePart {
 	private Boolean includeNotificationSettings;
 	private Boolean includePrivacy;
 	private Boolean includeVersion;
+	private Boolean includeSensors;
 
 	/**
 	 * The <code>SelectionType</code> defines the type of selection to perform.
@@ -740,6 +741,30 @@ public class Selection extends AbstractMessagePart {
 		this.includeVersion = includeVersion;
 	}
 
+	/**
+	 * @return include the {@link Thermostat.RemoteSensor}s. If not specified, defaults to <code>false</code>.
+	 */
+	@JsonProperty("includeSensors")
+	public Boolean getIncludeSensors() {
+		return this.includeSensors;
+	}
+
+	/**
+	 * @return <code>true</code> if we would like remote sensor information returned from this Selection.
+	 */
+	public boolean includeSensors() {
+		return (this.includeSensors == null) ? false : this.includeSensors;
+	}
+
+	/**
+	 * @param includeSensors
+	 *            include the {@link Thermostat.RemoteSensor}s. If not specified, defaults to <code>false</code>.
+	 */
+	@JsonProperty("includeSensors")
+	public void setIncludeSensors(final Boolean includeSensors) {
+		this.includeSensors = includeSensors;
+	}
+
 	@Override
 	public String toString() {
 		final ToStringBuilder builder = createToStringBuilder();
@@ -765,6 +790,7 @@ public class Selection extends AbstractMessagePart {
 		builder.append("includeNotificationSettings", this.includeNotificationSettings);
 		builder.append("includePrivacy", this.includePrivacy);
 		builder.append("includeVersion", this.includeVersion);
+		builder.append("includeSensors", this.includeSensors);
 
 		return builder.toString();
 	}

--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/messages/ThermostatRequest.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/messages/ThermostatRequest.java
@@ -40,10 +40,7 @@ public class ThermostatRequest extends AbstractRequest {
 	private final Page page;
 
 	/**
-	 * Creates a request for the measurements of a device or module.
-	 * 
-	 * If you don't specify a moduleId you will retrieve the device's measurements. If you do specify a moduleId you
-	 * will retrieve the module's measurements.
+	 * Creates a request for a selection of Thermostats.
 	 * 
 	 * @param accessToken
 	 * @param selection
@@ -68,6 +65,9 @@ public class ThermostatRequest extends AbstractRequest {
 			json = executeQuery(url);
 
 			final ThermostatResponse response = JSON.readValue(json, ThermostatResponse.class);
+
+			// build internal maps and fix any internal cross references
+			response.sync();
 
 			return response;
 		} catch (final Exception e) {

--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/messages/ThermostatResponse.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/messages/ThermostatResponse.java
@@ -48,6 +48,17 @@ public class ThermostatResponse extends ApiResponse {
 		return this.thermostatList;
 	}
 
+	/**
+	 * Fix up any internal references and create name-based maps for easy traversal.
+	 */
+	protected void sync() {
+		if (this.thermostatList != null) {
+			for (Thermostat t : this.thermostatList) {
+				t.sync();
+			}
+		}
+	}
+
 	@Override
 	public String toString() {
 		final ToStringBuilder builder = createToStringBuilder();

--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/messages/UpdateSensorFunction.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/messages/UpdateSensorFunction.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.ecobee.internal.messages;
+
+/**
+ * The update sensor function allows the caller to update the name of an ecobee3 remote sensor.
+ * 
+ * Each ecobee3 remote sensor "enclosure" contains two distinct sensors types temperature and occupancy. Only one of the
+ * sensors is required in the request. Both of the sensors' names will be updated to ensure consistency as they are part
+ * of the same remote sensor enclosure. This also reflects accurately what happens on the Thermostat itself.
+ * 
+ * Note: This function is restricted to the ecobee3 thermostat model only.
+ * 
+ * @see <a href="https://www.ecobee.com/home/developer/api/documentation/v1/functions/UpdateSensor.shtml">Update
+ *      Sensor</a>
+ * @author John Cocula
+ * @since 1.7.0
+ */
+public final class UpdateSensorFunction extends AbstractFunction {
+
+	/**
+	 * Construct an UpdateSensorFunction.
+	 * 
+	 * @param name
+	 *            the updated name to give the sensor. Has a max length of 32, but shorter is recommended.
+	 * @param deviceId
+	 *            the deviceId for the sensor, typically this indicates the enclosure and corresponds to the
+	 *            ThermostatRemoteSensor.id field. For example: <code>rs:100</code>
+	 * @param sensorId
+	 *            the identifier for the sensor within the enclosure. Corresponds to the RemoteSensorCapability.id. For
+	 *            example: 1
+	 */
+	public UpdateSensorFunction(final String name, final String deviceId, final String sensorId) {
+		super("updateSensor");
+
+		if (name == null || deviceId == null || sensorId == null) {
+			throw new IllegalArgumentException("name, deviceId and sensorId arguments are required.");
+		}
+
+		makeParams().put("name", name);
+		makeParams().put("deviceId", deviceId);
+		makeParams().put("sensorId", sensorId);
+	}
+}


### PR DESCRIPTION
This PR fixes a problem using the binding across two or more accounts #2367, removes interrogation of the item registry to suppress updates (based on recent discussions), and implements access to the wireless remote temperature/occupancy sensors that can be added to the ecobee3.  Issue #2366.
