### PR TITLE
Bug fix for KNX binding, Time update from ntp in March #2330

### DIFF
--- a/bundles/binding/org.openhab.binding.knx.test/src/test/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
+++ b/bundles/binding/org.openhab.binding.knx.test/src/test/java/org/openhab/binding/knx/internal/dpt/KNXCoreTypeMapperTest.java
@@ -984,7 +984,8 @@ public class KNXCoreTypeMapperTest {
 		 * 
 		 */
 		type=testToType(dpt, new byte[] { 0x00, 0x00, 0x00 }, DateTimeType.class);
-		testToDPTValue(dpt, type, "00:00:00");
+		String today=String.format(Locale.US, "%1$ta", Calendar.getInstance());
+		testToDPTValue(dpt, type, today+", 00:00:00");
 
 		/*
 		 * Set day to Monday, 0 hours, 0 minutes and 0 seconds January 5th, 1970 was a Monday


### PR DESCRIPTION
Removed workaround for KNX DPT_TIME. KNX time of type "no-day, HH:MM:SS"
will now be translated to current weekday: "Fri, HH:MM:SS" instead of
omitting the weekday part.