### PR TITLE
fix wiki links

### DIFF
--- a/bundles/io/org.openhab.io.dropbox/src/main/java/org/openhab/io/dropbox/internal/DropboxSynchronizer.java
+++ b/bundles/io/org.openhab.io.dropbox/src/main/java/org/openhab/io/dropbox/internal/DropboxSynchronizer.java
@@ -176,7 +176,7 @@ public class DropboxSynchronizer implements ManagedService {
 	 * @throws DbxException if there are technical or application level errors 
 	 * in the Dropbox communication
 	 * 
-	 * @see <a href="http://code.google.com/p/openhab/wiki/DropboxIOBundle">openHAB Dropbox Wiki</a>
+	 * @see <a href="https://github.com/openhab/openhab/wiki/Dropbox-IO">openHAB Dropbox IO Wiki</a>
 	 */
 	public void startAuthentication() throws DbxException {
 		DbxWebAuthNoRedirect webAuth = new DbxWebAuthNoRedirect(requestConfig, appInfo);
@@ -198,7 +198,7 @@ public class DropboxSynchronizer implements ManagedService {
 	 * @throws DbxException if there are technical or application level errors 
 	 * in the Dropbox communication
 	 * 
-	 * @see <a href="http://code.google.com/p/openhab/wiki/DropboxIOBundle">openHAB Dropbox Wiki</a>
+	 * @see <a href="https://github.com/openhab/openhab/wiki/Dropbox-IO">openHAB Dropbox IO Wiki</a>
 	 */
 	public void finishAuthentication(String code) throws DbxException {
 		DbxWebAuthNoRedirect webAuth = new DbxWebAuthNoRedirect(requestConfig, appInfo);

--- a/distribution/src/assemble/resources/README_DROOLS.TXT
+++ b/distribution/src/assemble/resources/README_DROOLS.TXT
@@ -9,4 +9,4 @@ This zip file contains the optional JBoss Drools support for openHAB.
 It can be manually added to the openHAB runtime by simply copying the
 content to ${openhab.home}.
 
-See http://code.google.com/p/openhab/wiki/Drools for more details.
+See https://github.com/openhab/openhab/wiki/Drools for more details.

--- a/distribution/src/assemble/resources/README_addons.TXT
+++ b/distribution/src/assemble/resources/README_addons.TXT
@@ -11,4 +11,4 @@ openHAB runtime by simply copying them to ${openhab.home}/addons.
 Each bundle (jar file) is a feature that can be installed independently from
 any other bundle in this zip file.
 You can thus decide yourself, what features you need and leave out the rest.
-See http://code.google.com/p/openhab/wiki/Addons for more details.
+See https://github.com/openhab/openhab/wiki/Addons for more details.

--- a/distribution/src/assemble/resources/README_greent.TXT
+++ b/distribution/src/assemble/resources/README_greent.TXT
@@ -10,4 +10,4 @@ It can be manually added to the openHAB runtime by simply copying the
 "greent" folder to ${openhab.home}/webapps. The UI is then accessible at
 http://localhost:8080/greent
 
-See http://code.google.com/p/openhab/wiki/TouchUI for more details.
+See https://github.com/openhab/openhab/wiki/TouchUI for more details.

--- a/distribution/src/assemble/resources/README_runtime.TXT
+++ b/distribution/src/assemble/resources/README_runtime.TXT
@@ -7,5 +7,5 @@
 
 This zip file contains the core runtime package of openHAB.
 
-See http://code.google.com/p/openhab/wiki/Setup for setup and
-configuration instructions.
+See https://github.com/openhab/openhab/wiki/Quick-Setup-an-openHAB-Server
+for setup and configuration instructions.


### PR DESCRIPTION
some links to wiki pages were still pointing to the former project wiki on code.google.com