### PR TITLE
Ihc command specific outbinding

### DIFF
--- a/bundles/binding/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/IhcBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/IhcBindingProvider.java
@@ -10,6 +10,7 @@ package org.openhab.binding.ihc;
 
 import org.openhab.core.binding.BindingProvider;
 import org.openhab.core.items.Item;
+import org.openhab.core.types.Command;
 
 /**
  * This interface is implemented by classes that can provide mapping information
@@ -19,6 +20,7 @@ import org.openhab.core.items.Item;
  * taken into account.
  * 
  * @author Pauli Anttila
+ * @author Simon Merschjohann
  * @since 1.1.0
  */
 public interface IhcBindingProvider extends BindingProvider {
@@ -26,20 +28,35 @@ public interface IhcBindingProvider extends BindingProvider {
 	/**
 	 * Returns the Type of the Item identified by {@code itemName}
 	 * 
-	 * @param itemName the name of the item to find the type for
+	 * @param itemName
+	 *            the name of the item to find the type for
 	 * @return the type of the Item identified by {@code itemName}
 	 */
 	Class<? extends Item> getItemType(String itemName);
-	
+
 	/**
-	 * Returns the resource id to the given <code>itemName</code>.
+	 * Returns the resource id of the associated In-Binding to the given
+	 * <code>itemName</code>
 	 * 
 	 * @param itemName
 	 *            the item for which to find a resource id.
+	 * @return the corresponding Resource Id of the In-Binding to the given
+	 *         <code>itemName</code>.
+	 */
+	public int getResourceIdForInBinding(String itemName);
+
+	/**
+	 * Returns the resource id to the given <code>itemName</code> and
+	 * <code>cmd</code>
+	 * 
+	 * @param itemName
+	 *            the item for which to find a resource id.
+	 * @param cmd
+	 *            the wanted command, choose null for wildcard.
 	 * 
 	 * @return the corresponding Resource Id to the given <code>itemName</code>.
 	 */
-	public int getResourceId(String itemName);
+	public int getResourceId(String itemName, Command cmd);
 
 	/**
 	 * Returns the refresh interval to the given <code>itemName</code>. Is used
@@ -54,13 +71,34 @@ public interface IhcBindingProvider extends BindingProvider {
 	public int getRefreshInterval(String itemName);
 
 	/**
-	 * Returns item binding mode to the given <code>itemName</code>.
+	 * Returns item binding mode to the given <code>itemName</code> and
+	 * <code>resourceId</code>.
 	 * 
 	 * @param itemName
 	 *            the item for which to find a binding mode.
 	 * 
-	 * @return true if item is out binding only.
+	 * @param resourceId
+	 *            the resourceId to be checked.
+	 * 
+	 * @return true if given resource is an out binding.
 	 */
-	public boolean isOutBindingOnly(String itemName);
+	public boolean isOutBinding(String itemName, int resourceId);
 
+	/**
+	 * Returns true if there exists an In-Binding ( "<0x1234" or "0x1234" ) for
+	 * the given Item
+	 * 
+	 * @param itemName
+	 * @return true if item has in binding
+	 */
+	public boolean hasInBinding(String itemName);
+
+	/**
+	 * Returns the value which is configured for the given item and the command
+	 * 
+	 * @param itemName
+	 * @param cmd
+	 * @return
+	 */
+	public Integer getValue(String itemName, Command cmd);
 }

--- a/bundles/binding/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/IhcBinding.java
+++ b/bundles/binding/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/IhcBinding.java
@@ -29,6 +29,7 @@ import org.openhab.core.binding.AbstractActiveBinding;
 import org.openhab.core.binding.BindingChangeListener;
 import org.openhab.core.binding.BindingProvider;
 import org.openhab.core.items.Item;
+import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
@@ -45,13 +46,14 @@ import org.slf4j.LoggerFactory;
  * Binding also polls resources from controller where interval is configured.
  * 
  * @author Pauli Anttila
+ * @author Simon Merschjohann
  * @since 1.1.0
  */
 public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 		implements ManagedService, IhcEventListener, BindingChangeListener {
 
-	private static final Logger logger = 
-		LoggerFactory.getLogger(IhcBinding.class);
+	private static final Logger logger = LoggerFactory
+			.getLogger(IhcBinding.class);
 
 	private long refreshInterval = 1000;
 
@@ -78,18 +80,19 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 	 * download from controller
 	 */
 	private static String projectFile = null;
-	
+
 	/** Path for resource's dump. Dump is useful to find out resource id's. */
 	private static String dumpResourceFile = null;
 
 	/** Timeout for controller communication */
 	private static int timeout = 5000;
 
-	/** Store current state of the controller, use to recognize when
-	 * controller state is changed
+	/**
+	 * Store current state of the controller, use to recognize when controller
+	 * state is changed
 	 */
 	private WSControllerState controllerState = null;
-	
+
 	/**
 	 * Reminder to slow down resource value notification ordering from
 	 * controller.
@@ -97,7 +100,7 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 	private NotificationsRequestReminder reminder = null;
 	private boolean reconnectRequest = false;
 	private boolean valueNotificationRequest = false;
-	
+
 	@Override
 	protected String getName() {
 		return "IHC / ELKO LS refresh and notification listener service";
@@ -112,30 +115,30 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 	}
 
 	public void deactivate(ComponentContext componentContext) {
-		discnnect();
+		disconnect();
 	}
-	
+
 	protected boolean isReconnectRequestActivated() {
 		synchronized (IhcBinding.class) {
 			return reconnectRequest;
-		}		
+		}
 	}
 
 	protected void setReconnectRequest(boolean reconnect) {
 		synchronized (IhcBinding.class) {
 			this.reconnectRequest = reconnect;
-		}	
+		}
 	}
 
 	protected boolean isValueNotificationRequestActivated() {
 		synchronized (IhcBinding.class) {
-			return valueNotificationRequest;	
+			return valueNotificationRequest;
 		}
 	}
 
 	protected void setValueNotificationRequest(boolean valueNotificationRequest) {
 		synchronized (IhcBinding.class) {
-			this.valueNotificationRequest = valueNotificationRequest;	
+			this.valueNotificationRequest = valueNotificationRequest;
 		}
 	}
 
@@ -144,7 +147,7 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 	 * 
 	 */
 	public void connect() throws IhcExecption {
-		
+
 		if (StringUtils.isNotBlank(ip) && StringUtils.isNotBlank(username)
 				&& StringUtils.isNotBlank(password)) {
 
@@ -158,19 +161,19 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 			ihc.openConnection();
 			controllerState = ihc.getControllerState();
 			ihc.addEventListener(this);
-			
+
 		} else {
 			logger.warn(
 					"Couldn't connect to IHC controller because of missing connection parameters [IP='{}' Username='{}' Password='{}'].",
 					new Object[] { ip, username, "******" });
 		}
 	}
-	
+
 	/**
 	 * Disconnect connection to IHC / ELKO LS controller.
 	 * 
 	 */
-	public void discnnect() {
+	public void disconnect() {
 		if (ihc != null) {
 			try {
 				ihc.removeEventListener(this);
@@ -191,7 +194,7 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 
 			try {
 				if (ihc != null) {
-					discnnect();
+					disconnect();
 				}
 				connect();
 				setReconnectRequest(false);
@@ -201,26 +204,29 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 				return;
 			}
 		}
-	
+
 		if (ihc != null) {
-			
+
 			if (isValueNotificationRequestActivated()) {
 				try {
 					enableResourceValueNotifications();
 				} catch (IhcExecption e) {
-					logger.warn("Can't enable resource value notifications from controller", e);
-				}	
+					logger.warn(
+							"Can't enable resource value notifications from controller",
+							e);
+				}
 			}
-			
+
 			// Poll all requested resources from controller
 			for (IhcBindingProvider provider : providers) {
 				for (String itemName : provider.getItemNames()) {
-
-					int resourceId = provider.getResourceId(itemName);
+					
+					int resourceId = provider
+							.getResourceIdForInBinding(itemName);
 					int itemRefreshInterval = provider
 							.getRefreshInterval(itemName) * 1000;
 
-					if (itemRefreshInterval > 0) {
+					if (resourceId > 0 && itemRefreshInterval > 0) {
 
 						Long lastUpdateTimeStamp = lastUpdateMap.get(itemName);
 						if (lastUpdateTimeStamp == null) {
@@ -232,7 +238,6 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 						boolean needsUpdate = age >= itemRefreshInterval;
 
 						if (needsUpdate) {
-
 							logger.debug(
 									"Item '{}' is about to be refreshed now",
 									itemName);
@@ -241,12 +246,16 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 								WSResourceValue resourceValue = null;
 
 								try {
-									resourceValue = ihc.resourceQuery(resourceId);
+									resourceValue = ihc
+											.resourceQuery(resourceId);
 								} catch (IhcExecption e) {
-									logger.warn("Value could not be read from controller - retrying one time.", e);
+									logger.warn(
+											"Value could not be read from controller - retrying one time.",
+											e);
 
 									try {
-										resourceValue = ihc.resourceQuery(resourceId);
+										resourceValue = ihc
+												.resourceQuery(resourceId);
 									} catch (IhcExecption ex) {
 										logger.error("Communication error", ex);
 										logger.debug("Reconnection request");
@@ -264,7 +273,9 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 								}
 
 							} catch (Exception e) {
-								logger.error("Error occured during resource query", e);
+								logger.error(
+										"Error occured during resource query",
+										e);
 							}
 
 							lastUpdateMap.put(itemName,
@@ -278,7 +289,7 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 		}
 
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -295,39 +306,40 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 	@Override
 	public void bindingChanged(BindingProvider provider, String itemName) {
 		logger.trace("bindingChanged {}", itemName);
-		if( reminder != null) {
+		if (reminder != null) {
 			reminder.cancel();
 			reminder = null;
 		}
-		
-		reminder = new NotificationsRequestReminder(NOTIFICATIONS_REORDER_WAIT_TIME);
+
+		reminder = new NotificationsRequestReminder(
+				NOTIFICATIONS_REORDER_WAIT_TIME);
 	}
 
 	/**
-	 * Used to slow down resource value notification ordering process.
-	 * All resource values need to be ordered by one request from the controller,
-	 * therefore wait that all binding items are loaded. 
+	 * Used to slow down resource value notification ordering process. All
+	 * resource values need to be ordered by one request from the controller,
+	 * therefore wait that all binding items are loaded.
 	 */
 	private class NotificationsRequestReminder {
-	    Timer timer;
+		Timer timer;
 
-	    public NotificationsRequestReminder(int milliseconds) {
-	        timer = new Timer();
-	        timer.schedule(new RemindTask(), milliseconds);
+		public NotificationsRequestReminder(int milliseconds) {
+			timer = new Timer();
+			timer.schedule(new RemindTask(), milliseconds);
 		}
 
-	    public void cancel() {
-	    	timer.cancel();
-	    }
-	    
-	    class RemindTask extends TimerTask {
-	    	
-	        public void run() {
-	        	logger.debug("Timer: enableResourceValueNotifications");
-	        	setValueNotificationRequest(true);
-	            timer.cancel();
-	        }
-	    }
+		public void cancel() {
+			timer.cancel();
+		}
+
+		class RemindTask extends TimerTask {
+
+			public void run() {
+				logger.debug("Timer: enableResourceValueNotifications");
+				setValueNotificationRequest(true);
+				timer.cancel();
+			}
+		}
 	}
 
 	public void updated(Dictionary<String, ?> config)
@@ -352,7 +364,7 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 	protected void internalReceiveCommand(String itemName, Command command) {
 		updateResource(itemName, command, false);
 	}
-	
+
 	@Override
 	public void internalReceiveUpdate(String itemName, State newState) {
 		updateResource(itemName, newState, true);
@@ -361,79 +373,149 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 	/**
 	 * Update resource value to IHC controller.
 	 */
-	private void updateResource(String itemName, Type type, boolean updateOnlyOutBinding) {
-		
-		if (itemName != null) {
+	private void updateResource(String itemName, Type type,
+			boolean updateOnlyExclusiveOutBinding) {
 
-			IhcBindingProvider provider = findFirstMatchingBindingProvider(itemName);
+		if (itemName != null) {
+			Command cmd = null;
+			try {
+				cmd = (Command) type;
+			} catch (Exception e) {
+			}
+
+			IhcBindingProvider provider = findFirstMatchingBindingProvider(
+					itemName, cmd);
 
 			if (provider == null) {
-				logger.warn(
-						"Doesn't find matching binding provider [itemName={}]",
-						itemName);
+				// command not configured, skip
 				return;
 			}
 
-			if (updateOnlyOutBinding && provider.isOutBindingOnly(itemName) == false) {
+			if (updateOnlyExclusiveOutBinding
+					&& provider.hasInBinding(itemName)) {
 				logger.trace("Ignore in binding update for item '{}'", itemName);
 				return;
 			}
-			
+
 			logger.debug(
 					"Received update/command (item='{}', state='{}', class='{}')",
 					new Object[] { itemName, type.toString(),
 							type.getClass().toString() });
 
 			if (ihc == null) {
-				logger.warn("Controller is not initialized, abort resource value update for item '{}'!", itemName);
+				logger.warn(
+						"Controller is not initialized, abort resource value update for item '{}'!",
+						itemName);
 				return;
 			}
 
 			if (ihc.getConnectionState() != ConnectionState.CONNECTED) {
-				logger.warn("Connection to controller is not ok, abort resource value update for item '{}'!", itemName);
+				logger.warn(
+						"Connection to controller is not ok, abort resource value update for item '{}'!",
+						itemName);
 				return;
 			}
-			
+
 			try {
+				int resourceId = provider.getResourceId(itemName,
+						(Command) type);
 
-				int resourceId = provider.getResourceId(itemName);
-				WSResourceValue value = ihc
-						.getResourceValueInformation(resourceId);
-				
-				ArrayList<IhcEnumValue> enumValues = null;
+				logger.trace(
+						"found resourceId {} (item='{}', state='{}', class='{}')",
+						new Object[] { new Integer(resourceId).toString(),
+								itemName, type.toString(),
+								type.getClass().toString() });
 
-				if (value instanceof WSEnumValue) {
+				if (resourceId > 0) {
+					WSResourceValue value = ihc
+							.getResourceValueInformation(resourceId);
 
-					enumValues = ihc.getEnumValues(((WSEnumValue) value)
-							.getDefinitionTypeID());
-				}
+					ArrayList<IhcEnumValue> enumValues = null;
 
-				value = IhcDataConverter.convertCommandToResourceValue(type, value,
-						enumValues);
+					if (value instanceof WSEnumValue) {
 
-				boolean result = updateResource(value);
-				
-				if (result == true) {
-					logger.debug("Item updated '{}' succesfully sent",
-							itemName);
+						enumValues = ihc.getEnumValues(((WSEnumValue) value)
+								.getDefinitionTypeID());
+					}
+
+					// check if configuration has a custom value defined
+					// (0->OFF, 1->ON, >1->trigger)
+					// if that is the case, the type will be overridden with a
+					// new type
+
+					Integer val = provider.getValue(itemName, (Command) type);
+					boolean trigger = false;
+					if (val != null) {
+						if (val == 0) {
+							type = OnOffType.OFF;
+						} else if (val == 1) {
+							type = OnOffType.ON;
+						} else {
+							trigger = true;
+						}
+					} else {
+						// the original type is kept
+					}
+
+					if (!trigger) {
+						value = IhcDataConverter.convertCommandToResourceValue(
+								type, value, enumValues);
+
+						boolean result = updateResource(value);
+
+						if (result == true) {
+							logger.debug("Item updated '{}' succesfully sent",
+									itemName);
+						} else {
+							logger.error("Item '{}' update failed", itemName);
+						}
+					} else {
+						value = IhcDataConverter.convertCommandToResourceValue(
+								OnOffType.ON, value, enumValues);
+
+						boolean result = updateResource(value);
+
+						if (result == true) {
+							logger.debug("Item '{}' trigger started", itemName);
+
+							Thread.sleep(val);
+
+							value = IhcDataConverter
+									.convertCommandToResourceValue(
+											OnOffType.OFF, value, enumValues);
+
+							result = updateResource(value);
+
+							if (result == true) {
+								logger.debug("Item '{}' trigger completed",
+										itemName);
+							} else {
+								logger.error("Item '{}' trigger stop failed",
+										itemName);
+							}
+
+						} else {
+							logger.error("Item '{}' update failed", itemName);
+						}
+					}
+
 				} else {
-					logger.error("Item '{}' update failed", itemName);
+					logger.error("resourceId invalid");
 				}
 
-			} catch ( IhcExecption e) {
+			} catch (IhcExecption e) {
 				logger.error("Can't update Item '{}' value ", itemName, e);
 			} catch (Exception e) {
 				logger.error("Error occured during item update", e);
 			}
 		}
-		
+
 	}
-	
+
 	/**
 	 * Update resource value to IHC controller.
 	 */
 	private boolean updateResource(WSResourceValue value) throws IhcExecption {
-		
 		boolean result = false;
 
 		try {
@@ -441,16 +523,15 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 
 		} catch (IhcExecption e) {
 
-			logger.warn(
-					"Value could not be set - retrying one time: {}",
+			logger.warn("Value could not be set - retrying one time: {}",
 					e.getMessage());
 
 			result = ihc.resourceUpdate(value);
 		}
-		
+
 		return result;
 	}
-	
+
 	/**
 	 * Find the first matching {@link IhcBindingProvider} according to
 	 * <code>itemName</code> and <code>command</code>.
@@ -460,15 +541,13 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 	 * @return the matching binding provider or <code>null</code> if no binding
 	 *         provider could be found
 	 */
-	private IhcBindingProvider findFirstMatchingBindingProvider(String itemName) {
-
+	private IhcBindingProvider findFirstMatchingBindingProvider(
+			String itemName, Command type) {
 		IhcBindingProvider firstMatchingProvider = null;
 
 		for (IhcBindingProvider provider : this.providers) {
-
-			int resourceId = provider.getResourceId(itemName);
-
-			if (resourceId > 0) {
+			if (provider.getResourceId(itemName, type) > 0
+					|| provider.getResourceId(itemName, null) > 0) {
 				firstMatchingProvider = provider;
 				break;
 			}
@@ -477,26 +556,26 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 		return firstMatchingProvider;
 	}
 
-
 	/**
 	 * Order resource value notifications from IHC controller.
 	 */
 	private void enableResourceValueNotifications() throws IhcExecption {
-		
+
 		logger.debug("Subscripe resource runtime value notifications");
 
 		if (ihc != null) {
-			
+
 			if (ihc.getConnectionState() != ConnectionState.CONNECTED) {
-				logger.debug("Controller is connecting, abort subscripe");
+				logger.debug("Controller is connecting, abort subscribe");
 				return;
 			}
-			
+
 			List<Integer> resourceIdList = new ArrayList<Integer>();
-			
+
 			for (IhcBindingProvider provider : providers) {
 				for (String itemName : provider.getItemNames()) {
-					resourceIdList.add(provider.getResourceId(itemName));
+					resourceIdList.add(provider
+							.getResourceIdForInBinding(itemName));
 				}
 			}
 
@@ -516,25 +595,23 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 			logger.debug("Reconnection request");
 			setReconnectRequest(true);
 		}
-		
+
 		setValueNotificationRequest(false);
 	}
 
 	@Override
 	public void statusUpdateReceived(EventObject event, WSControllerState state) {
-		
+
 		logger.trace("Controller state {}", state.getState());
 
 		if (controllerState.getState().equals(state.getState()) == false) {
-			logger.info(
-					"Controller state change detected ({} -> {})",
-					controllerState.getState(),
-					state.getState());
+			logger.info("Controller state change detected ({} -> {})",
+					controllerState.getState(), state.getState());
 
 			if (controllerState.getState().equals(
 					IhcClient.CONTROLLER_STATE_INITIALIZE)
-					|| state.getState().equals(
-							IhcClient.CONTROLLER_STATE_READY)) {
+					|| state.getState()
+							.equals(IhcClient.CONTROLLER_STATE_READY)) {
 
 				logger.debug("Reconnection request");
 				setReconnectRequest(true);
@@ -542,7 +619,7 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 
 			controllerState.setState(state.getState());
 		}
-		
+
 	}
 
 	@Override
@@ -552,14 +629,14 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 		for (IhcBindingProvider provider : providers) {
 			for (String itemName : provider.getItemNames()) {
 
-				int resourceId = provider.getResourceId(itemName);
+				int resourceId = provider.getResourceIdForInBinding(itemName);
 
 				if (value.getResourceID() == resourceId) {
 
-					if (provider.isOutBindingOnly(itemName)) {
+					if (!provider.hasInBinding(itemName)) {
 
 						logger.trace(
-								"{} is out binding only...skip update to OpenHAB bus",
+								"{} has no inbinding...skip update to OpenHAB bus",
 								itemName);
 
 					} else {
@@ -568,7 +645,7 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 								.getItemType(itemName);
 						State state = IhcDataConverter
 								.convertResourceValueToState(itemType, value);
-						
+
 						logger.trace(
 								"Received resource value update (item='{}', state='{}')",
 								new Object[] { itemName, state });
@@ -584,10 +661,9 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 
 	@Override
 	public void errorOccured(EventObject event, IhcExecption e) {
-		logger.warn(
-				"Error occured on communication to IHC controller: {}",
+		logger.warn("Error occured on communication to IHC controller: {}",
 				e.getMessage());
-				
+
 		logger.debug("Reconnection request");
 		setReconnectRequest(true);
 	}

--- a/bundles/binding/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/IhcGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/IhcGenericBindingProvider.java
@@ -8,6 +8,10 @@
  */
 package org.openhab.binding.ihc.internal;
 
+import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.openhab.binding.ihc.IhcBindingProvider;
 import org.openhab.core.autoupdate.AutoUpdateBindingProvider;
 import org.openhab.core.binding.BindingConfig;
@@ -19,6 +23,8 @@ import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.items.RollershutterItem;
 import org.openhab.core.library.items.StringItem;
 import org.openhab.core.library.items.SwitchItem;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.TypeParser;
 import org.openhab.model.item.binding.AbstractGenericBindingProvider;
 import org.openhab.model.item.binding.BindingConfigParseException;
 import org.slf4j.Logger;
@@ -62,6 +68,7 @@ import org.slf4j.LoggerFactory;
  * </ul>
  * 
  * @author Pauli Anttila
+ * @author Simon Merschjohann
  * @since 1.1.0
  */
 public class IhcGenericBindingProvider extends AbstractGenericBindingProvider
@@ -69,6 +76,9 @@ public class IhcGenericBindingProvider extends AbstractGenericBindingProvider
 
 	private static final Logger logger = LoggerFactory
 			.getLogger(IhcGenericBindingProvider.class);
+
+	private final static Pattern commandPattern = Pattern
+			.compile("\\[([\\w*]+):(0x[0-9a-fA-F]+|\\d+)(?::(\\d+)){0,1}\\]");
 
 	/**
 	 * {@inheritDoc}
@@ -87,49 +97,113 @@ public class IhcGenericBindingProvider extends AbstractGenericBindingProvider
 
 		IhcBindingConfig config = new IhcBindingConfig();
 		config.itemType = item.getClass();
-		
-		String[] configParts = bindingConfig.trim().split(":");
+		config.outCommandMap = new HashMap<Command, IhcOutCommandConfig>();
 
-		if (configParts.length > 2) {
-			throw new BindingConfigParseException(
-					"IHC / ELKO LS binding must contain of max two two parts separated by ':'");
-		}
+		String[] splittedCommands = bindingConfig.split(",");
 
-		if (bindingConfig.startsWith(">")) {
+		for (String split : splittedCommands) {
+			if (split.startsWith(">")) {
+				try {
+					// out binding
+					String resourceCommand = split.substring(1);
 
-			if (configParts.length == 1) {
-				config.outBindingOnly = true;
-				String resourceId = configParts[0].replace(">", "");
+					Matcher m = commandPattern.matcher(resourceCommand);
 
-				if (resourceId.startsWith("0x")) {
-					config.resourceId = Integer.parseInt(
-							resourceId.replace("0x", ""), 16);
-				} else {
-					config.resourceId = Integer.parseInt(resourceId);
+					IhcOutCommandConfig outConfig = new IhcOutCommandConfig();
+
+					if (!m.matches()) {
+						if (splittedCommands.length < 2) {
+							// assume old style out command
+							outConfig.command = null; // wildcard
+							outConfig.resourceId = getResourceIdFromString(resourceCommand);
+
+						} else {
+							throw new BindingConfigParseException("Item '"
+									+ item.getName()
+									+ "' has invalid out binding config");
+						}
+					} else {
+						// new style out binding
+						Command command = TypeParser.parseCommand(
+								item.getAcceptedCommandTypes(), m.group(1));
+						if (command == null && !m.group(1).equals("*")) {
+							throw new BindingConfigParseException("Item '"
+									+ item.getName() + " invalid Command: "
+									+ m.group(1));
+						}
+
+						outConfig.command = command;
+						outConfig.resourceId = getResourceIdFromString(m
+								.group(2));
+
+						if (m.groupCount() == 3 && m.group(3) != null) {
+							outConfig.value = Integer.parseInt(m.group(3));
+
+							if (outConfig.value > 2000) {
+								throw new BindingConfigParseException(
+										"Item '"
+												+ item.getName()
+												+ "' exceeds maximum value of 2000 ms for trigger command");
+							}
+
+						}
+					}
+
+					config.outCommandMap.put(outConfig.command, outConfig);
+				} catch (Exception e) {
+					logger.warn(
+							"Error in output config for item: "
+									+ item.getName(), e);
 				}
-				
+			} else if (split.startsWith("<")) {
+				if (config.resourceId < 1) {
+					config.resourceId = getResourceIdFromString(split
+							.substring(1));
+				} else {
+					throw new BindingConfigParseException(
+							"Multiple In-Bindings found, only one In-Binding allowed.");
+				}
 			} else {
-				throw new BindingConfigParseException(
-						"When configuration start with '>', refresh interval is not supported ");
+				if (splittedCommands.length < 2) {
+					String[] configParts = bindingConfig.trim().split(":");
+
+					if (configParts.length > 2) {
+						throw new BindingConfigParseException(
+								"IHC / ELKO LS binding must contain of max two two parts separated by ':'");
+					}
+
+					String resourceId = configParts[0];
+					config.resourceId = getResourceIdFromString(resourceId);
+
+					IhcOutCommandConfig outConfig = new IhcOutCommandConfig();
+
+					outConfig.command = null; // wildcard
+					outConfig.resourceId = config.resourceId;
+					config.outCommandMap.put(null, outConfig);
+
+					if (configParts.length == 2)
+						config.refreshInterval = Integer
+								.parseInt(configParts[1]);
+				} else {
+					throw new BindingConfigParseException(
+							"Only a sum of out bindings (+In-Only Binding) or a normal binding is supported.");
+				}
 			}
-
-		} else {
-
-			String resourceId = configParts[0];
-
-			if (resourceId.startsWith("0x")) {
-				config.resourceId = Integer.parseInt(
-						resourceId.replace("0x", ""), 16);
-			} else {
-				config.resourceId = Integer.parseInt(resourceId);
-			}
-
-			if (configParts.length == 2)
-				config.refreshInterval = Integer.parseInt(configParts[1]);
-
 		}
 
 		addBindingConfig(item, config);
+	}
+
+	private int getResourceIdFromString(String resourceId) {
+		int ret = 0;
+
+		if (resourceId.startsWith("0x")) {
+			ret = Integer.parseInt(resourceId.replace("0x", ""), 16);
+		} else {
+			ret = Integer.parseInt(resourceId);
+		}
+
+		return ret;
 	}
 
 	/**
@@ -142,23 +216,60 @@ public class IhcGenericBindingProvider extends AbstractGenericBindingProvider
 		Class<? extends Item> itemType;
 		public int resourceId;
 		public int refreshInterval;
-		public boolean outBindingOnly;
+
+		public HashMap<Command, IhcOutCommandConfig> outCommandMap;
+	}
+
+	static private class IhcOutCommandConfig {
+		public Command command;
+		public Integer resourceId;
+
+		public Integer value; // used if it is a function
 	}
 
 	/**
-	 * @{inheritDoc}
+	 * @{inheritDoc
 	 */
 	@Override
 	public Class<? extends Item> getItemType(String itemName) {
-		IhcBindingConfig config = (IhcBindingConfig) bindingConfigs.get(itemName);
-		return config != null ? config.itemType : null;
-	}
-	
-	@Override
-	public int getResourceId(String itemName) {
 		IhcBindingConfig config = (IhcBindingConfig) bindingConfigs
 				.get(itemName);
-		return config != null ? config.resourceId : null;
+		return config != null ? config.itemType : null;
+	}
+
+	@Override
+	public int getResourceIdForInBinding(String itemName) {
+		int result = 0;
+
+		IhcBindingConfig config = (IhcBindingConfig) bindingConfigs
+				.get(itemName);
+		if (config != null) {
+			result = config.resourceId;
+		}
+
+		return result;
+	}
+
+	@Override
+	public int getResourceId(String itemName, Command cmd) {
+		int result = 0;
+
+		IhcBindingConfig config = (IhcBindingConfig) bindingConfigs
+				.get(itemName);
+		if (config != null) {
+			IhcOutCommandConfig outConfig = config.outCommandMap.get(cmd);
+			if (outConfig != null) {
+				// command matching resource found
+				result = outConfig.resourceId;
+			} else {
+				// check if wildcard resource exists
+				outConfig = config.outCommandMap.get(null);
+				if (outConfig != null)
+					result = outConfig.resourceId;
+			}
+		}
+
+		return result;
 	}
 
 	@Override
@@ -169,10 +280,25 @@ public class IhcGenericBindingProvider extends AbstractGenericBindingProvider
 	}
 
 	@Override
-	public boolean isOutBindingOnly(String itemName) {
+	public boolean isOutBinding(String itemName, int resourceId) {
 		IhcBindingConfig config = (IhcBindingConfig) bindingConfigs
 				.get(itemName);
-		return config != null ? config.outBindingOnly : null;
+
+		boolean isOutBinding = true;
+
+		if (config.resourceId == resourceId) {
+			isOutBinding = false;
+		}
+
+		return isOutBinding;
+	}
+
+	@Override
+	public boolean hasInBinding(String itemName) {
+		IhcBindingConfig config = (IhcBindingConfig) bindingConfigs
+				.get(itemName);
+
+		return config != null ? config.resourceId > 0 : null;
 	}
 
 	@Override
@@ -181,8 +307,7 @@ public class IhcGenericBindingProvider extends AbstractGenericBindingProvider
 
 		if (!(item instanceof NumberItem || item instanceof SwitchItem
 				|| item instanceof ContactItem || item instanceof StringItem
-				|| item instanceof DateTimeItem || item instanceof DimmerItem 
-				|| item instanceof RollershutterItem)) {
+				|| item instanceof DateTimeItem || item instanceof DimmerItem || item instanceof RollershutterItem)) {
 			throw new BindingConfigParseException(
 					"Item '"
 							+ item.getName()
@@ -196,21 +321,21 @@ public class IhcGenericBindingProvider extends AbstractGenericBindingProvider
 
 	@Override
 	public Boolean autoUpdate(String itemName) {
-
-		// Cancel auto update functionality for items, which are handled on this binding
-
-		if (providesBindingFor(itemName)) {
-
-			if (isOutBindingOnly(itemName) == false) {
-				
-				// Cancel auto update functionality only if item is not 'out binding only'
-
-				logger.debug("AutoUpdate for item {} canceled", itemName);
-				return false;
-			}
-		}
-
 		return null;
+	}
+
+	@Override
+	public Integer getValue(String itemName, Command cmd) {
+		IhcBindingConfig config = (IhcBindingConfig) bindingConfigs
+				.get(itemName);
+
+		IhcOutCommandConfig outConfig = (config != null && config.outCommandMap != null) ? config.outCommandMap
+				.get(cmd) : null;
+		if (outConfig == null)
+			outConfig = (config != null && config.outCommandMap != null) ? config.outCommandMap
+					.get(null) : null;
+
+		return (outConfig != null) ? outConfig.value : null;
 	}
 
 }


### PR DESCRIPTION
This modification allows to specify different resources and the wanted value related to the called command.

# Configuration Syntax
## Before
```
ihc=">123456"
```

Only a single resourceId could be referenced. Values were automatically determined based on the item state.

## After

```
ihc=">[UP:12345:100],>[DOWN:0x9bcd:100],>[STOP:99999]"
```

Syntax:  >[COMMAND:RESOURCE_ID(:VALUE)]

1. Command which is called
2. The resource id to use (hex or int)
3. optional
    * if not specified the value will be determined like before
    * 1: OnOffType.ON is sent to the resource
    * 0: OnOffType.OFF is sent to the resource
    * value > 1: Sequence is sent: OnOfType.ON, sleep(value), OnOffType.OFF
