### PR TITLE
Items not being updated when a partition is disarmed while in alarm state

### DIFF
--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmActiveBinding.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmActiveBinding.java
@@ -896,8 +896,9 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 				dscAlarmItemType = DSCAlarmItemType.PARTITION_STATUS;
 				break;
 			case PartitionArmed: /*652*/
-				//forLimit = 1;
-
+			case UserClosing: /*700*/
+			case SpecialClosing: /*701*/
+			case PartialClosing: /*702*/
 				updateItemType(DSCAlarmItemType.PARTITION_ARMED, apiMessage.getPartition(), -1, 1);
 
 				updateItemType(DSCAlarmItemType.PARTITION_ENTRY_DELAY, apiMessage.getPartition(), -1, 0);
@@ -907,6 +908,8 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 				setPartitionStatus(partitionId, 0, apiMessage.getAPIName());
 				break;
 			case PartitionDisarmed: /*655*/
+			case UserOpening: /*750*/
+			case SpecialOpening: /*751*/
 				updateItemType(DSCAlarmItemType.PARTITION_ARMED, apiMessage.getPartition(), -1, 0);
 
 				updateItemType(DSCAlarmItemType.PARTITION_ENTRY_DELAY, apiMessage.getPartition(), -1, 0);

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/APIMessage.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/APIMessage.java
@@ -332,7 +332,7 @@ public class APIMessage {
 						apiMessageType = APIMessageType.PARTITION_EVENT;
 						break;
 					case PartitionArmed: /*652*/
-						apiName = "Partition Armed (0=Away, 1=Stay, 2=ZEA, 3=ZES)";
+						apiName = "Partition Armed";
 						apiDescription = apiCodeReceived + ": Partition has been armed.";
 						partition = Integer.parseInt(apiMessage.substring(3, 4));
 						mode = apiMessage.substring(4);


### PR DESCRIPTION
Fixed resetting of items *partition_in_alarm* and *partition_arm_mode* when a user code is used to disarm a partition that is in alarm.