### PR TITLE
allows negative numbers as commands in widget mappings (see https://code...

### DIFF
--- a/bundles/model/org.openhab.model.sitemap/src/org/openhab/model/Sitemap.xtext
+++ b/bundles/model/org.openhab.model.sitemap/src/org/openhab/model/Sitemap.xtext
@@ -130,7 +130,7 @@ ColorArray:
 	((item=ID)? (condition=("==" | ">" | "<" | ">=" | "<=" | "!="))? (sign=('-'|'+'))? (state=XState) '=')? (arg=STRING);
 
 Command returns ecore::EString:
-	INT | ID | STRING;
+	Number | ID | STRING;
 
 Number returns ecore::EBigDecimal:
 	'-'? (INT | FLOAT);


### PR DESCRIPTION
....google.com/p/openhab/issues/detail?id=302)

Signed-off-by: Kai Kreuzer <kai@openhab.org> (github: @kaikreuzer)