### PR TITLE
Make mysql persistent documentation more clear

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -335,7 +335,7 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 #db4o:maxbackups=
 
 ############################ SQL Persistence Service ##################################
-# the database url like 'jdbc:mysql://<host>:<port>/<database>'
+# the database url like 'jdbc:mysql://<host>:<port>/<database>' (without quotes)
 #mysql:url=
 
 # the database user
@@ -1758,7 +1758,7 @@ tcp:refreshinterval=250
 
 # Load different parser, currently supported
 # >> common - All telegrams defined by eBus interest group
-# >> wolf - All telegrams specified by Wolf/Kromschröder
+# >> wolf - All telegrams specified by Wolf/KromschrÃ¶der
 # >> vaillant - All telegrams specified by Vaillant
 # >> testing -  All unknown or test telegrams
 # >> custom - Use configuration defined by ebus:parserUrl


### PR DESCRIPTION
Make mysql persistent documentation more clear to avoid multiple hours of bug hunting