### PR TITLE
Fix absolute path problem in systeminfo Binding and add unit tests

### DIFF
--- a/bundles/binding/org.openhab.binding.systeminfo.test/.classpath
+++ b/bundles/binding/org.openhab.binding.systeminfo.test/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/test/java"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="output" path="target/test-classes"/>
+</classpath>

--- a/bundles/binding/org.openhab.binding.systeminfo.test/.project
+++ b/bundles/binding/org.openhab.binding.systeminfo.test/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.http.test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/binding/org.openhab.binding.systeminfo.test/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/binding/org.openhab.binding.systeminfo.test/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning

--- a/bundles/binding/org.openhab.binding.systeminfo.test/.settings/org.maven.ide.eclipse.prefs
+++ b/bundles/binding/org.openhab.binding.systeminfo.test/.settings/org.maven.ide.eclipse.prefs
@@ -1,0 +1,9 @@
+#Fri Feb 18 22:39:16 CET 2011
+activeProfiles=
+eclipse.preferences.version=1
+fullBuildGoals=process-test-resources
+includeModules=false
+resolveWorkspaceProjects=true
+resourceFilterGoals=process-resources resources\:testResources
+skipCompilerPlugin=true
+version=1

--- a/bundles/binding/org.openhab.binding.systeminfo.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.systeminfo.test/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Tests for the Systeminfo binding
+Bundle-SymbolicName: org.openhab.binding.systeminfo.test
+Bundle-Version: 1.7.0.qualifier
+Bundle-Vendor: openHAB.org
+Fragment-Host: org.openhab.binding.systeminfo
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Require-Bundle: org.junit;bundle-version="4.8.1"

--- a/bundles/binding/org.openhab.binding.systeminfo.test/SysteminfoBindingTests.launch
+++ b/bundles/binding/org.openhab.binding.systeminfo.test/SysteminfoBindingTests.launch
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<stringAttribute key="application" value="org.eclipse.pde.junit.runtime.coretestapplication"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="false"/>
+<booleanAttribute key="automaticValidate" value="false"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="false"/>
+<booleanAttribute key="includeOptional" value="false"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/org.openhab.binding.systeminfo.test"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=org.openhab.binding.systeminfo.test"/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.openhab.binding.systeminfo.test"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="org.eclipse.platform.ide"/>
+<booleanAttribute key="run_in_ui_thread" value="false"/>
+<stringAttribute key="selected_target_plugins" value="ch.qos.logback.classic@default:default,ch.qos.logback.core@default:default,ch.qos.logback.slf4j@default:false,com.google.guava@default:default,com.google.inject@default:default,javax.activation@default:default,javax.inject@default:default,javax.mail@default:default,javax.servlet@default:default,javax.transaction@default:false,org.antlr.runtime@default:default,org.apache.commons.codec@default:default,org.apache.commons.collections@default:default,org.apache.commons.httpclient@default:default,org.apache.commons.io@default:default,org.apache.commons.lang@default:default,org.apache.commons.net@default:default,org.eclipse.ant.core@default:default,org.eclipse.core.contenttype@default:default,org.eclipse.core.expressions@default:default,org.eclipse.core.filesystem.macosx@default:false,org.eclipse.core.filesystem@default:default,org.eclipse.core.jobs@default:default,org.eclipse.core.resources@default:default,org.eclipse.core.runtime.compatibility.registry@default:false,org.eclipse.core.runtime@default:true,org.eclipse.core.variables@default:default,org.eclipse.emf.common@default:default,org.eclipse.emf.ecore.xmi@default:default,org.eclipse.emf.ecore@default:default,org.eclipse.equinox.app@default:default,org.eclipse.equinox.common@2:true,org.eclipse.equinox.preferences@default:default,org.eclipse.equinox.registry@default:default,org.eclipse.equinox.servletbridge.extensionbundle@default:false,org.eclipse.equinox.transforms.hook@default:false,org.eclipse.equinox.weaving.hook@default:false,org.eclipse.osgi.services@default:default,org.eclipse.osgi@-1:true,org.eclipse.team.core@default:default,org.eclipse.xtend.lib@default:default,org.eclipse.xtext.common.types@default:default,org.eclipse.xtext.util@default:default,org.eclipse.xtext.xbase.lib@default:default,org.eclipse.xtext.xbase@default:default,org.eclipse.xtext@default:default,org.hamcrest.core@default:default,org.junit*4.10.0.v4_10_0_v20120426-0900@default:default,org.junit4@default:default,org.slf4j.api@default:default,org.slf4j.jcl@default:default,org.slf4j.jul@default:default,org.slf4j.log4j@default:default"/>
+<stringAttribute key="selected_workspace_plugins" value="org.openhab.binding.systeminfo.test@default:false,org.openhab.binding.systeminfo@default:default,org.openhab.config.core@default:default,org.openhab.core.library.test@default:false,org.openhab.core.library@default:default,org.openhab.core.scheduler@default:default,org.openhab.core.scriptengine@default:default,org.openhab.core.test@default:false,org.openhab.core.transform.test@default:false,org.openhab.core.transform@default:default,org.openhab.core@default:default,org.openhab.io.console@default:default,org.openhab.io.multimedia.tts.marytts@default:default,org.openhab.io.multimedia@default:default,org.openhab.io.net.test@default:false,org.openhab.io.net@default:default,org.openhab.model.core@default:default,org.openhab.model.item@default:default"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="false"/>
+</launchConfiguration>

--- a/bundles/binding/org.openhab.binding.systeminfo.test/build.properties
+++ b/bundles/binding/org.openhab.binding.systeminfo.test/build.properties
@@ -1,0 +1,3 @@
+source.. = src/test/java/
+output.. = target/test-classes/
+bin.includes = META-INF/

--- a/bundles/binding/org.openhab.binding.systeminfo.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.systeminfo.test/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<parent>
+		<groupId>org.openhab.bundles</groupId>
+		<artifactId>binding</artifactId>
+		<version>1.7.0-SNAPSHOT</version>
+	</parent>
+
+	<properties>
+		<bundle.symbolicName>org.openhab.binding.systeminfo.test</bundle.symbolicName>
+		<bundle.namespace>org.openhab.binding.systeminfo.test</bundle.namespace>
+	</properties>
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.openhab.binding</groupId>
+	<artifactId>org.openhab.binding.systeminfo.test</artifactId>
+
+	<name>openHAB Systeminfo Binding Tests</name>
+
+	<packaging>eclipse-test-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tycho-version}</version>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/bundles/binding/org.openhab.binding.systeminfo.test/src/test/java/org/openhab/binding/systeminfo/internal/SysteminfoGenericBindingProviderTest.java
+++ b/bundles/binding/org.openhab.binding.systeminfo.test/src/test/java/org/openhab/binding/systeminfo/internal/SysteminfoGenericBindingProviderTest.java
@@ -1,0 +1,264 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.systeminfo.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openhab.binding.systeminfo.internal.SysteminfoGenericBindingProvider;
+import org.openhab.core.items.GenericItem;
+import org.openhab.core.items.Item;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.openhab.model.item.binding.BindingConfigParseException;
+
+
+/**
+ * @author Chris Carman
+ * @since 1.7.0
+ */
+public class SysteminfoGenericBindingProviderTest {
+	
+	private SysteminfoGenericBindingProvider provider;
+	private Item testItem;
+	private String simpleConfig;
+
+	@Before
+	public void init() {
+		provider = new SysteminfoGenericBindingProvider();
+		testItem = new StringTestItem();
+		simpleConfig = "DirFiles:60000:.";
+	}
+	
+	@Test
+	public void testGetBindingType() {
+		Assert.assertEquals("systeminfo", provider.getBindingType());
+	}
+
+	@Test(expected=BindingConfigParseException.class)
+	public void testValidateItemType_nullItem() throws BindingConfigParseException {
+		Item s = null;
+		provider.validateItemType(s, "?");
+	}
+
+	@Test(expected=BindingConfigParseException.class)
+	public void testValidateItemType_nullConfig() throws BindingConfigParseException {
+		String s = null;
+		provider.validateItemType(testItem, s);
+	}
+
+	@Test(expected=BindingConfigParseException.class)
+	public void testValidateItemType_itemNotNumOrStr() throws BindingConfigParseException {
+		Item newItem = new DummyItem();
+		provider.validateItemType(newItem, "?");
+	}
+
+	@Test(expected=BindingConfigParseException.class)
+	public void testValidateItemType_emptyConfig() throws BindingConfigParseException {
+		provider.validateItemType(testItem, "");
+	}
+
+	@Test(expected=BindingConfigParseException.class)
+	public void testProcessBindingConfig_nullContext() throws BindingConfigParseException {
+		provider.processBindingConfiguration(null, testItem, simpleConfig);
+	}
+
+	@Test(expected=BindingConfigParseException.class)
+	public void testProcessBindingConfig_nullItem() throws BindingConfigParseException {
+		provider.processBindingConfiguration("systeminfo", null, simpleConfig);
+	}
+
+	@Test(expected=BindingConfigParseException.class)
+	public void testProcessBindingConfig_nullConfig() throws BindingConfigParseException {
+		provider.processBindingConfiguration("systeminfo", testItem, null);
+	}
+
+	@Test(expected=BindingConfigParseException.class)
+	public void testProcessBindingConfig_emptyConfig() throws BindingConfigParseException {
+		provider.processBindingConfiguration("systeminfo", testItem, "");
+	}
+
+	/*
+	 * "DirFiles" tests
+	 */
+	@Test
+	/* Verify a simple file count configuration: "DirFiles:60000:." */
+	public void testProcessBindingConfig_FileCount01() throws BindingConfigParseException {
+		NumberItem testItem = new NumberItem("DirFiles01");
+		String simpleConfig = "DirFiles:60000:.";
+		provider.processBindingConfiguration("systeminfo", testItem, simpleConfig);
+
+		Assert.assertNull(provider.getCommandType(null));
+		Assert.assertNull(provider.getCommandType(""));
+		Assert.assertEquals("DirFiles", provider.getCommandType("DirFiles01").toString());
+
+		Assert.assertNull(provider.getItemType(null));
+		Assert.assertNull(provider.getItemType(""));
+		Assert.assertNull(provider.getItemType("DirFiles01"));
+
+		Assert.assertEquals(0, provider.getRefreshInterval(null));
+		Assert.assertEquals(0, provider.getRefreshInterval(""));
+		Assert.assertEquals(60000, provider.getRefreshInterval("DirFiles01"));
+
+		Assert.assertNull(provider.getTarget(null));
+		Assert.assertNull(provider.getTarget(""));
+		Assert.assertEquals(".", provider.getTarget("DirFiles01"));
+	}
+
+	@Test
+	/* Verify a relative path file count configuration (*nix): "DirFiles:60000:../resources/" */
+	public void testProcessBindingConfig_FileCount02() throws BindingConfigParseException {
+		NumberItem testItem = new NumberItem("DirFiles02");
+		String simpleConfig = "DirFiles:60000:../resources/";
+		provider.processBindingConfiguration("systeminfo", testItem, simpleConfig);
+
+		Assert.assertEquals("DirFiles", provider.getCommandType("DirFiles02").toString());
+		Assert.assertNull(provider.getItemType("DirFiles02"));
+		Assert.assertEquals(60000, provider.getRefreshInterval("DirFiles02"));
+		Assert.assertEquals("../resources/", provider.getTarget("DirFiles02"));
+	}
+
+	@Test
+	/* Verify a relative path file count configuration (Windows): "DirFiles:60000:..\resources\" */
+	public void testProcessBindingConfig_FileCount03() throws BindingConfigParseException {
+		String simpleConfig = "DirFiles:60000:..\\resources\\";
+
+		NumberItem testItem = new NumberItem("DirFiles03");
+		provider.processBindingConfiguration("systeminfo", testItem, simpleConfig);
+
+		Assert.assertEquals("DirFiles", provider.getCommandType("DirFiles03").toString());
+		Assert.assertNull(provider.getItemType("DirFiles03"));
+		Assert.assertEquals(60000, provider.getRefreshInterval("DirFiles03"));
+		Assert.assertEquals("..\\resources\\", provider.getTarget("DirFiles03"));
+	}
+
+	/* Verify an absolute path file count configuration (*nix): "DirFiles:60000:/usr/bin/" */
+	public void testProcessBindingConfig_FileCount04() throws BindingConfigParseException {
+		String simpleConfig = "DirFiles:60000:/usr/bin/";
+
+		NumberItem testItem = new NumberItem("DirFiles04");
+		provider.processBindingConfiguration("systeminfo", testItem, simpleConfig);
+
+		Assert.assertEquals("DirFiles", provider.getCommandType("DirFiles04").toString());
+		Assert.assertNull(provider.getItemType("DirFiles04"));
+		Assert.assertEquals(60000, provider.getRefreshInterval("DirFiles04"));
+		Assert.assertEquals("/usr/bin/", provider.getTarget("DirFiles04"));
+	}
+
+	@Test
+	/* Verify an absolute path file count configuration (Windows): "DirFiles:60000:c:\windows\" */
+	public void testProcessBindingConfig_FileCount05() throws BindingConfigParseException {
+		String simpleConfig = "DirFiles:60000:c:\\temp\\";
+
+		NumberItem testItem = new NumberItem("DirFiles05");
+		provider.processBindingConfiguration("systeminfo", testItem, simpleConfig);
+
+		Assert.assertEquals("DirFiles", provider.getCommandType("DirFiles05").toString());
+		Assert.assertNull(provider.getItemType("DirFiles05"));
+		Assert.assertEquals(60000, provider.getRefreshInterval("DirFiles05"));
+		Assert.assertEquals("c:\\temp\\", provider.getTarget("DirFiles05"));
+	}
+	/*** END of "DirFiles" tests ***/
+
+	/*
+	 * "DirUsage" tests
+	 */
+	@Test
+	/* Verify a simple dir usage configuration: "DirUsage:60000:/temp" */
+	public void testProcessBindingConfig_FileUsage01() throws BindingConfigParseException {
+		NumberItem testItem = new NumberItem("DirUsage01");
+		String simpleConfig = "DirUsage:60000:/temp";
+		provider.processBindingConfiguration("systeminfo", testItem, simpleConfig);
+
+		Assert.assertNull(provider.getCommandType(null));
+		Assert.assertNull(provider.getCommandType(""));
+		Assert.assertEquals("DirUsage", provider.getCommandType("DirUsage01").toString());
+
+		Assert.assertNull(provider.getItemType(null));
+		Assert.assertNull(provider.getItemType(""));
+		Assert.assertNull(provider.getItemType("DirUsage01"));
+
+		Assert.assertEquals(0, provider.getRefreshInterval(null));
+		Assert.assertEquals(0, provider.getRefreshInterval(""));
+		Assert.assertEquals(60000, provider.getRefreshInterval("DirUsage01"));
+
+		Assert.assertNull(provider.getTarget(null));
+		Assert.assertNull(provider.getTarget(""));
+		Assert.assertEquals("/temp", provider.getTarget("DirUsage01"));
+	}
+	/*** END of "DirUsage" tests ***/
+
+
+	class StringTestItem extends GenericItem {
+		
+		public StringTestItem() {
+			super("TEST");
+		}
+		
+		public StringTestItem(String name) {
+			super(name);
+		}
+		
+		public List<Class<? extends State>> getAcceptedDataTypes() {
+			List<Class<? extends State>> list = new ArrayList<Class<? extends State>>();
+			list.add(StringType.class);
+			return list;
+		}
+		
+		public List<Class<? extends Command>> getAcceptedCommandTypes() {
+			List<Class<? extends Command>> list = new ArrayList<Class<? extends Command>>();
+			list.add(StringType.class);
+			return list;
+		}
+
+		@Override
+		public State getStateAs(Class<? extends State> typeClass) {
+			return null;
+		}
+		
+	};
+
+
+	class DummyItem extends GenericItem {
+		public DummyItem() {
+			super("DUMMY!");
+		}
+
+		public DummyItem(String name) {
+			super(name);
+		}
+
+		public List<Class<? extends State>> getAcceptedDataTypes() {
+			List<Class<? extends State>> list = new ArrayList<Class<? extends State>>();
+				/*list.add(OnOffType.class);
+				list.add(PercentType.class);
+				list.add(UnDefType.class);*/
+			return list;
+		}
+		
+		public List<Class<? extends Command>> getAcceptedCommandTypes() {
+			List<Class<? extends Command>> list = new ArrayList<Class<? extends Command>>();
+				/*list.add(OnOffType.class);
+				list.add(IncreaseDecreaseType.class);
+				list.add(PercentType.class);*/
+			return list;
+		}
+
+		@Override
+		public State getStateAs(Class<? extends State> typeClass) {
+			return null;
+		}
+	}
+}

--- a/bundles/binding/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/SysteminfoGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.systeminfo/src/main/java/org/openhab/binding/systeminfo/internal/SysteminfoGenericBindingProvider.java
@@ -37,7 +37,11 @@ public class SysteminfoGenericBindingProvider extends
 	 */
 	@Override
 	public void validateItemType(Item item, String bindingConfig) throws BindingConfigParseException {
-		if (!(item instanceof NumberItem || item instanceof StringItem)) {
+		if( item == null ) {
+			throw new BindingConfigParseException(
+					"item is not permitted to be null.  item must be a non-null NumberItem or StringItem - please check your *.items configuration");
+		}
+		else if (!(item instanceof NumberItem || item instanceof StringItem)) {
 			throw new BindingConfigParseException(
 					"item '" + item.getName() + "' is of type '" + item.getClass().getSimpleName()
 					+ "', only NumberItem and StringItem are allowed - please check your *.items configuration");
@@ -51,16 +55,37 @@ public class SysteminfoGenericBindingProvider extends
 	public void processBindingConfiguration(String context, Item item, String bindingConfig) throws BindingConfigParseException {
 		super.processBindingConfiguration(context, item, bindingConfig);
 
+		if( item == null ) {
+			throw new BindingConfigParseException("item is not permitted to be null");
+		}
+		else if( bindingConfig == null ) {
+			throw new BindingConfigParseException("bindingConfig is not permitted to be null");
+		}
+
 		SysteminfoBindingConfig config = new SysteminfoBindingConfig();
 
 		String[] configParts = bindingConfig.trim().split(":");
 
-		if (configParts.length < 2 || configParts.length > 3) {
-			throw new BindingConfigParseException("Systeminfo binding must contain 2-3 parts separated by ':'");
+		if(configParts.length < 2) {
+			throw new BindingConfigParseException("Systeminfo binding must contain at least 2 parts separated by ':'");
 		}
 
 		String commandType = configParts[0].trim();
-		
+		if( configParts.length > 3 ) {
+			try {
+				int index1 = bindingConfig.indexOf(":");
+				int index2 = bindingConfig.indexOf(":", index1+1);
+				if( index1 > 0 && index2 > index1+1) {
+					config.target = bindingConfig.substring(index2+1);
+				}
+				else {
+					throw new BindingConfigParseException("Systeminfo binding must contain 2-3 parts separated by ':'");
+				}
+			}catch(Exception e) {
+				throw new BindingConfigParseException("Systeminfo binding must contain 2-3 parts separated by ':'");
+			 }
+		}
+
 		try {
 			config.commandType = SysteminfoCommandType.getCommandType(commandType);	
 		} catch (IllegalArgumentException e) {
@@ -73,8 +98,10 @@ public class SysteminfoGenericBindingProvider extends
 			throw new BindingConfigParseException("'" + configParts[1] + "' is not a valid refresh interval" );
 		}
 
-		if (configParts.length > 2) {
-			config.target = configParts[2].trim();
+		if( config.target == null ) {
+			if (configParts.length > 2) {
+				config.target = configParts[2].trim();
+			}
 		}
 
 		addBindingConfig(item, config);
@@ -82,24 +109,40 @@ public class SysteminfoGenericBindingProvider extends
 
 	@Override
 	public SysteminfoCommandType getCommandType(String itemName) {
+		if( itemName == null ) {
+			return null;
+		}
+
 		SysteminfoBindingConfig config = (SysteminfoBindingConfig) bindingConfigs.get(itemName);
 		return config != null ? config.commandType : null;
 	}
 
 	@Override
 	public Class<? extends Item> getItemType(String itemName) {
+		if( itemName == null ) {
+			return null;
+		}
+
 		SysteminfoBindingConfig config = (SysteminfoBindingConfig) bindingConfigs.get(itemName);
 		return config != null ? config.itemType : null;
 	}
 
 	@Override
 	public int getRefreshInterval(String itemName) {
+		if( itemName == null ) {
+			return 0;
+		}
+
 		SysteminfoBindingConfig config = (SysteminfoBindingConfig) bindingConfigs.get(itemName);
 		return config != null ? config.refreshInterval : 0;
 	}
 
 	@Override
 	public String getTarget(String itemName) {
+		if( itemName == null ) {
+			return null;
+		}
+
 		SysteminfoBindingConfig config = (SysteminfoBindingConfig) bindingConfigs.get(itemName);
 		return config != null ? config.target : null;
 	}

--- a/bundles/binding/pom.xml
+++ b/bundles/binding/pom.xml
@@ -72,6 +72,7 @@
     <module>org.openhab.binding.mqttitude</module>
     <module>org.openhab.binding.milight</module>
     <module>org.openhab.binding.systeminfo</module>
+    <module>org.openhab.binding.systeminfo.test</module>
     <module>org.openhab.binding.piface</module>
     <module>org.openhab.binding.pilight</module>
     <module>org.openhab.binding.pilight.test</module>

--- a/bundles/model/org.openhab.model.item/src/org/openhab/model/item/binding/AbstractGenericBindingProvider.java
+++ b/bundles/model/org.openhab.model.item/src/org/openhab/model/item/binding/AbstractGenericBindingProvider.java
@@ -73,6 +73,10 @@ public abstract class AbstractGenericBindingProvider implements BindingConfigRea
 	 * {@inheritDoc}
 	 */
 	public void processBindingConfiguration(String context, Item item, String bindingConfig) throws BindingConfigParseException {
+		if( context == null ) {
+			throw new BindingConfigParseException("context is not permitted to be null for item "+item);
+		}
+
 		Set<Item> items = contextMap.get(context);
 		if (items==null) {
 			items = new HashSet<Item>();


### PR DESCRIPTION
This fixes the absolute path problem from #2430 and adds a package of unit tests for the systeminfo binding.
