### PR TITLE
Bugfix: Handle multiline messages from MAX!Cube

### DIFF
--- a/bundles/binding/org.openhab.binding.maxcube.test/src/test/java/org/openhab/binding/maxcube/internal/message/MessageProcessorTest.java
+++ b/bundles/binding/org.openhab.binding.maxcube.test/src/test/java/org/openhab/binding/maxcube/internal/message/MessageProcessorTest.java
@@ -1,0 +1,224 @@
+package org.openhab.binding.maxcube.internal.message;
+
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openhab.binding.maxcube.internal.exceptions.IncompleteMessageException;
+import org.openhab.binding.maxcube.internal.exceptions.IncorrectMultilineIndexException;
+import org.openhab.binding.maxcube.internal.exceptions.MessageIsWaitingException;
+import org.openhab.binding.maxcube.internal.exceptions.NoMessageAvailableException;
+import org.openhab.binding.maxcube.internal.exceptions.UnprocessableMessageException;
+import org.openhab.binding.maxcube.internal.exceptions.UnsupportedMessageTypeException;
+
+/**
+ * @author Christian Rockrohr <christian@rockrohr.de>
+ * @since 1.7.0
+ */
+public class MessageProcessorTest {
+
+	MessageProcessor processor;
+
+	@Before
+	public void before() {
+		this.processor = new MessageProcessor();
+	}
+
+	private void commonMessageTest(String line, Message expectedMessage) {
+		try {
+			Assert.assertTrue(this.processor.addReceivedLine(line));
+			Assert.assertTrue(this.processor.isMessageAvailable());
+			Message message = this.processor.pull();
+			Assert.assertNotNull(message);
+			Assert.assertEquals(message.getClass().getName(), expectedMessage.getClass().getName());
+			Assert.assertEquals(expectedMessage.getPayload(), message.getPayload());
+		} catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("Unexpected error");
+		}
+	}
+
+	@Ignore //Don't have an S_Message at the moment
+	@Test
+	public void testS_Message() {
+		String rawData ="";
+		S_Message expectedMessage = new S_Message(rawData);
+		commonMessageTest(rawData, expectedMessage);
+	}
+
+	@Test
+	public void testC_Message() {
+		String rawData = "C:0ff1bc,EQ/xvAQJEAJMRVEwNzk0MDA3";
+		C_Message expectedMessage = new C_Message(rawData);
+		commonMessageTest(rawData, expectedMessage);
+	}
+
+	@Test
+	public void testL_Message() {
+		String rawData ="L:Bg/xvAkAAA==";
+		L_Message expectedMessage = new L_Message(rawData);
+		commonMessageTest(rawData, expectedMessage);
+	}
+
+	@Test
+	public void testH_Message() {
+		String rawData ="H:KHA0007199,081dd4,0113,00000000,0d524351,10,30,0f0407,1130,03,0000";
+		H_Message expectedMessage = new H_Message(rawData);
+		commonMessageTest(rawData, expectedMessage);
+	}
+
+	@Test
+	public void testSingleM_Message() {
+		String rawData ="M:00,01,VgIBAQpXb2huemltbWVyAAAAAQMQV6lMRVEwOTgyMTU2DldhbmR0aGVybW9zdGF0AQE=";
+		M_Message expectedMessage = new M_Message(rawData);
+		commonMessageTest(rawData, expectedMessage);
+	}
+
+	@Test
+	public void testMultilineM_Message() {
+		String line1_part1 = "M:00,02,";
+		String line1_part2 = "VgIMAQpXb2huemltbWVyCvMrAgtUb2lsZXR0ZSBFRwrenQMOVG9pbGV0dGUgMS4gT0cK3rgECkJhZGV6aW1tZXIK3qoFDFNjaGxhZnppbW1lcgresQYDSmFuD4lCBwlDaHJpc3RpbmEPiTYIBEZsdXIPiT0KEEJhZGV6aW1tZXIgMi4gT0cPiRwLBULDvHJvD4k/DAxHw6RzdGV6aW1tZXIPiRoJC1dhc2Noa8O8Y2hlD4lXNgQHOCtLRVEwMTg4NjczCFRlcnJhc3NlAQQHMblLRVEwMTg3MTkwCEZsdXJ0w7xyAQIK8ytLRVEwMzc5NTg3C1dhbmRoZWl6dW5nAQIK9P9LRVEwMzgwMDU1DkZlbnN0ZXJoZWl6dW5nAQQHMbtLRVEwMTg3MTg4CEZsdXJ0w7xyAgQHMuxLRVEwMTg2ODg0B0ZlbnN0ZXICAQrenUtFUTA0MDY5NjIHSGVpenVuZwIBCt64S0VRMDQwNjk4OQdIZWl6dW5nAwQIFGdLRVEwMTkwNTc3B0ZlbnN0ZXIDBAc2l0tFUTAxODU5NDUIRmx1cnTDvHIEAQreqktFUTA0MDY5NzUHSGVpenVuZwQBCt8JS0VRMDQwNzA3MA5IYW5kdHVjaGVpenVuZwQEBzhTS0VRMDE4ODcxMAdGZW5zdGVyBAQIFIxLRVEwMTkwNTQzFkZlbnN0ZXIgU3RyYcOfZSByZWNodHMFAQresUtFUTA0MDY5ODIHSGVpenVuZwUEBzHmS0VRMDE4NzE0NhVGZW5zdGVyIFN0cmHDn2UgbGlua3MFAxBXqUxFUTA5ODIxNTYOV2FuZHRoZXJtb3N0YXQBBA/u1ExFUTA3OTQ3NTIIRmx1cnTDvHIGBA/v6kxFUTA3OTQ0NzQNRmVuc3RlciBsaW5rcwYED/HnTEVRMDc5Mzk2NA5GZW5zdGVyIHJlY2h0cwYBD4lCTEVRMTAwNDYwMAdIZWl6dW5nBgQP9BVMRVEwNzkzNDA2CEZsdXJ0w7xyBwQP79FMRVEwNzk0NDk5B0ZlbnN0ZXIHAQ+JNkxFUTEwMDQ1ODgHSGVpenVuZwcBD4k9TEVRMTAwNDU5NQ1IZWl6dW5nIHVudGVuCAEPiRxMRVExMDA0NTYyB0hlaXp1bmcKBA/yTUxFUTA3OTM4NjIHRmVuc3RlcgoED/F+TEVRMDc5NDA2OQhGbHVydMO8cgoBD4k/TEVRMTAwNDU5NwdIZWl6dW5nCwQP8YdMRVEwNzk0MDYwB0ZlbnN0ZXILBA/xSExFUTA3OTQxMjQIRmx1cnTDvHILBA/yVkxFUTA3OTM4NTMURmVuc3RlciBHYXJ0ZW4gbGlua3MMBA/yI0xFUTA3OTM5MDQVRmVuc3RlciBHYXJ0ZW4gcmVjaHRzDAEPiRpMRVExMDA0NTYwB0hlaXp1bmcMBA/vj0xFUTA3OTQ1NjUPRmVuc3RlciBTdHJhw59lDAQP8CtMRVEwNzk0NDA5BFTDvHIDBAgUa0tFUTAxODcwNjkNRmVuc3RlciBTZWl0ZQUEBzagS0VRMDE4NTkzNhVGZW5zdGVyIFN0cmHDn2UgbGlua3MBBA/wI0xFUTA3OTQ0MTYORmVuc3RlciBLw7xjaGUBAxBV50xFUTA5ODI2NzYOV2FuZHRoZXJtb3N0YXQFAxBW2kxFUTA5ODIzNjgOV2FuZHRoZXJtb3N0YXQEAxBV4kxFUTA5ODI2NzEOV2FuZHRoZXJtb3N0YXQHAxBZWExFUTA5ODE3MjkOV2FuZHRoZXJtb3N0YXQMAxBV6ExFUTA5ODI2NzcOV2FuZHRoZXJtb3N0YXQGAxBV40xFUTA5ODI2NzIOV2FuZHRoZXJtb3N0YXQKBAcxoEtFUTAxODcyMTYLV2FzY2hrw7xjaGUF";
+		String line1 = line1_part1 + line1_part2;
+		
+		String line2_part1 = "M:01,02,";
+		String line2_part2 = "AxBV8ExFUTA5ODI2ODUOV2FuZHRoZXJtb3N0YXQJBA/v50xFUTA3OTQ0NzcNQmFsa29uZmVuc3RlcgkBD4lXTEVRMTAwNDYyMRZIZWl6dW5nIHVudGVybSBGZW5zdGVyCQQP8llMRVEwNzkzODUwDkZlbnN0ZXIgcmVjaHRzCQQP8bxMRVEwNzk0MDA3DUZlbnN0ZXIgbGlua3MJAQ+JOExFUTEwMDQ1OTAOSGVpenVuZyBCYWxrb24JBA/yLExFUTA3OTM4OTUKQmFsa29udMO8cgkED++zTEVRMDc5NDUyOQhGbHVydMO8cgkB";
+		String line2 = line2_part1 + line2_part2;
+		
+		
+		String expectedString = line1 + line2_part2;
+		M_Message expectedMessage = new M_Message(expectedString);
+		try {
+			Assert.assertFalse(this.processor.addReceivedLine(line1));
+			Assert.assertTrue(this.processor.addReceivedLine(line2));
+			Message message = this.processor.pull();
+			Assert.assertNotNull(message);
+			Assert.assertEquals(message.getClass().getName(), M_Message.class.getName());
+			Assert.assertEquals(expectedMessage.getPayload(), message.getPayload());
+		} catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("Unexpected error");
+		}
+	}
+
+	@Test
+	public void testWrongIndexOfMultilineM_Message() {
+		String line1 = "M:00,02,VgIMAQpXb2huemltbWVyCvMrAgtUb2lsZXR0ZSBFRwrenQMOVG9pbGV0dGUgMS4gT0cK3rgECkJhZGV6aW1tZXIK3qoFDFNjaGxhZnppbW1lcgresQYDSmFuD4lCBwlDaHJpc3RpbmEPiTYIBEZsdXIPiT0KEEJhZGV6aW1tZXIgMi4gT0cPiRwLBULDvHJvD4k/DAxHw6RzdGV6aW1tZXIPiRoJC1dhc2Noa8O8Y2hlD4lXNgQHOCtLRVEwMTg4NjczCFRlcnJhc3NlAQQHMblLRVEwMTg3MTkwCEZsdXJ0w7xyAQIK8ytLRVEwMzc5NTg3C1dhbmRoZWl6dW5nAQIK9P9LRVEwMzgwMDU1DkZlbnN0ZXJoZWl6dW5nAQQHMbtLRVEwMTg3MTg4CEZsdXJ0w7xyAgQHMuxLRVEwMTg2ODg0B0ZlbnN0ZXICAQrenUtFUTA0MDY5NjIHSGVpenVuZwIBCt64S0VRMDQwNjk4OQdIZWl6dW5nAwQIFGdLRVEwMTkwNTc3B0ZlbnN0ZXIDBAc2l0tFUTAxODU5NDUIRmx1cnTDvHIEAQreqktFUTA0MDY5NzUHSGVpenVuZwQBCt8JS0VRMDQwNzA3MA5IYW5kdHVjaGVpenVuZwQEBzhTS0VRMDE4ODcxMAdGZW5zdGVyBAQIFIxLRVEwMTkwNTQzFkZlbnN0ZXIgU3RyYcOfZSByZWNodHMFAQresUtFUTA0MDY5ODIHSGVpenVuZwUEBzHmS0VRMDE4NzE0NhVGZW5zdGVyIFN0cmHDn2UgbGlua3MFAxBXqUxFUTA5ODIxNTYOV2FuZHRoZXJtb3N0YXQBBA/u1ExFUTA3OTQ3NTIIRmx1cnTDvHIGBA/v6kxFUTA3OTQ0NzQNRmVuc3RlciBsaW5rcwYED/HnTEVRMDc5Mzk2NA5GZW5zdGVyIHJlY2h0cwYBD4lCTEVRMTAwNDYwMAdIZWl6dW5nBgQP9BVMRVEwNzkzNDA2CEZsdXJ0w7xyBwQP79FMRVEwNzk0NDk5B0ZlbnN0ZXIHAQ+JNkxFUTEwMDQ1ODgHSGVpenVuZwcBD4k9TEVRMTAwNDU5NQ1IZWl6dW5nIHVudGVuCAEPiRxMRVExMDA0NTYyB0hlaXp1bmcKBA/yTUxFUTA3OTM4NjIHRmVuc3RlcgoED/F+TEVRMDc5NDA2OQhGbHVydMO8cgoBD4k/TEVRMTAwNDU5NwdIZWl6dW5nCwQP8YdMRVEwNzk0MDYwB0ZlbnN0ZXILBA/xSExFUTA3OTQxMjQIRmx1cnTDvHILBA/yVkxFUTA3OTM4NTMURmVuc3RlciBHYXJ0ZW4gbGlua3MMBA/yI0xFUTA3OTM5MDQVRmVuc3RlciBHYXJ0ZW4gcmVjaHRzDAEPiRpMRVExMDA0NTYwB0hlaXp1bmcMBA/vj0xFUTA3OTQ1NjUPRmVuc3RlciBTdHJhw59lDAQP8CtMRVEwNzk0NDA5BFTDvHIDBAgUa0tFUTAxODcwNjkNRmVuc3RlciBTZWl0ZQUEBzagS0VRMDE4NTkzNhVGZW5zdGVyIFN0cmHDn2UgbGlua3MBBA/wI0xFUTA3OTQ0MTYORmVuc3RlciBLw7xjaGUBAxBV50xFUTA5ODI2NzYOV2FuZHRoZXJtb3N0YXQFAxBW2kxFUTA5ODIzNjgOV2FuZHRoZXJtb3N0YXQEAxBV4kxFUTA5ODI2NzEOV2FuZHRoZXJtb3N0YXQHAxBZWExFUTA5ODE3MjkOV2FuZHRoZXJtb3N0YXQMAxBV6ExFUTA5ODI2NzcOV2FuZHRoZXJtb3N0YXQGAxBV40xFUTA5ODI2NzIOV2FuZHRoZXJtb3N0YXQKBAcxoEtFUTAxODcyMTYLV2FzY2hrw7xjaGUF";
+		String line2 = "M:02,02,AxBV8ExFUTA5ODI2ODUOV2FuZHRoZXJtb3N0YXQJBA/v50xFUTA3OTQ0NzcNQmFsa29uZmVuc3RlcgkBD4lXTEVRMTAwNDYyMRZIZWl6dW5nIHVudGVybSBGZW5zdGVyCQQP8llMRVEwNzkzODUwDkZlbnN0ZXIgcmVjaHRzCQQP8bxMRVEwNzk0MDA3DUZlbnN0ZXIgbGlua3MJAQ+JOExFUTEwMDQ1OTAOSGVpenVuZyBCYWxrb24JBA/yLExFUTA3OTM4OTUKQmFsa29udMO8cgkED++zTEVRMDc5NDUyOQhGbHVydMO8cgkB";
+		
+		try {
+			this.processor.addReceivedLine(line2);
+			Assert.fail("Expected exception was not thrown.");
+		} catch(IncorrectMultilineIndexException e) {
+			//OK, correct Exception was thrown
+		} catch (Exception e) { 
+			e.printStackTrace();
+			Assert.fail("Unexpected error");
+		}
+
+		
+		try {
+			this.processor.reset();
+			Assert.assertFalse(this.processor.addReceivedLine(line1));
+			this.processor.addReceivedLine(line2);
+			Assert.fail("Expected exception was not thrown.");
+		} catch(IncorrectMultilineIndexException e) {
+			//OK, correct Exception was thrown
+		} catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("Unexpected error");
+		}
+	}
+
+	@Test
+	public void testPullBeforeNewLine() {
+		String line1 ="H:KHA0007199,081dd4,0113,00000000,0d524351,10,30,0f0407,1130,03,0000";
+		String line2 ="M:00,01,VgIBAQpXb2huemltbWVyAAAAAQMQV6lMRVEwOTgyMTU2DldhbmR0aGVybW9zdGF0AQE=";
+		
+		try {
+			Assert.assertTrue(this.processor.addReceivedLine(line1));
+			this.processor.addReceivedLine(line2);
+			Assert.fail("Expected exception was not thrown.");
+		} catch (MessageIsWaitingException e) {
+			//OK, correct Exception was thrown
+		} catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("Unexpected error");
+		}
+		
+		try {
+			Message message = this.processor.pull();
+			Assert.assertNotNull(message);
+			Assert.assertEquals(message.getClass().getName(), H_Message.class.getName());
+			this.processor.addReceivedLine(line2);
+			message = this.processor.pull();
+			Assert.assertNotNull(message);
+			Assert.assertEquals(message.getClass().getName(), M_Message.class.getName());
+		} catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("Unexpected error");
+		}
+	}
+
+	@Test
+	public void testWrongIndicatorWhileMultilineProcessing() {
+		String line1 = "M:00,02,VgIMAQpXb2huemltbWVyCvMrAgtUb2lsZXR0ZSBFRwrenQMOVG9pbGV0dGUgMS4gT0cK3rgECkJhZGV6aW1tZXIK3qoFDFNjaGxhZnppbW1lcgresQYDSmFuD4lCBwlDaHJpc3RpbmEPiTYIBEZsdXIPiT0KEEJhZGV6aW1tZXIgMi4gT0cPiRwLBULDvHJvD4k/DAxHw6RzdGV6aW1tZXIPiRoJC1dhc2Noa8O8Y2hlD4lXNgQHOCtLRVEwMTg4NjczCFRlcnJhc3NlAQQHMblLRVEwMTg3MTkwCEZsdXJ0w7xyAQIK8ytLRVEwMzc5NTg3C1dhbmRoZWl6dW5nAQIK9P9LRVEwMzgwMDU1DkZlbnN0ZXJoZWl6dW5nAQQHMbtLRVEwMTg3MTg4CEZsdXJ0w7xyAgQHMuxLRVEwMTg2ODg0B0ZlbnN0ZXICAQrenUtFUTA0MDY5NjIHSGVpenVuZwIBCt64S0VRMDQwNjk4OQdIZWl6dW5nAwQIFGdLRVEwMTkwNTc3B0ZlbnN0ZXIDBAc2l0tFUTAxODU5NDUIRmx1cnTDvHIEAQreqktFUTA0MDY5NzUHSGVpenVuZwQBCt8JS0VRMDQwNzA3MA5IYW5kdHVjaGVpenVuZwQEBzhTS0VRMDE4ODcxMAdGZW5zdGVyBAQIFIxLRVEwMTkwNTQzFkZlbnN0ZXIgU3RyYcOfZSByZWNodHMFAQresUtFUTA0MDY5ODIHSGVpenVuZwUEBzHmS0VRMDE4NzE0NhVGZW5zdGVyIFN0cmHDn2UgbGlua3MFAxBXqUxFUTA5ODIxNTYOV2FuZHRoZXJtb3N0YXQBBA/u1ExFUTA3OTQ3NTIIRmx1cnTDvHIGBA/v6kxFUTA3OTQ0NzQNRmVuc3RlciBsaW5rcwYED/HnTEVRMDc5Mzk2NA5GZW5zdGVyIHJlY2h0cwYBD4lCTEVRMTAwNDYwMAdIZWl6dW5nBgQP9BVMRVEwNzkzNDA2CEZsdXJ0w7xyBwQP79FMRVEwNzk0NDk5B0ZlbnN0ZXIHAQ+JNkxFUTEwMDQ1ODgHSGVpenVuZwcBD4k9TEVRMTAwNDU5NQ1IZWl6dW5nIHVudGVuCAEPiRxMRVExMDA0NTYyB0hlaXp1bmcKBA/yTUxFUTA3OTM4NjIHRmVuc3RlcgoED/F+TEVRMDc5NDA2OQhGbHVydMO8cgoBD4k/TEVRMTAwNDU5NwdIZWl6dW5nCwQP8YdMRVEwNzk0MDYwB0ZlbnN0ZXILBA/xSExFUTA3OTQxMjQIRmx1cnTDvHILBA/yVkxFUTA3OTM4NTMURmVuc3RlciBHYXJ0ZW4gbGlua3MMBA/yI0xFUTA3OTM5MDQVRmVuc3RlciBHYXJ0ZW4gcmVjaHRzDAEPiRpMRVExMDA0NTYwB0hlaXp1bmcMBA/vj0xFUTA3OTQ1NjUPRmVuc3RlciBTdHJhw59lDAQP8CtMRVEwNzk0NDA5BFTDvHIDBAgUa0tFUTAxODcwNjkNRmVuc3RlciBTZWl0ZQUEBzagS0VRMDE4NTkzNhVGZW5zdGVyIFN0cmHDn2UgbGlua3MBBA/wI0xFUTA3OTQ0MTYORmVuc3RlciBLw7xjaGUBAxBV50xFUTA5ODI2NzYOV2FuZHRoZXJtb3N0YXQFAxBW2kxFUTA5ODIzNjgOV2FuZHRoZXJtb3N0YXQEAxBV4kxFUTA5ODI2NzEOV2FuZHRoZXJtb3N0YXQHAxBZWExFUTA5ODE3MjkOV2FuZHRoZXJtb3N0YXQMAxBV6ExFUTA5ODI2NzcOV2FuZHRoZXJtb3N0YXQGAxBV40xFUTA5ODI2NzIOV2FuZHRoZXJtb3N0YXQKBAcxoEtFUTAxODcyMTYLV2FzY2hrw7xjaGUF";
+		String line2 = "H:KHA0007199,081dd4,0113,00000000,0d524351,10,30,0f0407,1130,03,0000";
+		
+		try {
+			Assert.assertFalse(this.processor.addReceivedLine(line1));
+			this.processor.addReceivedLine(line2);
+			Assert.fail("Expected exception was not thrown.");
+		} catch (IncompleteMessageException e) {
+			//OK, correct Exception was thrown
+		} catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("Unexpected error");
+		}
+	}
+
+	@Test
+	public void testUnknownMessageIndicator() {
+		String rawData = "X:0ff1bc,EQ/xvAQJEAJMRVEwNzk0MDA3";
+		
+		try {
+			Assert.assertFalse(this.processor.addReceivedLine(rawData));
+			Assert.fail("Expected exception was not thrown.");
+		} catch (UnsupportedMessageTypeException e) {
+			//OK, correct Exception was thrown
+		} catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("Unexpected error");
+		}
+	}
+
+	@Test
+	public void testNoMessageAvailable() {
+		String rawData ="M:00,01,VgIBAQpXb2huemltbWVyAAAAAQMQV6lMRVEwOTgyMTU2DldhbmR0aGVybW9zdGF0AQE=";
+		M_Message expectedMessage = new M_Message(rawData);
+		commonMessageTest(rawData, expectedMessage);
+		
+		try {
+			this.processor.pull();
+			Assert.fail("Expected exception was not thrown.");
+		} catch (NoMessageAvailableException e) {
+			//OK, correct Exception was thrown
+		}
+	}
+
+	@Test
+	public void testUnprocessableMessage() {
+		String line1 = "M:00"; //Some information are missing.
+		
+		try {
+			this.processor.addReceivedLine(line1);
+			Assert.fail("Expected exception was not thrown.");
+		} catch (UnprocessableMessageException e) {
+			//OK, correct Exception was thrown
+		} catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("Unexpected error");
+		}
+	}
+
+}

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeBinding.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeBinding.java
@@ -19,6 +19,12 @@ import java.util.Dictionary;
 
 import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.maxcube.MaxCubeBindingProvider;
+import org.openhab.binding.maxcube.internal.exceptions.IncompleteMessageException;
+import org.openhab.binding.maxcube.internal.exceptions.IncorrectMultilineIndexException;
+import org.openhab.binding.maxcube.internal.exceptions.MessageIsWaitingException;
+import org.openhab.binding.maxcube.internal.exceptions.NoMessageAvailableException;
+import org.openhab.binding.maxcube.internal.exceptions.UnprocessableMessageException;
+import org.openhab.binding.maxcube.internal.exceptions.UnsupportedMessageTypeException;
 import org.openhab.binding.maxcube.internal.message.C_Message;
 import org.openhab.binding.maxcube.internal.message.Configuration;
 import org.openhab.binding.maxcube.internal.message.Device;
@@ -28,6 +34,7 @@ import org.openhab.binding.maxcube.internal.message.HeatingThermostat;
 import org.openhab.binding.maxcube.internal.message.L_Message;
 import org.openhab.binding.maxcube.internal.message.M_Message;
 import org.openhab.binding.maxcube.internal.message.Message;
+import org.openhab.binding.maxcube.internal.message.MessageProcessor;
 import org.openhab.binding.maxcube.internal.message.MessageType;
 import org.openhab.binding.maxcube.internal.message.S_Command;
 import org.openhab.binding.maxcube.internal.message.S_Message;
@@ -119,6 +126,12 @@ public class MaxCubeBinding extends AbstractActiveBinding<MaxCubeBindingProvider
 	private BufferedReader reader = null;
 	private OutputStreamWriter writer = null;
 	
+	
+	/**
+	 * Processor that handles lines received from MAX!Cube
+	 */
+	MessageProcessor messageProcessor = new MessageProcessor();
+	
 	/**
 	 * {@inheritDoc}
 	 */
@@ -186,10 +199,15 @@ public class MaxCubeBinding extends AbstractActiveBinding<MaxCubeBindingProvider
 					cont = false;
 					continue;
 				}
-
-				Message message;
+				
+				Message message = null;
 				try {
-					message = processRawMessage(raw);
+					this.messageProcessor.addReceivedLine(raw);
+					if (this.messageProcessor.isMessageAvailable()) {
+						message = this.messageProcessor.pull();
+					} else {
+						continue;
+					}
 
 					message.debug(logger);
 
@@ -244,9 +262,28 @@ public class MaxCubeBinding extends AbstractActiveBinding<MaxCubeBindingProvider
 							cont = false;
 						}
 					}
+				} catch (IncorrectMultilineIndexException ex) {
+					logger.info("Incorrect MAX!Cube multiline message detected. Stopping processing and continue with next Line.");
+					this.messageProcessor.reset();
+				} catch (NoMessageAvailableException ex) {
+					logger.info("Could not process MAX!Cube message. Stopping processing and continue with next Line.");
+					this.messageProcessor.reset();
+				} catch (IncompleteMessageException ex) {
+					logger.info("Error while parsing MAX!Cube multiline message. Stopping processing, and continue with next Line.");
+					this.messageProcessor.reset();
+				} catch (UnprocessableMessageException ex) {
+					logger.info("Error while parsing MAX!Cube message. Stopping processing, and continue with next Line.");
+					this.messageProcessor.reset();
+				} catch (UnsupportedMessageTypeException ex) {
+					logger.info("Unsupported MAX!Cube message detected. Ignoring and continue with next Line.");
+					this.messageProcessor.reset();
+				} catch (MessageIsWaitingException ex) {
+					logger.info("There was and unhandled message waiting. Ignoring and continue with next Line.");
+					this.messageProcessor.reset();
 				} catch (Exception e) {
 					logger.info("Failed to process message received by MAX! protocol.");
 					logger.debug(Utils.getStackTrace(e));
+					this.messageProcessor.reset();
 				}
 			}
 			if(!exclusive) {
@@ -395,8 +432,22 @@ public class MaxCubeBinding extends AbstractActiveBinding<MaxCubeBindingProvider
 					writer.write(commandString);
 					logger.debug(commandString);
 					writer.flush();
+					
+					Message message = null;
 					String raw = reader.readLine();
-					Message message = processRawMessage(raw);
+                    try {
+                        while (!this.messageProcessor.isMessageAvailable()) {
+                        	this.messageProcessor.addReceivedLine(raw);
+                            raw = reader.readLine();
+                        }
+
+                        message = this.messageProcessor.pull();
+                    } catch (Exception e) {
+                        logger.info("Error while handling response from MAX! Cube lan gateway!");
+                        logger.debug(Utils.getStackTrace(e));
+                        this.messageProcessor.reset();
+                    }
+					
 					if (message !=null) {
 						if (message.getType() == MessageType.S) {
 							sMessageProcessing((S_Message)message);
@@ -464,32 +515,6 @@ public class MaxCubeBinding extends AbstractActiveBinding<MaxCubeBindingProvider
 			}
 		}
 		return null;
-	}
-
-	/**
-	 * Processes the raw TCP data read from the MAX protocol, returning the
-	 * corresponding Message.
-	 * 
-	 * @param raw
-	 *            the raw data provided read from the MAX protocol
-	 * @return the correct message for the given raw data
-	 */
-	private Message processRawMessage(String raw) {
-
-		if (raw.startsWith("H:")) {
-			return new H_Message(raw);
-		} else if (raw.startsWith("M:")) {
-			return new M_Message(raw);
-		} else if (raw.startsWith("C:")) {
-			return new C_Message(raw);
-		} else if (raw.startsWith("L:")) {
-			return new L_Message(raw);
-		} else if (raw.startsWith("S:")) {
-			return new S_Message(raw);
-		} else {
-			logger.debug("Unknown message block: '{}'",raw);
-		}
-			return null;
 	}
 
 	/**

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/exceptions/IncompleteMessageException.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/exceptions/IncompleteMessageException.java
@@ -1,0 +1,11 @@
+package org.openhab.binding.maxcube.internal.exceptions;
+
+/**
+ * Will be thrown when there is an attempt to put a new message line into the message processor,
+ * but the processor is currently processing an other message type.
+ * 
+ * @author Christian Rockrohr <christian@rockrohr.de>
+ */
+public class IncompleteMessageException extends Exception {
+
+}

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/exceptions/IncorrectMultilineIndexException.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/exceptions/IncorrectMultilineIndexException.java
@@ -1,0 +1,11 @@
+package org.openhab.binding.maxcube.internal.exceptions;
+
+/**
+ * Will be thrown when there is an attempt to put a new message line into the message processor,
+ * but the processor is currently processing an other message type.
+ * 
+ * @author Christian Rockrohr <christian@rockrohr.de>
+ */
+public class IncorrectMultilineIndexException extends Exception {
+
+}

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/exceptions/MessageIsWaitingException.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/exceptions/MessageIsWaitingException.java
@@ -1,0 +1,12 @@
+package org.openhab.binding.maxcube.internal.exceptions;
+
+/**
+ * Will be thrown when there is an attempt to put a new message line into the message processor,
+ * but the processor is not yet ready to handle new lines because there is already a message that
+ * has be pulled before.
+ * 
+ * @author Christian Rockrohr <christian@rockrohr.de>
+ */
+public class MessageIsWaitingException extends Exception {
+
+}

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/exceptions/NoMessageAvailableException.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/exceptions/NoMessageAvailableException.java
@@ -1,0 +1,11 @@
+package org.openhab.binding.maxcube.internal.exceptions;
+
+/**
+ * Will be thrown when there is an attempt to pull a  message from the message processor,
+ * but the processor does not yet have a complete message.
+ * 
+ * @author Christian Rockrohr <christian@rockrohr.de>
+ */
+public class NoMessageAvailableException extends Exception {
+
+}

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/exceptions/UnprocessableMessageException.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/exceptions/UnprocessableMessageException.java
@@ -1,0 +1,11 @@
+package org.openhab.binding.maxcube.internal.exceptions;
+
+/**
+ * Will be thrown when there is an attempt to put a new message line into the message processor,
+ * the processor detects a known message indicator, but the message could not be parsed correctly.
+ * 
+ * @author Christian Rockrohr <christian@rockrohr.de>
+ */
+public class UnprocessableMessageException extends Exception {
+
+}

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/exceptions/UnsupportedMessageTypeException.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/exceptions/UnsupportedMessageTypeException.java
@@ -1,0 +1,11 @@
+package org.openhab.binding.maxcube.internal.exceptions;
+
+/**
+ * Will be thrown when there is an attempt to put a new message line into the message processor,
+ * but the line starts with an unknown message indicator.
+ * 
+ * @author Christian Rockrohr <christian@rockrohr.de>
+ */
+public class UnsupportedMessageTypeException extends Exception {
+
+}

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/MessageProcessor.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/MessageProcessor.java
@@ -1,0 +1,225 @@
+package org.openhab.binding.maxcube.internal.message;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openhab.binding.maxcube.internal.exceptions.IncompleteMessageException;
+import org.openhab.binding.maxcube.internal.exceptions.IncorrectMultilineIndexException;
+import org.openhab.binding.maxcube.internal.exceptions.MessageIsWaitingException;
+import org.openhab.binding.maxcube.internal.exceptions.NoMessageAvailableException;
+import org.openhab.binding.maxcube.internal.exceptions.UnprocessableMessageException;
+import org.openhab.binding.maxcube.internal.exceptions.UnsupportedMessageTypeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The message processor was introduced to combine multiple received lines to
+ * one single message. There are cases, when the MAX!Cube sends multiple
+ * messages (M-Message for example). The message processor acts as stack for
+ * received messages. Every received line should be added to the processor.
+ * After every added line, the message processor analyses the line. It is not
+ * possible to add additional lines when there is a message ready to be
+ * processed.
+ * 
+ * @author Christian Rockrohr <christian@rockrohr.de>
+ * @since 1.7.0
+ */
+public class MessageProcessor {
+
+	private static final Logger logger = LoggerFactory.getLogger(MessageProcessor.class);
+	
+	public static final String SEPARATOR = ":";
+	
+	/**
+	 * The message that was created from last line received. (Null if no message
+	 * available yet)
+	 */
+	private Message currentMessage = null;
+
+	/**
+	 * <pre>
+	 * If more that one single line is required to create a message
+	 * 	  	numberOfRequiredLines holds the number of required messages to complete
+	 * 		receivedLines holds the lines received so far
+	 * 		currentMessageType indicates which message type is currently on stack
+	 * </pre>
+	 */
+	private Integer numberOfRequiredLines = null;
+	private List<String> receivedLines = new ArrayList<String>();
+	private MessageType currentMessageType = null;
+
+	/**
+	 * Resets the current status and processed lines. Should be used after
+	 * processing a message
+	 */
+	public void reset() {
+		this.currentMessage = null;
+		receivedLines.clear();
+		currentMessageType = null;
+		numberOfRequiredLines = null;
+	}
+
+	/**
+	 * Analyses the line and creates a message when possible. If the line
+	 * indicates, that additional lines are required to create a complete
+	 * message, the message processor keeps the line in memory and awaits
+	 * additional lines. If the new line does not fit into current state
+	 * (incomplete M: message on stack but L: message line received) a
+	 * IncompleteMessageException is thrown.
+	 * 
+	 * @param line
+	 *            is the new line received
+	 * @return true if a message could be created by this line, false in any
+	 *         other cases (line was stacked, error, ...)
+	 * @throws MessageIsWaitingException
+	 *             when a line was added without pulling the previous message
+	 * @throws IncompleteMessageException
+	 *             when a line was added that does not belong to current message
+	 *             stack
+	 * @throws UnsupportedMessageTypeException
+	 *             in case the line starts with an unknown message indicator
+	 * @throws UnprocessableMessageException
+	 *             is thrown when there was a known message indicator found, but
+	 *             message could not be parsed correctly.
+	 * @throws IncorrectMultilineIndexException 
+	 */
+	public Boolean addReceivedLine(String line) throws IncompleteMessageException, MessageIsWaitingException,
+			UnsupportedMessageTypeException, UnprocessableMessageException, IncorrectMultilineIndexException {
+
+		if (this.currentMessage != null) {
+			throw new MessageIsWaitingException();
+		}
+
+		MessageType messageType = getMessageType(line);
+
+		if (messageType == null) {
+			throw new UnsupportedMessageTypeException();
+		}
+
+		if ((this.currentMessageType != null) && (!messageType.equals(this.currentMessageType))) {
+			throw new IncompleteMessageException();
+		}
+
+		Boolean result = true;
+
+		switch (messageType) {
+		case H:
+			this.currentMessage = new H_Message(line);
+			break;
+		case C:
+			this.currentMessage = new C_Message(line);
+			break;
+		case L:
+			this.currentMessage = new L_Message(line);
+			break;
+		case S:
+			this.currentMessage = new S_Message(line);
+			break;
+		case M:
+			result = handle_M_MessageLine(line);
+			break;
+		default:
+		}
+
+		return result;
+	}
+
+	private Boolean handle_M_MessageLine(String line) throws UnprocessableMessageException, IncompleteMessageException, IncorrectMultilineIndexException {
+		Boolean result = false;
+
+		String[] tokens = line.split(Message.DELIMETER);  //M:00,01,xyz.....
+
+		try {
+			Integer index = Integer.valueOf(tokens[0].replaceFirst("M:", ""));  //M:00
+			Integer counter = Integer.valueOf(tokens[1]);  //01
+
+			if (this.numberOfRequiredLines == null) {
+				switch (counter) {
+				case 0:
+					throw new UnprocessableMessageException();
+				case 1:
+					this.currentMessage = new M_Message(line);
+					result = true;
+					break;
+				default:
+					this.numberOfRequiredLines = counter;
+					this.currentMessageType = MessageType.M;
+					if (index == 0) {
+						this.receivedLines.add(line);
+					} else {
+						throw new IncorrectMultilineIndexException();
+					}
+				}
+			} else {
+				if ((!counter.equals(this.numberOfRequiredLines)) || (!(index == this.receivedLines.size()))) {
+					throw new IncorrectMultilineIndexException();
+				}
+				
+				receivedLines.add(tokens[2]);
+				
+				if (index+1 == receivedLines.size()) {
+					String newLine = "";
+					for (String curLine : receivedLines)
+						newLine += curLine;
+					this.currentMessage = new M_Message(newLine);
+					result = true;
+				}
+			}
+		} catch (IncorrectMultilineIndexException ex) {
+			throw ex;
+		} catch (Exception ex) {
+			throw new UnprocessableMessageException();
+		}
+
+		return result;
+	}
+	
+	/**
+	 * @return true if there is a message waiting to be pulled
+	 */
+	public boolean isMessageAvailable() {
+		return this.currentMessage != null;
+	}
+
+	/**
+	 * Pulls the message from the stack when there is one available. This needs
+	 * to be done before next line can be added into message processor. When
+	 * message is pulled, the message processor is reseted and ready to process
+	 * next line.
+	 * 
+	 * @return Message
+	 * @throws NoMessageAvailableException
+	 *             when there was no message on the stack
+	 */
+	public Message pull() throws NoMessageAvailableException {
+		Message result = null;
+
+		if (this.currentMessage == null) {
+			throw new NoMessageAvailableException();
+		} else {
+			result = this.currentMessage;
+			reset();
+		}
+
+		return result;
+	}
+
+	/**
+	 * Processes the raw TCP data read from the MAX protocol, returning the
+	 * corresponding MessageType.
+	 * 
+	 * @param line
+	 *            the raw data provided read from the MAX protocol
+	 * @return MessageType of the line added
+	 */
+	private static MessageType getMessageType(String line) {
+
+		for (MessageType msgType : MessageType.values()) {
+			if (line.startsWith(msgType.name() + SEPARATOR)) {
+				return msgType;
+			}
+		}
+
+		return null;
+	}
+}


### PR DESCRIPTION
I added the support for multiline messages, received from MAX!Cube.

When a MAX!Cube has configured many devices with long names and long room names (I have 54 devices with nice german names configured) the configuration data does not fit into one single M_Message. In this case, the cube splits the message into multiple lines. This was not supported by the former implementation.

Now there is a new class "MessageProcessor" that does the job. All messages received from MAX!Cube are passed to an instance of MessageProcessor. The MessageProcessor recignizes when there are additional lines required for a complete message.