### PR TITLE
Make changing of state asynchronous to fix continous sending of dimmer commands

### DIFF
--- a/bundles/ui/org.openhab.ui.webapp/snippets/main.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/main.html
@@ -69,7 +69,7 @@
       document.OH = OH = {};
 
       OH.changeState = function changeState(request) {
-        WA.Request(request, null, null);
+        WA.Request(request, null, null, true);
       };
 
       // Functions for image refresh


### PR DESCRIPTION
Fixes #2210 .
Caused by a bug in (at least) Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=664720) the onmouseup is not triggered if a synchronous Ajax request made in the onmousedown does not complete soon enough.
Anyway the use of synchronous HTTP Requests seems to be deprecated.

Would be great if this pull request could be reviewed by @sja 
