### PR TITLE
MySQL-Persistence: Add errCnt++ to getTable and check connection

### DIFF
--- a/bundles/persistence/org.openhab.persistence.mysql/java/org/openhab/persistence/mysql/internal/MysqlPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.mysql/java/org/openhab/persistence/mysql/internal/MysqlPersistenceService.java
@@ -186,6 +186,8 @@ public class MysqlPersistenceService implements QueryablePersistenceService, Man
 			tableName = new String("Item" + rowId);
 			logger.debug("mySQL: new item {} is Item{}", itemName, rowId);
 		} catch (SQLException e) {
+			errCnt++;
+			
 			logger.error("mySQL: Could not create table for item '{}': ", itemName, e.getMessage());
 		} finally {
 			if (statement != null) {
@@ -223,6 +225,8 @@ public class MysqlPersistenceService implements QueryablePersistenceService, Man
 					+ " in SQL database.");
 			sqlTables.put(itemName, tableName);
 		} catch (Exception e) {
+			errCnt++;
+			
 			logger.error("mySQL: Could not create table for item '" + itemName + "' with statement '" + sqlCmd + "': "
 					+ e.getMessage());			
 		} finally {
@@ -246,6 +250,8 @@ public class MysqlPersistenceService implements QueryablePersistenceService, Man
 				statement = connection.createStatement();
 				statement.executeUpdate(sqlCmd);	
 			} catch (Exception e) {
+				errCnt++;
+				
 				logger.error("mySQL: Could not remove index for item '" + itemName + "' with statement '" + sqlCmd + "': "
 						+ e.getMessage());			
 			} finally {
@@ -280,8 +286,8 @@ public class MysqlPersistenceService implements QueryablePersistenceService, Man
 		// If we still didn't manage to connect, then return!
 		if (!isConnected()) {
 			logger.warn(
-					"mySQL: No connection to database. Can not persist item '{}'! Will retry connecting to database next time.",
-					item);
+					"mySQL: No connection to database. Can not persist item '{}'! Will retry connecting to database when error count:{} equals errReconnectThreshold:{}",
+					item,errCnt,errReconnectThreshold);
 			return;
 		}
 
@@ -350,6 +356,18 @@ public class MysqlPersistenceService implements QueryablePersistenceService, Man
 	 * @return true if connection has been established, false otherwise
 	 */
 	private boolean isConnected() {
+		//Check if connection is valid
+		try {
+			if (connection!= null && !connection.isValid(5000)) {
+				errCnt++;
+				logger.error("mySQL: Connection is not valid!");
+			}
+		} catch (SQLException e) {
+			errCnt++;
+			
+			logger.error("mySQL: Error while checking connection: {}", e);
+		}
+		
 		// Error check. If we have 'errReconnectThreshold' errors in a row, then
 		// reconnect to the database
 		if (errReconnectThreshold != 0 && errCnt >= errReconnectThreshold) {


### PR DESCRIPTION
changes discussed in Issue #1934. Adding errCnt to getTable Method
and check connection with JDBC isValid method, before a broken
connection is used to store values, which will result in data loss.