### PR TITLE
Various fixes and improvements to InsteonPLM

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/DeviceFeature.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/DeviceFeature.java
@@ -79,6 +79,7 @@ public class DeviceFeature {
 	private HashMap<Class<? extends Command>, CommandHandler> m_commandHandlers =
 				new HashMap<Class<? extends Command>, CommandHandler>();
 	private ArrayList<DeviceFeatureListener> m_listeners = new ArrayList<DeviceFeatureListener>();
+	private ArrayList<DeviceFeature>	m_connectedFeatures = new ArrayList<DeviceFeature>();
 	
 	
 	/**
@@ -103,12 +104,15 @@ public class DeviceFeature {
 	public String	 	getName()			{ return m_name; }
 	public synchronized QueryStatus	getQueryStatus()	{ return m_queryStatus; }
 	public InsteonDevice getDevice() 		{ return m_device; }
-	public boolean 		hasListeners() 		{ return !m_listeners.isEmpty(); }
 	public boolean		isStatusFeature()	{ return m_isStatus; }
 	public MessageHandler getDefaultMsgHandler() { return m_defaultMsgHandler; }
 	public HashMap<Integer, MessageHandler> getMsgHandlers() {
 		return this.m_msgHandlers;
 	}
+	public ArrayList<DeviceFeature>	getConnectedFeatures() {
+		 return (m_connectedFeatures); 
+	}
+
 	// various simple setters
 	public void setStatusFeature(boolean f)	{ m_isStatus = f; }
 	public void setPollHandler(PollHandler h)	{ m_pollHandler = h; }
@@ -134,6 +138,22 @@ public class DeviceFeature {
 			}
 			m_listeners.add(l);
 		}
+	}
+	/**
+	 * Adds a connected feature such that this DeviceFeature can
+	 * act as a feature group
+	 * @param f the device feature related to this feature
+	 */
+	public void addConnectedFeature(DeviceFeature f) {
+		m_connectedFeatures.add(f);
+	}
+
+	public boolean hasListeners() {
+		if (!m_listeners.isEmpty()) return true;
+		for (DeviceFeature f: m_connectedFeatures) {
+			if (f.hasListeners()) return true;
+		}
+		return false;
 	}
 
 	/**

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/DeviceType.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/DeviceType.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.binding.insteonplm.internal.device;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map.Entry;
 
@@ -23,6 +24,8 @@ public class DeviceType {
 	private String m_model			= "";
 	private String m_description 	= "";
 	private HashMap<String, String> m_features = new HashMap<String, String>();
+	private HashMap<String, FeatureGroup> m_featureGroups =
+				new HashMap<String, FeatureGroup>();
 	
 	/**
 	 * Constructor
@@ -36,6 +39,11 @@ public class DeviceType {
 	 * @return all features that this device type supports
 	 */
 	public HashMap<String, String> getFeatures() { return m_features; }
+	/**
+	 * Get all feature groups
+	 * @return all feature groups of this device type
+	 */
+	public HashMap<String, FeatureGroup> getFeatureGroups() { return m_featureGroups; }
 	/**
 	 * Sets the descriptive model string
 	 * @param aModel descriptive model string
@@ -53,17 +61,60 @@ public class DeviceType {
 	 * @return false if feature was already there
 	 */
 	public boolean addFeature(String aKey, String aFeatureName) {
-		if (m_features.containsKey(aFeatureName)) return false;
+		if (m_features.containsKey(aKey)) return false;
 		m_features.put(aKey,  aFeatureName);
 		return true;
 	}
+	/**
+	 * Adds feature group to device type
+	 * @param aKey name of the feature group, which acts as key for lookup later
+	 * @param fg feature group to add
+	 * @return true if add succeeded, false if group was already there
+	 */
+	public boolean addFeatureGroup(String aKey, FeatureGroup fg) {
+		if (m_features.containsKey(aKey)) return false;
+		m_featureGroups.put(aKey,  fg);
+		return true;
+	}
+	
 	public String toString() {
 		String s = "pk:" + m_productKey + "|model:" + m_model +
 				"|desc:" + m_description + "|features";
 		for (Entry<String, String> f : m_features.entrySet()) {
 			s += ":" + f.getKey() + "=" + f.getValue();
 		}
+		s += "|groups";
+		for (Entry<String, FeatureGroup> f : m_featureGroups.entrySet()) {
+			s += ":" + f.getKey() + "=" + f.getValue();
+		}
 		return s;
 	}
+	/**
+	 * Class that reflects feature group association
+	 * @author Bernd Pfrommer
+	 */
+	public static class FeatureGroup {
+		private	String				m_name = null;
+		private	String				m_type = null;
+		private	ArrayList<String>	m_features = new ArrayList<String>();
+		
+		FeatureGroup(String name, String type) {
+			m_name = name;
+			m_type = type;
+		}
+		public void addFeature(String f) { m_features.add(f); }
+		public ArrayList<String> getFeatures() { return m_features; }
+		public String getName() { return m_name; }
+		public String getType() { return m_type; }
+		public String toString() {
+			String s = "";
+			for (String g : m_features) {
+				s += g + ",";
+			}
+			return (s.replaceAll(",$",""));
+		}
+	}
+
+
 	
 }

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/InsteonDevice.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/InsteonDevice.java
@@ -9,13 +9,13 @@
 package org.openhab.binding.insteonplm.internal.device;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.Map.Entry;
+import java.util.PriorityQueue;
 
 import org.openhab.binding.insteonplm.InsteonPLMBindingConfig;
+import org.openhab.binding.insteonplm.internal.device.DeviceType.FeatureGroup;
 import org.openhab.binding.insteonplm.internal.driver.Driver;
 import org.openhab.binding.insteonplm.internal.message.FieldException;
 import org.openhab.binding.insteonplm.internal.message.Msg;
@@ -51,9 +51,14 @@ public class InsteonDevice {
 	private Long						m_lastTimePolled = 0L;
 	private Long						m_lastMsgReceived = 0L;
 	private boolean						m_isModem		= false;
-	private	 Deque<QEntry>				m_requestQueue  = new LinkedList<QEntry>();
-	private DeviceFeature.QueryStatus	m_requestQueueState = DeviceFeature.QueryStatus.QUERY_ANSWERED;
-	private static final long			QUERY_TIMEOUT	= 2000;
+	private	PriorityQueue<QEntry>		m_requestQueue  = new PriorityQueue<QEntry>();
+	private	DeviceFeature				m_featureQueried = null;
+	/** time to wait for reply after direct message */
+	private static final long			TIMEOUT_DIRECT_MESSAGE_REPLY	= 30000;
+	/** need to wait after query to avoid misinterpretation of duplicate replies */
+	private static final int			QUIET_TIME_DIRECT_MESSAGE = 2000;
+	/** how far to space out poll messages */
+	private static final int			TIME_BETWEEN_POLL_MESSAGES = 1500;
 	private long						m_lastQueryTime	= 0L;					
 	private	boolean						m_hasModemDBEntry = false;
 	private DeviceStatus				m_status		= DeviceStatus.INITIALIZED;
@@ -116,6 +121,16 @@ public class InsteonDevice {
 		logger.trace("setting poll interval for {} to {} ", m_address, pi);
 		if (pi > 0) m_pollInterval = pi;
 	}
+	public void setFeatureQueried(DeviceFeature f) {
+		synchronized (m_requestQueue) {
+			m_featureQueried = f;
+		}
+	};
+	public DeviceFeature getFeatureQueried() {
+		synchronized (m_requestQueue) {
+			return (m_featureQueried);
+		}
+	};
 
 	/**
 	 * Add a port. Currently only a single port is being used.
@@ -166,15 +181,19 @@ public class InsteonDevice {
 	 * Execute poll on this device: create an array of messages,
 	 * add them to the request queue, and schedule the queue
 	 * for processing.
+	 * @param delay scheduling delay (in milliseconds)
 	 */
-	public void doPoll() {
+	public void doPoll(long delay) {
+		long now = System.currentTimeMillis();
 		ArrayList<QEntry> l = new ArrayList<QEntry>();
 		synchronized(m_features) {
+			int spacing = 0;
 			for (DeviceFeature i : m_features.values()) {
 				if (i.hasListeners()) {
 					Msg m = i.makePollMsg();
-					if (m != null) l.add(new QEntry(i, m));
+					if (m != null) l.add(new QEntry(i, m, now + delay + spacing));
 				}
+				spacing += TIME_BETWEEN_POLL_MESSAGES;
 			}
 		}
 		if (l.isEmpty()) return;
@@ -183,8 +202,7 @@ public class InsteonDevice {
 				m_requestQueue.add(e);
 			}
 		}
-		long now = System.currentTimeMillis();
-		RequestQueueManager.s_instance().addQueue(this, now);
+		RequestQueueManager.s_instance().addQueue(this, now + delay);
 		
 		if (!l.isEmpty()) {
 			synchronized(m_lastTimePolled) {
@@ -209,6 +227,10 @@ public class InsteonDevice {
 			for (DeviceFeature f : m_features.values()) {
 				if (!f.isStatusFeature()) {
 					if (f.handleMessage(msg, fromPort)) {
+						// handled a reply to a query,
+						// mark it as processed
+						logger.trace("handled reply of direct: {}", f);
+						setFeatureQueried(null);
 						break;
 					}
 				}
@@ -304,27 +326,44 @@ public class InsteonDevice {
 			if (m_requestQueue.isEmpty()) {
 				return 0L;
 			}
-			if (m_requestQueueState == DeviceFeature.QueryStatus.QUERY_PENDING) {
-				long dt = timeNow - (m_lastQueryTime + QUERY_TIMEOUT);
+			if (m_featureQueried != null) {
+				// A feature has been queried, but
+				// the response has not been digested yet.
+				// Must wait for the query to be processed.
+				long dt = timeNow - (m_lastQueryTime + TIMEOUT_DIRECT_MESSAGE_REPLY);
 				if (dt < 0) {
 					logger.debug("still waiting for query reply from {} for another {} usec",
-							m_address, dt);
-					return (m_lastQueryTime + QUERY_TIMEOUT);
+							m_address, -dt);
+					return (timeNow + 2000L); // retry soon
 				} else {
 					logger.warn("gave up waiting for query reply from device {}", m_address);
 				}
-			} 
-			m_lastQueryTime = timeNow;
-			QEntry qe = m_requestQueue.poll();
-			qe.getFeature().setQueryStatus(DeviceFeature.QueryStatus.QUERY_PENDING);
+			}
+			QEntry qe = m_requestQueue.poll(); // take it off the queue!
+			if (!qe.getMsg().isBroadcast()) {
+				logger.debug("qe taken off direct: {} {}", qe.getFeature(), qe.getMsg());
+				m_lastQueryTime = timeNow;
+				// mark feature as pending
+				qe.getFeature().setQueryStatus(DeviceFeature.QueryStatus.QUERY_PENDING);
+				// also mark this queue as pending so there is no doubt
+				m_featureQueried = qe.getFeature();
+			} else {
+				logger.debug("qe taken off bcast: {} {}", qe.getFeature(), qe.getMsg());
+			}
 			long quietTime = qe.getMsg().getQuietTime();
-			qe.getMsg().setQuietTime(500L); // rate limiting downstream:
+			qe.getMsg().setQuietTime(500L); // rate limiting downstream!
 			try {
 				writeMessage(qe.getMsg());
 			} catch (IOException e) {
 				logger.error("message write failed for msg {}", qe.getMsg(), e);
 			}
-			return (timeNow + quietTime);
+			// figure out when the request queue should be checked next
+			QEntry qnext = m_requestQueue.peek();
+			long nextExpTime = (qnext == null ? 0L : qnext.getExpirationTime());
+			long nextTime = Math.max(timeNow + quietTime, nextExpTime);
+			logger.debug("next request queue processed in {} msec, quiettime = {}",
+						 nextTime - timeNow, quietTime);
+			return (nextTime);
 		}
 	}
 	/**
@@ -343,10 +382,13 @@ public class InsteonDevice {
 	 * @param d time (in milliseconds)to delay before enqueuing message
 	 */
 	public void enqueueDelayedMessage(Msg m, DeviceFeature f, long delay) {
-		synchronized (m_requestQueue) {
-			m_requestQueue.add(new QEntry(f, m));
-		}
 		long now = System.currentTimeMillis();
+		synchronized (m_requestQueue) {
+			m_requestQueue.add(new QEntry(f, m, now + delay));
+		}
+		if (!m.isBroadcast()) {
+			m.setQuietTime(QUIET_TIME_DIRECT_MESSAGE);
+		}
 		logger.trace("enqueing direct message with delay {}", delay);
 		RequestQueueManager.s_instance().addQueue(this, now + delay);
 	}
@@ -362,6 +404,29 @@ public class InsteonDevice {
 				logger.error("device type {} references unknown feature: {}", dt, fe.getValue());
 			} else {
 				addFeature(fe.getKey(), f);
+			}
+		}
+		for (Entry<String, FeatureGroup> fe : dt.getFeatureGroups().entrySet()) {
+			FeatureGroup fg = fe.getValue();
+			DeviceFeature f = DeviceFeature.s_makeDeviceFeature(fg.getType());
+			if (f == null) {
+				logger.error("device type {} references unknown feature group: {}",
+						dt, fg.getType());
+			} else {
+				addFeature(fe.getKey(), f);
+			}
+			connectFeatures(fe.getKey(), f, fg.getFeatures());
+		}
+	}
+
+	private void connectFeatures(String gn, DeviceFeature fg, ArrayList<String> features) {
+		for (String fs : features) {
+			DeviceFeature f = m_features.get(fs);
+			if (f == null) {
+				logger.error("feature group {} references unknown feature {}", gn, fs);
+			} else {
+				logger.debug("{} connected feature: {}", gn, f);
+				fg.addConnectedFeature(f);
 			}
 		}
 	}
@@ -397,14 +462,21 @@ public class InsteonDevice {
 	 * Queue entry helper class
 	 * @author Bernd Pfrommer
 	 */
-	public static class QEntry {
+	public static class QEntry implements Comparable<QEntry> {
 		private DeviceFeature	m_feature	= null;
 		private Msg 			m_msg		= null;
+		private long			m_expirationTime = 0L;
 		public DeviceFeature getFeature() { return m_feature; }
 		public Msg getMsg() { return m_msg; }
-		QEntry(DeviceFeature f, Msg m) {
-			m_feature	= f;
-			m_msg		= m;
+		public long getExpirationTime() { return m_expirationTime; }
+		QEntry(DeviceFeature f, Msg m, long t) {
+			m_feature			= f;
+			m_msg				= m;
+			m_expirationTime	= t;
+		}
+		@Override
+		public int compareTo(QEntry a) {
+			return (int)(m_expirationTime - a.m_expirationTime);
 		}
 	}
 }

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
@@ -166,6 +166,7 @@ public abstract class MessageHandler {
 			m = new GroupMessageStateMachine();
 			m_groupState.put(new Integer(group), m);
 		}
+		logger.debug("updating group state for {} to {}", group, a);
 		return (m.action(a, hops));
 	}
 	
@@ -262,6 +263,8 @@ public abstract class MessageHandler {
 				logger.info("{}: device {} was switched on.", nm(),
 								f.getDevice().getAddress());
 				f.publish(OnOffType.ON, StateChangeType.ALWAYS);
+			} else {
+				logger.debug("ignored message: {} or {}", isDuplicate(msg), isMybutton(msg,f));
 			}
 		}
 	}
@@ -509,16 +512,20 @@ public abstract class MessageHandler {
 				DeviceFeature f, String fromPort) {
 			if (msg.isExtended()) {
 				try {
+					// see iMeter developer notes 2423A1dev-072013-en.pdf
 					int b7	= msg.getByte("userData7")	& 0xff;
 					int b8	= msg.getByte("userData8")	& 0xff;
 					int watts = (b7 << 8) | b8;
+					if (watts > 32767) {
+						watts -= 65535;
+					}
 
 					int b9	= msg.getByte("userData9")	& 0xff;
 					int b10	= msg.getByte("userData10")	& 0xff;
 					int b11	= msg.getByte("userData11")	& 0xff;
 					int b12	= msg.getByte("userData12")	& 0xff;
 					BigDecimal kwh = BigDecimal.ZERO;
-					if (b9 != 0xff) {
+					if (b9 < 254) {
 						int e = (b9 << 24) | (b10 << 16) | (b11 << 8) | b12;
 						kwh = new BigDecimal(e * 65535.0 / (1000 * 60 * 60 * 60)).setScale(4, RoundingMode.HALF_UP);
 					}

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/Poller.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/Poller.java
@@ -21,7 +21,15 @@ import org.slf4j.LoggerFactory;
  * Between successive polls of a any device there is a quiet time of
  * at least MIN_MSEC_BETWEEN_POLLS. This avoids bunching up of poll messages
  * and keeps the network bandwidth open for other messages.
- *  
+ * 
+ * - An entry in the poll queue corresponds to a single device, i.e. each device should
+ *   have exactly one entry in the poll queue. That entry is created when startPolling()
+ *   is called, and then re-enqueued whenever it expires.  
+ * - When a device comes up for polling, its doPoll() method is called, which in turn
+ *   puts an entry into that devices request queue. So the Poller class actually never
+ *   sends out messages directly. That is done by the device itself via its request
+ *   queue. The poller just reminds the device to poll.
+ *    
  * @author Bernd Pfrommer
  * @since 1.5.0
  */
@@ -104,6 +112,13 @@ public class Poller {
 			logger.debug("got interrupted on exit: {}", e.getMessage());
 		}
 	}
+	/**
+	 * Adds a device to the poll queue. After this call, the device's doPoll() method
+	 * will be called according to the polling frequency set.
+	 * @param d the device to poll periodically
+	 * @param time the target time for the next poll to happen. Note that this time is merely
+	 * a suggestion, and may be adjusted, because there must be at least a minimum gap in polling.
+	 */
 	
 	private void addToPollQueue(InsteonDevice d, long time) {
 		long texp = findNextExpirationTime(d, time);
@@ -111,6 +126,15 @@ public class Poller {
 		logger.trace("added entry {} originally aimed at time {}", ne, String.format("%tc", new Date(time)));
 		m_pollQueue.add(ne);
 	}
+	/**
+	 * Finds the best expiration time for a poll queue, i.e. a time slot that is after the
+	 * desired expiration time, but does not collide with any of the already scheduled
+	 * polls.
+	 *
+	 * @param d		device to poll (for logging)
+	 * @param aTime desired time after which the device should be polled
+	 * @return the suggested time to poll
+	 */
 	
 	private long findNextExpirationTime(InsteonDevice d, long aTime) {
 		long expTime = aTime;
@@ -162,6 +186,11 @@ public class Poller {
 			logger.debug("poll thread exiting");
 		}
 
+		/**
+		 * Waits for first element of poll queue to become current,
+		 * then process it.
+		 * @throws InterruptedException
+		 */
 		private void readPollQueue() throws InterruptedException {
 			while (m_pollQueue.isEmpty() && m_keepRunning) {
 				m_pollQueue.wait();
@@ -182,14 +211,23 @@ public class Poller {
 				processQueue(now);
 			}
 		}
-		
+		/**
+		 * Takes first element off the poll queue, polls the corresponding device,
+		 * and puts the device back into the poll queue to be polled again later.
+		 * @param now the current time 
+		 */
 		private void processQueue(long now) {
 			PQEntry pqe = m_pollQueue.pollFirst();
-			pqe.getDevice().doPoll();
+			pqe.getDevice().doPoll(0);
 			addToPollQueue(pqe.getDevice(), now + pqe.getDevice().getPollInterval());
 		}
 	}
-	
+	/**
+	 * A poll queue entry corresponds to a single device that needs
+	 * to be polled.
+	 * @author Bernd Pfrommer
+	 *
+	 */
 	private static class PQEntry implements Comparable<PQEntry> {
 		private InsteonDevice	m_dev = null;
 		private long			m_expirationTime = 0L;
@@ -212,7 +250,10 @@ public class Poller {
 			return m_dev.getAddress().toString() + "/" + String.format("%tc", new Date(m_expirationTime));
 		}
 	}
-	
+	/**
+	 * Singleton pattern instance() method
+	 * @return the poller instance
+	 */
 	public static synchronized Poller s_instance() {
 		if (s_poller == null) {
 			s_poller = new Poller();

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/SerialIOStream.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/SerialIOStream.java
@@ -45,7 +45,11 @@ public class SerialIOStream extends IOStream {
 			 * /dev/ttyUSB*, and will so not find symlinks. The
 			 *  setProperty() call below helps 
 			 */
-			System.setProperty("gnu.io.rxtx.SerialPorts", m_devName);
+			String ports = System.getProperty("gnu.io.rxtx.SerialPorts");
+			String sp = ((ports == null) ? "" : (ports + ":")) + m_devName;
+			// note: calling setProperty() is not threadsafe, in particular if
+			// multiple bindings use the serial port
+			System.setProperty("gnu.io.rxtx.SerialPorts", sp);
 			CommPortIdentifier ci =
 					CommPortIdentifier.getPortIdentifier(m_devName);
 			CommPort cp = ci.open(m_appName, 1000);

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/message/Msg.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/message/Msg.java
@@ -189,6 +189,10 @@ public class Msg {
 		return isOfType(MsgType.ACK_OF_DIRECT);
 	}
 	
+	public boolean isAllLinkCleanupAckOrNack() {
+		return isOfType(MsgType.ALL_LINK_CLEANUP_ACK) || isOfType(MsgType.ALL_LINK_CLEANUP_NACK);
+	}
+	
 	public boolean isX10() {
 		try {
 			int cmd = getByte("Cmd") & 0xff;

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
@@ -57,6 +57,10 @@
     <command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
     <poll-handler>DefaultPollHandler</poll-handler>
 </feature>
+<feature name="KeyPadButtonGroup">
+	<message-dispatcher>DefaultGroupDispatcher</message-dispatcher>
+	<poll-handler>LEDBitPollHandler</poll-handler>
+</feature>
 <feature name="KeyPadButton2">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
@@ -64,7 +68,6 @@
 	<message-handler cmd="0x13" button="2" group="2">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="2" group="2">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
-	<poll-handler>LEDBitPollHandler</poll-handler>
 </feature>
 <feature name="KeyPadButton3">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
@@ -73,7 +76,6 @@
 	<message-handler cmd="0x13" button="3" group="3">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="3" group="3">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
-	<poll-handler>LEDBitPollHandler</poll-handler>
 </feature>
 <feature name="KeyPadButton4">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
@@ -82,7 +84,6 @@
 	<message-handler cmd="0x13" button="4" group="4">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="4" group="4">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
-	<poll-handler>LEDBitPollHandler</poll-handler>
 </feature>
 <feature name="KeyPadButton5">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
@@ -91,7 +92,6 @@
 	<message-handler cmd="0x13" button="5" group="5">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="5" group="5">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
-	<poll-handler>LEDBitPollHandler</poll-handler>
 </feature>
 <feature name="KeyPadButton6">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
@@ -100,7 +100,6 @@
 	<message-handler cmd="0x13" button="6" group="6">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="6" group="6">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
-	<poll-handler>LEDBitPollHandler</poll-handler>
 </feature>
 <feature name="KeyPadButton7">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
@@ -109,7 +108,6 @@
 	<message-handler cmd="0x13" button="7" group="7">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="7" group="7">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
-	<poll-handler>LEDBitPollHandler</poll-handler>
 </feature>
 <feature name="KeyPadButton8">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
@@ -118,7 +116,6 @@
 	<message-handler cmd="0x13" button="8" group="8">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="8" group="8">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>	
-	<poll-handler>LEDBitPollHandler</poll-handler>
 </feature>
 <feature name="GenericLastTime" statusFeature="true">
 	<message-dispatcher>PassThroughDispatcher</message-dispatcher>

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
@@ -242,10 +242,12 @@ Example entry:
      <model>2487S</model>
      <description>KeypadLinc On/Off 6-Button Scene Control </description>
      <feature name="loadswitch">LoadSwitchButton</feature>
-     <feature name="keypadbuttonA">KeyPadButton3</feature>
-     <feature name="keypadbuttonB">KeyPadButton4</feature>
-     <feature name="keypadbuttonC">KeyPadButton5</feature>
-     <feature name="keypadbuttonD">KeyPadButton6</feature>
+     <feature_group name="button_group" type="KeyPadButtonGroup">
+     	<feature name="keypadbuttonA">KeyPadButton3</feature>
+     	<feature name="keypadbuttonB">KeyPadButton4</feature>
+     	<feature name="keypadbuttonC">KeyPadButton5</feature>
+     	<feature name="keypadbuttonD">KeyPadButton6</feature>
+     </feature_group>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
  
@@ -253,10 +255,12 @@ Example entry:
      <model>2334-232</model>
      <description>Keypad Dimmer Switch, 6-Button </description>
      <feature name="loaddimmer">LoadDimmerButton</feature>
-     <feature name="keypadbuttonA">KeyPadButton3</feature>
-     <feature name="keypadbuttonB">KeyPadButton4</feature>
-     <feature name="keypadbuttonC">KeyPadButton5</feature>
-     <feature name="keypadbuttonD">KeyPadButton6</feature>
+     <feature_group name="button_group" type="KeyPadButtonGroup">
+     	<feature name="keypadbuttonA">KeyPadButton3</feature>
+     	<feature name="keypadbuttonB">KeyPadButton4</feature>
+     	<feature name="keypadbuttonC">KeyPadButton5</feature>
+     	<feature name="keypadbuttonD">KeyPadButton6</feature>
+     </feature_group>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 
@@ -264,13 +268,15 @@ Example entry:
      <model>2334-232</model>
      <description>Keypad Dimmer Switch, 8-Button </description>
      <feature name="loaddimmer">LoadDimmerButton</feature>
-     <feature name="keypadbuttonB">KeyPadButton2</feature>
-     <feature name="keypadbuttonC">KeyPadButton3</feature>
-     <feature name="keypadbuttonD">KeyPadButton4</feature>
-     <feature name="keypadbuttonE">KeyPadButton5</feature>
-     <feature name="keypadbuttonF">KeyPadButton6</feature>
-     <feature name="keypadbuttonG">KeyPadButton7</feature>
-     <feature name="keypadbuttonH">KeyPadButton8</feature>
+     <feature_group name="button_group" type="KeyPadButtonGroup">
+     	<feature name="keypadbuttonB">KeyPadButton2</feature>
+     	<feature name="keypadbuttonC">KeyPadButton3</feature>
+     	<feature name="keypadbuttonD">KeyPadButton4</feature>
+     	<feature name="keypadbuttonE">KeyPadButton5</feature>
+     	<feature name="keypadbuttonF">KeyPadButton6</feature>
+     	<feature name="keypadbuttonG">KeyPadButton7</feature>
+     	<feature name="keypadbuttonH">KeyPadButton8</feature>
+     </feature_group>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 


### PR DESCRIPTION
    - use ConcurrentHashMap to avoid synchronized() sections in InsteonPLMActiveBinding class

    - fixes for iMeter calculations

    - the concept of "related" devices is introduced. When a device
      changes its state, all related devices are polled as well. This is
      useful for 3-way switch configurations

    - a DeviceFeature can now act as a group of other
      DeviceFeatures. These feature groups allow for consolidated polling
      when one message can query multiple features' values at the same
      time.

    - added protecting synchronized statements around m_devices in
      InsteonPLM binding

    - added explicit expiration time to request queue entries to control
      message delay better