### PR TITLE
Update the HUE binding to work with non continuous device numbers on the...

### DIFF
--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBindingConfig.java
@@ -22,7 +22,9 @@ import org.slf4j.LoggerFactory;
  * 
  * <ul>
  * <li>The device number the bulb has on the Hue bridge. The bulbs should have
- * numbers from 1 up to the number of connected bulbs.</li>
+ * numbers from 1 up to the number of connected bulbs.
+ * (Since the option to delete items on the bridge the assumption of continuous sequence 
+ * of item numbers is no longer correct, but this is now handled in HueBinding execute correctly)</li>
  * <li>The binding type of the hue item</li>
  * <ul>
  * <li>Switch</li>

--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java
@@ -9,6 +9,7 @@
 package org.openhab.binding.hue.internal.data;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
@@ -56,6 +57,19 @@ public class HueSettings {
 	}
 
 	/**
+	 * Return the keys of lights connected to Hue hub
+	 * 
+	 * @return the keys of lights connected to Hue hub
+	 */
+	public Set<String> getKeys() {
+		if (settingsData == null) {
+			logger.error("Hue bridge settings not initialized correctly.");
+			return null;
+		}
+		return settingsData.node("lights").getKeys();
+	}
+	
+	/**
 	 * Determines whether the given bulb is turned on.
 	 * 
 	 * @param deviceNumber
@@ -90,20 +104,6 @@ public class HueSettings {
 				.node(Integer.toString(deviceNumber)).node("state").value("reachable");
 	}
 	
-	
-	/**
-	 * Determine amount of lights connected to Hue hub
-	 * 
-	 * @return amount of lights connected to Hue hub
-	 */
-	public int getCount() {
-		if (settingsData == null) {
-			logger.error("Hue bridge settings not initialized correctly.");
-			return -1;
-		}
-		return settingsData.node("lights").count();
-	}
-
 	/**
 	 * Determines the color temperature of the given bulb.
 	 * 
@@ -223,6 +223,10 @@ public class HueSettings {
 			return dataMap.size();
 		}
 
+		protected Set<String> getKeys(){
+			return dataMap.keySet();
+		}
+		
 		/**
 		 * @param valueName
 		 *            The name of the child node.

--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBulb.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBulb.java
@@ -48,19 +48,37 @@ public class HueBulb {
 
 	private Client client;
 
+    /**
+     * Constructor for the HueBulb.
+     *
+     * This constructor fetches the current settings for the bulb from the bridge
+     *
+     * @param connectedBridge
+     *            The bridge the bulb is connected to.
+     * @param deviceNumber
+     *            The number under which the bulb is filed in the bridge.
+     */
+	public HueBulb(HueBridge connectedBridge, int deviceNumber) {
+		this(connectedBridge, deviceNumber, connectedBridge.getSettings());
+	}
+	
 	/**
 	 * Constructor for the HueBulb.
+     *
+     * This constructor reuses already fetched settings to reduce the load of creating a bulb.
 	 * 
 	 * @param connectedBridge
 	 *            The bridge the bulb is connected to.
-	 * @param deviceNumber
-	 *            The number under which the bulb is filed in the bridge.
+     * @param deviceNumber
+     *            The number under which the bulb is filed in the bridge.
+     * @param settings
+     *            The settings data from the bridge.
 	 */
-	public HueBulb(HueBridge connectedBridge, int deviceNumber) {
+	public HueBulb(HueBridge connectedBridge, int deviceNumber, HueSettings settings) {
 		this.bridge = connectedBridge;
 		this.deviceNumber = deviceNumber;
-		getStatus(this.bridge.getSettings());
-
+		getStatus(settings);
+        
 		this.client = Client.create();
 		this.client.setReadTimeout(1000);
 		this.client.setConnectTimeout(2000);
@@ -259,6 +277,7 @@ public class HueBulb {
 	private void executeMessage(String message) {
 		String targetURL = bridge.getUrl() + "lights/" + deviceNumber + "/state";
 		WebResource webResource = client.resource(targetURL);
+
 		ClientResponse response = webResource.type("application/json").put(
 				ClientResponse.class, message);
 


### PR DESCRIPTION
... bridge (and speed up the initial loading)

Due the new option to delete bulb on the Hue bridge the old assumption
of continuous device numbers is no longer true. The for loop in
HueBinding.java crashed with a NPE if it hits a deleted bulb.

The second fix in the update is a speed up of updates/initial reads by
removing multiple call to the settings on the bridge. The code now
fetches the settings once per refresh from the bridge and hands the
settings over the the bulb construction.

This fixes the 
issue #2504 and 
issue #2505 