### PR TITLE
TF binding: Fix for configuration handling of device aliases

### DIFF
--- a/bundles/binding/org.openhab.binding.tinkerforge/model/tinkerforge.xcore
+++ b/bundles/binding/org.openhab.binding.tinkerforge/model/tinkerforge.xcore
@@ -371,7 +371,7 @@ class MIndustrialQuadRelayBricklet extends
 
 class MIndustrialQuadRelay extends MInSwitchActor, 
 				MSubDevice<MIndustrialQuadRelayBricklet>{
-	readonly String deviceType = "industrial_quad_relay"
+	readonly String deviceType = "quad_relay"
 }
 
 class MBrickletIndustrialDigitalIn4 extends 
@@ -383,15 +383,19 @@ class MBrickletIndustrialDigitalIn4 extends
 
 class MIndustrialDigitalIn extends MSubDevice<MBrickletIndustrialDigitalIn4>, 
 		MSensor<DigitalValue> {
+	readonly String deviceType = "digital_4in"
 }
 
 class MBrickletIndustrialDigitalOut4 extends MDevice<MTinkerBrickletIndustrialDigitalOut4>,
         MSubDeviceHolder<DigitalActorDigitalOut4>{
+	readonly String deviceType = "bricklet_industrial_digital_4out"
 }
 
 class DigitalActorDigitalOut4 extends DigitalActor, MSubDevice<MBrickletIndustrialDigitalOut4> {
     int pin
+    readonly String deviceType = "digital_4out"
 }
+
 
 class MBrickletSegmentDisplay4x7 extends NumberActor, MDevice<TinkerBrickletSegmentDisplay4x7>{
     readonly String deviceType = "bricklet_segmentdisplay4x7"
@@ -886,6 +890,10 @@ enum NoSubIds {
 
 enum IndustrialDigitalInSubIDs {
 	IN0, IN1, IN2,IN3
+}
+
+enum IndustrialDigitalOutSubIDs {
+	OUT0, OUT1, OUT2, OUT3
 }
 
 enum IndustrialQuadRelayIDs {

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/config/ConfigurationHandler.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/config/ConfigurationHandler.java
@@ -32,10 +32,14 @@ import org.openhab.binding.tinkerforge.internal.model.ButtonConfiguration;
 import org.openhab.binding.tinkerforge.internal.model.DualButtonButtonSubIds;
 import org.openhab.binding.tinkerforge.internal.model.DualButtonLEDConfiguration;
 import org.openhab.binding.tinkerforge.internal.model.DualButtonLedSubIds;
+import org.openhab.binding.tinkerforge.internal.model.DualRelaySubIds;
 import org.openhab.binding.tinkerforge.internal.model.Ecosystem;
 import org.openhab.binding.tinkerforge.internal.model.IO16SubIds;
 import org.openhab.binding.tinkerforge.internal.model.IO4SubIds;
+import org.openhab.binding.tinkerforge.internal.model.IndustrialDigitalInSubIDs;
+import org.openhab.binding.tinkerforge.internal.model.IndustrialDigitalOutSubIDs;
 import org.openhab.binding.tinkerforge.internal.model.IndustrialDual020mASubIds;
+import org.openhab.binding.tinkerforge.internal.model.IndustrialQuadRelayIDs;
 import org.openhab.binding.tinkerforge.internal.model.JoystickSubIds;
 import org.openhab.binding.tinkerforge.internal.model.LCDButtonSubIds;
 import org.openhab.binding.tinkerforge.internal.model.LEDGroupConfiguration;
@@ -104,9 +108,11 @@ public class ConfigurationHandler {
     bricklet_moisture, bricklet_distanceUS, bricklet_voltageCurrent, 
     voltageCurrent_voltage, voltageCurrent_current, voltageCurrent_power, bricklet_tilt, 
     io4_actuator, io4sensor, bricklet_io4, bricklet_halleffect, bricklet_joystick, 
-    joystick_button, bricklet_linear_poti, dualbutton_button, dualbutton_led, lcd_button, 
+    joystick_button, joystick_xposition, joystick_yposition,
+    bricklet_linear_poti, dualbutton_button, dualbutton_led, lcd_button, 
     bricklet_ledstrip, ledgroup, bricklet_ptc, ptc_temperature, ptc_resistance, 
-    industrial020ma_sensor, bricklet_industrialdual020ma
+    industrial020ma_sensor, bricklet_industrialdual020ma, dual_relay, quad_relay,
+    digital_4in, digital_4out
   }
 
 
@@ -477,6 +483,47 @@ public class ConfigurationHandler {
           modelFactory.createOHTFDevice();
       ohtfDevice.getSubDeviceIds().addAll(Arrays.asList(IndustrialDual020mASubIds.values()));
       ohtfDevice.setTfConfig(configuration);
+      fillupConfig(ohtfDevice, deviceConfig);
+    } else if (deviceType.equals(TypeKey.dual_relay.name())) {
+      logger.debug("{} setting no tfConfig device_type {}", LoggerConstants.CONFIG, deviceType);
+      logger.debug("{} setting subdevice ids to {}", LoggerConstants.CONFIG,
+          DualRelaySubIds.values());
+      logger.trace("{} deviceType {}", LoggerConstants.CONFIG, deviceType);
+      OHTFDevice<?, DualRelaySubIds> ohtfDevice = modelFactory.createOHTFDevice();
+      ohtfDevice.getSubDeviceIds().addAll(Arrays.asList(DualRelaySubIds.values()));
+      fillupConfig(ohtfDevice, deviceConfig);
+    } else if (deviceType.equals(TypeKey.quad_relay.name())) {
+      logger.debug("{} setting no tfConfig device_type {}", LoggerConstants.CONFIG, deviceType);
+      logger.debug("{} setting subdevice ids to {}", LoggerConstants.CONFIG,
+          IndustrialQuadRelayIDs.values());
+      logger.trace("{} deviceType {}", LoggerConstants.CONFIG, deviceType);
+      OHTFDevice<?, IndustrialQuadRelayIDs> ohtfDevice = modelFactory.createOHTFDevice();
+      ohtfDevice.getSubDeviceIds().addAll(Arrays.asList(IndustrialQuadRelayIDs.values()));
+      fillupConfig(ohtfDevice, deviceConfig);
+    } else if (deviceType.equals(TypeKey.joystick_xposition.name())
+        || deviceType.equals(TypeKey.joystick_yposition.name())) {
+      logger.debug("{} setting no tfConfig device_type {}", LoggerConstants.CONFIG, deviceType);
+      logger.debug("{} setting subdevice ids to {}", LoggerConstants.CONFIG,
+          JoystickSubIds.values());
+      logger.trace("{} deviceType {}", LoggerConstants.CONFIG, deviceType);
+      OHTFDevice<?, JoystickSubIds> ohtfDevice = modelFactory.createOHTFDevice();
+      ohtfDevice.getSubDeviceIds().addAll(Arrays.asList(JoystickSubIds.values()));
+      fillupConfig(ohtfDevice, deviceConfig);
+    } else if (deviceType.equals(TypeKey.digital_4in.name())) {
+      logger.debug("{} setting no tfConfig device_type {}", LoggerConstants.CONFIG, deviceType);
+      logger.debug("{} setting subdevice ids to {}", LoggerConstants.CONFIG,
+          IndustrialDigitalInSubIDs.values());
+      logger.trace("{} deviceType {}", LoggerConstants.CONFIG, deviceType);
+      OHTFDevice<?, IndustrialDigitalInSubIDs> ohtfDevice = modelFactory.createOHTFDevice();
+      ohtfDevice.getSubDeviceIds().addAll(Arrays.asList(IndustrialDigitalInSubIDs.values()));
+      fillupConfig(ohtfDevice, deviceConfig);
+    } else if (deviceType.equals(TypeKey.digital_4out.name())) {
+      logger.debug("{} setting no tfConfig device_type {}", LoggerConstants.CONFIG, deviceType);
+      logger.debug("{} setting subdevice ids to {}", LoggerConstants.CONFIG,
+          IndustrialDigitalOutSubIDs.values());
+      logger.trace("{} deviceType {}", LoggerConstants.CONFIG, deviceType);
+      OHTFDevice<?, IndustrialDigitalOutSubIDs> ohtfDevice = modelFactory.createOHTFDevice();
+      ohtfDevice.getSubDeviceIds().addAll(Arrays.asList(IndustrialDigitalOutSubIDs.values()));
       fillupConfig(ohtfDevice, deviceConfig);
     } else {
       logger.debug("{} setting no tfConfig device_type {}", LoggerConstants.CONFIG, deviceType);

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/DigitalActorDigitalOut4.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/DigitalActorDigitalOut4.java
@@ -21,6 +21,7 @@ package org.openhab.binding.tinkerforge.internal.model;
  * The following features are supported:
  * <ul>
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.DigitalActorDigitalOut4#getPin <em>Pin</em>}</li>
+ *   <li>{@link org.openhab.binding.tinkerforge.internal.model.DigitalActorDigitalOut4#getDeviceType <em>Device Type</em>}</li>
  * </ul>
  * </p>
  *
@@ -56,4 +57,20 @@ public interface DigitalActorDigitalOut4 extends DigitalActor, MSubDevice<MBrick
    * @generated
    */
   void setPin(int value);
+
+  /**
+   * Returns the value of the '<em><b>Device Type</b></em>' attribute.
+   * The default value is <code>"digital_4out"</code>.
+   * <!-- begin-user-doc -->
+   * <p>
+   * If the meaning of the '<em>Device Type</em>' attribute isn't clear,
+   * there really should be more of a description here...
+   * </p>
+   * <!-- end-user-doc -->
+   * @return the value of the '<em>Device Type</em>' attribute.
+   * @see org.openhab.binding.tinkerforge.internal.model.ModelPackage#getDigitalActorDigitalOut4_DeviceType()
+   * @model default="digital_4out" unique="false" changeable="false"
+   * @generated
+   */
+  String getDeviceType();
 } // DigitalActorDigitalOut4

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/IndustrialDigitalOutSubIDs.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/IndustrialDigitalOutSubIDs.java
@@ -1,0 +1,274 @@
+/**
+ */
+package org.openhab.binding.tinkerforge.internal.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.emf.common.util.Enumerator;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the literals of the enumeration '<em><b>Industrial Digital Out Sub IDs</b></em>',
+ * and utility methods for working with them.
+ * <!-- end-user-doc -->
+ * @see org.openhab.binding.tinkerforge.internal.model.ModelPackage#getIndustrialDigitalOutSubIDs()
+ * @model
+ * @generated
+ */
+public enum IndustrialDigitalOutSubIDs implements Enumerator
+{
+  /**
+   * The '<em><b>OUT0</b></em>' literal object.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #OUT0_VALUE
+   * @generated
+   * @ordered
+   */
+  OUT0(0, "OUT0", "OUT0"),
+
+  /**
+   * The '<em><b>OUT1</b></em>' literal object.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #OUT1_VALUE
+   * @generated
+   * @ordered
+   */
+  OUT1(0, "OUT1", "OUT1"),
+
+  /**
+   * The '<em><b>OUT2</b></em>' literal object.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #OUT2_VALUE
+   * @generated
+   * @ordered
+   */
+  OUT2(0, "OUT2", "OUT2"),
+
+  /**
+   * The '<em><b>OUT3</b></em>' literal object.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #OUT3_VALUE
+   * @generated
+   * @ordered
+   */
+  OUT3(0, "OUT3", "OUT3");
+
+  /**
+   * The '<em><b>OUT0</b></em>' literal value.
+   * <!-- begin-user-doc -->
+   * <p>
+   * If the meaning of '<em><b>OUT0</b></em>' literal object isn't clear,
+   * there really should be more of a description here...
+   * </p>
+   * <!-- end-user-doc -->
+   * @see #OUT0
+   * @model
+   * @generated
+   * @ordered
+   */
+  public static final int OUT0_VALUE = 0;
+
+  /**
+   * The '<em><b>OUT1</b></em>' literal value.
+   * <!-- begin-user-doc -->
+   * <p>
+   * If the meaning of '<em><b>OUT1</b></em>' literal object isn't clear,
+   * there really should be more of a description here...
+   * </p>
+   * <!-- end-user-doc -->
+   * @see #OUT1
+   * @model
+   * @generated
+   * @ordered
+   */
+  public static final int OUT1_VALUE = 0;
+
+  /**
+   * The '<em><b>OUT2</b></em>' literal value.
+   * <!-- begin-user-doc -->
+   * <p>
+   * If the meaning of '<em><b>OUT2</b></em>' literal object isn't clear,
+   * there really should be more of a description here...
+   * </p>
+   * <!-- end-user-doc -->
+   * @see #OUT2
+   * @model
+   * @generated
+   * @ordered
+   */
+  public static final int OUT2_VALUE = 0;
+
+  /**
+   * The '<em><b>OUT3</b></em>' literal value.
+   * <!-- begin-user-doc -->
+   * <p>
+   * If the meaning of '<em><b>OUT3</b></em>' literal object isn't clear,
+   * there really should be more of a description here...
+   * </p>
+   * <!-- end-user-doc -->
+   * @see #OUT3
+   * @model
+   * @generated
+   * @ordered
+   */
+  public static final int OUT3_VALUE = 0;
+
+  /**
+   * An array of all the '<em><b>Industrial Digital Out Sub IDs</b></em>' enumerators.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  private static final IndustrialDigitalOutSubIDs[] VALUES_ARRAY =
+    new IndustrialDigitalOutSubIDs[]
+    {
+      OUT0,
+      OUT1,
+      OUT2,
+      OUT3,
+    };
+
+  /**
+   * A public read-only list of all the '<em><b>Industrial Digital Out Sub IDs</b></em>' enumerators.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public static final List<IndustrialDigitalOutSubIDs> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
+
+  /**
+   * Returns the '<em><b>Industrial Digital Out Sub IDs</b></em>' literal with the specified literal value.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public static IndustrialDigitalOutSubIDs get(String literal)
+  {
+    for (int i = 0; i < VALUES_ARRAY.length; ++i)
+    {
+      IndustrialDigitalOutSubIDs result = VALUES_ARRAY[i];
+      if (result.toString().equals(literal))
+      {
+        return result;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns the '<em><b>Industrial Digital Out Sub IDs</b></em>' literal with the specified name.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public static IndustrialDigitalOutSubIDs getByName(String name)
+  {
+    for (int i = 0; i < VALUES_ARRAY.length; ++i)
+    {
+      IndustrialDigitalOutSubIDs result = VALUES_ARRAY[i];
+      if (result.getName().equals(name))
+      {
+        return result;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns the '<em><b>Industrial Digital Out Sub IDs</b></em>' literal with the specified integer value.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public static IndustrialDigitalOutSubIDs get(int value)
+  {
+    switch (value)
+    {
+      case OUT0_VALUE: return OUT0;
+    }
+    return null;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  private final int value;
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  private final String name;
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  private final String literal;
+
+  /**
+   * Only this class can construct instances.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  private IndustrialDigitalOutSubIDs(int value, String name, String literal)
+  {
+    this.value = value;
+    this.name = name;
+    this.literal = literal;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public int getValue()
+  {
+    return value;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public String getName()
+  {
+    return name;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public String getLiteral()
+  {
+    return literal;
+  }
+
+  /**
+   * Returns the literal value of the enumerator, which is its string representation.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  @Override
+  public String toString()
+  {
+    return literal;
+  }
+  
+} //IndustrialDigitalOutSubIDs

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/MBrickletIndustrialDigitalOut4.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/MBrickletIndustrialDigitalOut4.java
@@ -18,6 +18,12 @@ import com.tinkerforge.BrickletIndustrialDigitalOut4;
  * @since 1.5.0
  * <!-- end-user-doc -->
  *
+ * <p>
+ * The following features are supported:
+ * <ul>
+ *   <li>{@link org.openhab.binding.tinkerforge.internal.model.MBrickletIndustrialDigitalOut4#getDeviceType <em>Device Type</em>}</li>
+ * </ul>
+ * </p>
  *
  * @see org.openhab.binding.tinkerforge.internal.model.ModelPackage#getMBrickletIndustrialDigitalOut4()
  * @model superTypes="org.openhab.binding.tinkerforge.internal.model.MDevice<org.openhab.binding.tinkerforge.internal.model.MTinkerBrickletIndustrialDigitalOut4> org.openhab.binding.tinkerforge.internal.model.MSubDeviceHolder<org.openhab.binding.tinkerforge.internal.model.DigitalActorDigitalOut4>"
@@ -25,4 +31,20 @@ import com.tinkerforge.BrickletIndustrialDigitalOut4;
  */
 public interface MBrickletIndustrialDigitalOut4 extends MDevice<BrickletIndustrialDigitalOut4>, MSubDeviceHolder<DigitalActorDigitalOut4>
 {
+
+  /**
+   * Returns the value of the '<em><b>Device Type</b></em>' attribute.
+   * The default value is <code>"bricklet_industrial_digital_4out"</code>.
+   * <!-- begin-user-doc -->
+   * <p>
+   * If the meaning of the '<em>Device Type</em>' attribute isn't clear,
+   * there really should be more of a description here...
+   * </p>
+   * <!-- end-user-doc -->
+   * @return the value of the '<em>Device Type</em>' attribute.
+   * @see org.openhab.binding.tinkerforge.internal.model.ModelPackage#getMBrickletIndustrialDigitalOut4_DeviceType()
+   * @model default="bricklet_industrial_digital_4out" unique="false" changeable="false"
+   * @generated
+   */
+  String getDeviceType();
 } // MBrickletIndustrialDigitalOut4

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/MIndustrialDigitalIn.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/MIndustrialDigitalIn.java
@@ -19,6 +19,12 @@ import org.openhab.binding.tinkerforge.internal.types.HighLowValue;
  * @since 1.5.0
  * <!-- end-user-doc -->
  *
+ * <p>
+ * The following features are supported:
+ * <ul>
+ *   <li>{@link org.openhab.binding.tinkerforge.internal.model.MIndustrialDigitalIn#getDeviceType <em>Device Type</em>}</li>
+ * </ul>
+ * </p>
  *
  * @see org.openhab.binding.tinkerforge.internal.model.ModelPackage#getMIndustrialDigitalIn()
  * @model superTypes="org.openhab.binding.tinkerforge.internal.model.MSubDevice<org.openhab.binding.tinkerforge.internal.model.MBrickletIndustrialDigitalIn4> org.openhab.binding.tinkerforge.internal.model.MSensor<org.openhab.binding.tinkerforge.internal.model.DigitalValue>"
@@ -26,4 +32,20 @@ import org.openhab.binding.tinkerforge.internal.types.HighLowValue;
  */
 public interface MIndustrialDigitalIn extends MSubDevice<MBrickletIndustrialDigitalIn4>, MSensor<HighLowValue>
 {
+
+  /**
+   * Returns the value of the '<em><b>Device Type</b></em>' attribute.
+   * The default value is <code>"digital_4in"</code>.
+   * <!-- begin-user-doc -->
+   * <p>
+   * If the meaning of the '<em>Device Type</em>' attribute isn't clear,
+   * there really should be more of a description here...
+   * </p>
+   * <!-- end-user-doc -->
+   * @return the value of the '<em>Device Type</em>' attribute.
+   * @see org.openhab.binding.tinkerforge.internal.model.ModelPackage#getMIndustrialDigitalIn_DeviceType()
+   * @model default="digital_4in" unique="false" changeable="false"
+   * @generated
+   */
+  String getDeviceType();
 } // MIndustrialDigitalIn

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/MIndustrialQuadRelay.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/MIndustrialQuadRelay.java
@@ -32,7 +32,7 @@ public interface MIndustrialQuadRelay extends MInSwitchActor, MSubDevice<MIndust
 {
   /**
    * Returns the value of the '<em><b>Device Type</b></em>' attribute.
-   * The default value is <code>"industrial_quad_relay"</code>.
+   * The default value is <code>"quad_relay"</code>.
    * <!-- begin-user-doc -->
    * <p>
    * If the meaning of the '<em>Device Type</em>' attribute isn't clear,
@@ -41,7 +41,7 @@ public interface MIndustrialQuadRelay extends MInSwitchActor, MSubDevice<MIndust
    * <!-- end-user-doc -->
    * @return the value of the '<em>Device Type</em>' attribute.
    * @see org.openhab.binding.tinkerforge.internal.model.ModelPackage#getMIndustrialQuadRelay_DeviceType()
-   * @model default="industrial_quad_relay" unique="false" changeable="false"
+   * @model default="quad_relay" unique="false" changeable="false"
    * @generated
    */
   String getDeviceType();

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/ModelPackage.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/ModelPackage.java
@@ -5398,13 +5398,22 @@ public interface ModelPackage extends EPackage
   int MINDUSTRIAL_DIGITAL_IN__SENSOR_VALUE = MSUB_DEVICE_FEATURE_COUNT + 0;
 
   /**
+   * The feature id for the '<em><b>Device Type</b></em>' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int MINDUSTRIAL_DIGITAL_IN__DEVICE_TYPE = MSUB_DEVICE_FEATURE_COUNT + 1;
+
+  /**
    * The number of structural features of the '<em>MIndustrial Digital In</em>' class.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
    * @generated
    * @ordered
    */
-  int MINDUSTRIAL_DIGITAL_IN_FEATURE_COUNT = MSUB_DEVICE_FEATURE_COUNT + 1;
+  int MINDUSTRIAL_DIGITAL_IN_FEATURE_COUNT = MSUB_DEVICE_FEATURE_COUNT + 2;
 
   /**
    * The operation id for the '<em>Init</em>' operation.
@@ -5560,13 +5569,22 @@ public interface ModelPackage extends EPackage
   int MBRICKLET_INDUSTRIAL_DIGITAL_OUT4__MSUBDEVICES = MDEVICE_FEATURE_COUNT + 0;
 
   /**
+   * The feature id for the '<em><b>Device Type</b></em>' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int MBRICKLET_INDUSTRIAL_DIGITAL_OUT4__DEVICE_TYPE = MDEVICE_FEATURE_COUNT + 1;
+
+  /**
    * The number of structural features of the '<em>MBricklet Industrial Digital Out4</em>' class.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
    * @generated
    * @ordered
    */
-  int MBRICKLET_INDUSTRIAL_DIGITAL_OUT4_FEATURE_COUNT = MDEVICE_FEATURE_COUNT + 1;
+  int MBRICKLET_INDUSTRIAL_DIGITAL_OUT4_FEATURE_COUNT = MDEVICE_FEATURE_COUNT + 2;
 
   /**
    * The operation id for the '<em>Init</em>' operation.
@@ -5686,13 +5704,22 @@ public interface ModelPackage extends EPackage
   int DIGITAL_ACTOR_DIGITAL_OUT4__PIN = DIGITAL_ACTOR_FEATURE_COUNT + 6;
 
   /**
+   * The feature id for the '<em><b>Device Type</b></em>' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int DIGITAL_ACTOR_DIGITAL_OUT4__DEVICE_TYPE = DIGITAL_ACTOR_FEATURE_COUNT + 7;
+
+  /**
    * The number of structural features of the '<em>Digital Actor Digital Out4</em>' class.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
    * @generated
    * @ordered
    */
-  int DIGITAL_ACTOR_DIGITAL_OUT4_FEATURE_COUNT = DIGITAL_ACTOR_FEATURE_COUNT + 7;
+  int DIGITAL_ACTOR_DIGITAL_OUT4_FEATURE_COUNT = DIGITAL_ACTOR_FEATURE_COUNT + 8;
 
   /**
    * The operation id for the '<em>Turn Digital</em>' operation.
@@ -16425,7 +16452,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getSwitchState()
    * @generated
    */
-  int SWITCH_STATE = 163;
+  int SWITCH_STATE = 164;
 
   /**
    * The meta object id for the '<em>Digital Value</em>' data type.
@@ -16435,7 +16462,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDigitalValue()
    * @generated
    */
-  int DIGITAL_VALUE = 164;
+  int DIGITAL_VALUE = 165;
 
   /**
    * The meta object id for the '<em>HSB Value</em>' data type.
@@ -16445,7 +16472,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getHSBValue()
    * @generated
    */
-  int HSB_VALUE = 165;
+  int HSB_VALUE = 166;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet IO16</em>' data type.
@@ -16455,7 +16482,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletIO16()
    * @generated
    */
-  int TINKER_BRICKLET_IO16 = 166;
+  int TINKER_BRICKLET_IO16 = 167;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.DCDriveMode <em>DC Drive Mode</em>}' enum.
@@ -16465,7 +16492,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDCDriveMode()
    * @generated
    */
-  int DC_DRIVE_MODE = 145;
+  int DC_DRIVE_MODE = 146;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.ConfigOptsServo <em>Config Opts Servo</em>}' enum.
@@ -16475,7 +16502,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getConfigOptsServo()
    * @generated
    */
-  int CONFIG_OPTS_SERVO = 146;
+  int CONFIG_OPTS_SERVO = 147;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.DualButtonDevicePosition <em>Dual Button Device Position</em>}' enum.
@@ -16485,7 +16512,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDualButtonDevicePosition()
    * @generated
    */
-  int DUAL_BUTTON_DEVICE_POSITION = 147;
+  int DUAL_BUTTON_DEVICE_POSITION = 148;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.DualButtonLedSubIds <em>Dual Button Led Sub Ids</em>}' enum.
@@ -16495,7 +16522,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDualButtonLedSubIds()
    * @generated
    */
-  int DUAL_BUTTON_LED_SUB_IDS = 148;
+  int DUAL_BUTTON_LED_SUB_IDS = 149;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.DualButtonButtonSubIds <em>Dual Button Button Sub Ids</em>}' enum.
@@ -16505,7 +16532,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDualButtonButtonSubIds()
    * @generated
    */
-  int DUAL_BUTTON_BUTTON_SUB_IDS = 149;
+  int DUAL_BUTTON_BUTTON_SUB_IDS = 150;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.JoystickSubIds <em>Joystick Sub Ids</em>}' enum.
@@ -16515,7 +16542,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getJoystickSubIds()
    * @generated
    */
-  int JOYSTICK_SUB_IDS = 150;
+  int JOYSTICK_SUB_IDS = 151;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.PTCSubIds <em>PTC Sub Ids</em>}' enum.
@@ -16525,7 +16552,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getPTCSubIds()
    * @generated
    */
-  int PTC_SUB_IDS = 151;
+  int PTC_SUB_IDS = 152;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.IndustrialDual020mASubIds <em>Industrial Dual020m ASub Ids</em>}' enum.
@@ -16535,7 +16562,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getIndustrialDual020mASubIds()
    * @generated
    */
-  int INDUSTRIAL_DUAL020M_ASUB_IDS = 152;
+  int INDUSTRIAL_DUAL020M_ASUB_IDS = 153;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.NoSubIds <em>No Sub Ids</em>}' enum.
@@ -16558,6 +16585,16 @@ public interface ModelPackage extends EPackage
   int INDUSTRIAL_DIGITAL_IN_SUB_IDS = 129;
 
   /**
+   * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.IndustrialDigitalOutSubIDs <em>Industrial Digital Out Sub IDs</em>}' enum.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see org.openhab.binding.tinkerforge.internal.model.IndustrialDigitalOutSubIDs
+   * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getIndustrialDigitalOutSubIDs()
+   * @generated
+   */
+  int INDUSTRIAL_DIGITAL_OUT_SUB_IDS = 130;
+
+  /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.IndustrialQuadRelayIDs <em>Industrial Quad Relay IDs</em>}' enum.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
@@ -16565,7 +16602,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getIndustrialQuadRelayIDs()
    * @generated
    */
-  int INDUSTRIAL_QUAD_RELAY_IDS = 130;
+  int INDUSTRIAL_QUAD_RELAY_IDS = 131;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.ServoSubIDs <em>Servo Sub IDs</em>}' enum.
@@ -16575,7 +16612,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getServoSubIDs()
    * @generated
    */
-  int SERVO_SUB_IDS = 131;
+  int SERVO_SUB_IDS = 132;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.BarometerSubIDs <em>Barometer Sub IDs</em>}' enum.
@@ -16585,7 +16622,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getBarometerSubIDs()
    * @generated
    */
-  int BAROMETER_SUB_IDS = 132;
+  int BAROMETER_SUB_IDS = 133;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.IO16SubIds <em>IO16 Sub Ids</em>}' enum.
@@ -16595,7 +16632,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getIO16SubIds()
    * @generated
    */
-  int IO16_SUB_IDS = 133;
+  int IO16_SUB_IDS = 134;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.IO4SubIds <em>IO4 Sub Ids</em>}' enum.
@@ -16605,7 +16642,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getIO4SubIds()
    * @generated
    */
-  int IO4_SUB_IDS = 134;
+  int IO4_SUB_IDS = 135;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.DualRelaySubIds <em>Dual Relay Sub Ids</em>}' enum.
@@ -16615,7 +16652,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDualRelaySubIds()
    * @generated
    */
-  int DUAL_RELAY_SUB_IDS = 135;
+  int DUAL_RELAY_SUB_IDS = 136;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.LCDButtonSubIds <em>LCD Button Sub Ids</em>}' enum.
@@ -16625,7 +16662,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getLCDButtonSubIds()
    * @generated
    */
-  int LCD_BUTTON_SUB_IDS = 136;
+  int LCD_BUTTON_SUB_IDS = 137;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.LCDBacklightSubIds <em>LCD Backlight Sub Ids</em>}' enum.
@@ -16635,7 +16672,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getLCDBacklightSubIds()
    * @generated
    */
-  int LCD_BACKLIGHT_SUB_IDS = 137;
+  int LCD_BACKLIGHT_SUB_IDS = 138;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.MultiTouchSubIds <em>Multi Touch Sub Ids</em>}' enum.
@@ -16645,7 +16682,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMultiTouchSubIds()
    * @generated
    */
-  int MULTI_TOUCH_SUB_IDS = 138;
+  int MULTI_TOUCH_SUB_IDS = 139;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.TemperatureIRSubIds <em>Temperature IR Sub Ids</em>}' enum.
@@ -16655,7 +16692,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTemperatureIRSubIds()
    * @generated
    */
-  int TEMPERATURE_IR_SUB_IDS = 139;
+  int TEMPERATURE_IR_SUB_IDS = 140;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.VoltageCurrentSubIds <em>Voltage Current Sub Ids</em>}' enum.
@@ -16665,7 +16702,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getVoltageCurrentSubIds()
    * @generated
    */
-  int VOLTAGE_CURRENT_SUB_IDS = 140;
+  int VOLTAGE_CURRENT_SUB_IDS = 141;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.ConfigOptsMove <em>Config Opts Move</em>}' enum.
@@ -16675,7 +16712,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getConfigOptsMove()
    * @generated
    */
-  int CONFIG_OPTS_MOVE = 141;
+  int CONFIG_OPTS_MOVE = 142;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.ConfigOptsDimmable <em>Config Opts Dimmable</em>}' enum.
@@ -16685,7 +16722,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getConfigOptsDimmable()
    * @generated
    */
-  int CONFIG_OPTS_DIMMABLE = 142;
+  int CONFIG_OPTS_DIMMABLE = 143;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.ConfigOptsSetPoint <em>Config Opts Set Point</em>}' enum.
@@ -16695,7 +16732,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getConfigOptsSetPoint()
    * @generated
    */
-  int CONFIG_OPTS_SET_POINT = 143;
+  int CONFIG_OPTS_SET_POINT = 144;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.ConfigOptsSwitchSpeed <em>Config Opts Switch Speed</em>}' enum.
@@ -16705,7 +16742,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getConfigOptsSwitchSpeed()
    * @generated
    */
-  int CONFIG_OPTS_SWITCH_SPEED = 144;
+  int CONFIG_OPTS_SWITCH_SPEED = 145;
 
   /**
    * The meta object id for the '<em>MIP Connection</em>' data type.
@@ -16715,7 +16752,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMIPConnection()
    * @generated
    */
-  int MIP_CONNECTION = 153;
+  int MIP_CONNECTION = 154;
 
   /**
    * The meta object id for the '<em>MTinker Device</em>' data type.
@@ -16725,7 +16762,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerDevice()
    * @generated
    */
-  int MTINKER_DEVICE = 154;
+  int MTINKER_DEVICE = 155;
 
   /**
    * The meta object id for the '<em>MLogger</em>' data type.
@@ -16735,7 +16772,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMLogger()
    * @generated
    */
-  int MLOGGER = 155;
+  int MLOGGER = 156;
 
 
   /**
@@ -16746,7 +16783,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMAtomicBoolean()
    * @generated
    */
-  int MATOMIC_BOOLEAN = 156;
+  int MATOMIC_BOOLEAN = 157;
 
   /**
    * The meta object id for the '<em>MTinkerforge Device</em>' data type.
@@ -16756,7 +16793,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerforgeDevice()
    * @generated
    */
-  int MTINKERFORGE_DEVICE = 157;
+  int MTINKERFORGE_DEVICE = 158;
 
   /**
    * The meta object id for the '<em>MTinker Brick DC</em>' data type.
@@ -16766,7 +16803,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickDC()
    * @generated
    */
-  int MTINKER_BRICK_DC = 158;
+  int MTINKER_BRICK_DC = 159;
 
   /**
    * The meta object id for the '<em>MTinker Brick Servo</em>' data type.
@@ -16776,7 +16813,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickServo()
    * @generated
    */
-  int MTINKER_BRICK_SERVO = 167;
+  int MTINKER_BRICK_SERVO = 168;
 
 
   /**
@@ -16787,7 +16824,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerforgeValue()
    * @generated
    */
-  int MTINKERFORGE_VALUE = 168;
+  int MTINKERFORGE_VALUE = 169;
 
   /**
    * The meta object id for the '<em>MDecimal Value</em>' data type.
@@ -16797,7 +16834,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMDecimalValue()
    * @generated
    */
-  int MDECIMAL_VALUE = 169;
+  int MDECIMAL_VALUE = 170;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet Humidity</em>' data type.
@@ -16807,7 +16844,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletHumidity()
    * @generated
    */
-  int MTINKER_BRICKLET_HUMIDITY = 170;
+  int MTINKER_BRICKLET_HUMIDITY = 171;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet Distance IR</em>' data type.
@@ -16817,7 +16854,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletDistanceIR()
    * @generated
    */
-  int MTINKER_BRICKLET_DISTANCE_IR = 171;
+  int MTINKER_BRICKLET_DISTANCE_IR = 172;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet Temperature</em>' data type.
@@ -16827,7 +16864,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletTemperature()
    * @generated
    */
-  int MTINKER_BRICKLET_TEMPERATURE = 172;
+  int MTINKER_BRICKLET_TEMPERATURE = 173;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet Barometer</em>' data type.
@@ -16837,7 +16874,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletBarometer()
    * @generated
    */
-  int MTINKER_BRICKLET_BAROMETER = 173;
+  int MTINKER_BRICKLET_BAROMETER = 174;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet Ambient Light</em>' data type.
@@ -16847,7 +16884,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletAmbientLight()
    * @generated
    */
-  int MTINKER_BRICKLET_AMBIENT_LIGHT = 174;
+  int MTINKER_BRICKLET_AMBIENT_LIGHT = 175;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet LCD2 0x4</em>' data type.
@@ -16857,7 +16894,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletLCD20x4()
    * @generated
    */
-  int MTINKER_BRICKLET_LCD2_0X4 = 175;
+  int MTINKER_BRICKLET_LCD2_0X4 = 176;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Remote Switch</em>' data type.
@@ -16867,7 +16904,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletRemoteSwitch()
    * @generated
    */
-  int TINKER_BRICKLET_REMOTE_SWITCH = 176;
+  int TINKER_BRICKLET_REMOTE_SWITCH = 177;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Motion Detector</em>' data type.
@@ -16877,7 +16914,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletMotionDetector()
    * @generated
    */
-  int TINKER_BRICKLET_MOTION_DETECTOR = 177;
+  int TINKER_BRICKLET_MOTION_DETECTOR = 178;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Multi Touch</em>' data type.
@@ -16887,7 +16924,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletMultiTouch()
    * @generated
    */
-  int TINKER_BRICKLET_MULTI_TOUCH = 178;
+  int TINKER_BRICKLET_MULTI_TOUCH = 179;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Temperature IR</em>' data type.
@@ -16897,7 +16934,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletTemperatureIR()
    * @generated
    */
-  int TINKER_BRICKLET_TEMPERATURE_IR = 179;
+  int TINKER_BRICKLET_TEMPERATURE_IR = 180;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Sound Intensity</em>' data type.
@@ -16907,7 +16944,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletSoundIntensity()
    * @generated
    */
-  int TINKER_BRICKLET_SOUND_INTENSITY = 180;
+  int TINKER_BRICKLET_SOUND_INTENSITY = 181;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Moisture</em>' data type.
@@ -16917,7 +16954,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletMoisture()
    * @generated
    */
-  int TINKER_BRICKLET_MOISTURE = 181;
+  int TINKER_BRICKLET_MOISTURE = 182;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Distance US</em>' data type.
@@ -16927,7 +16964,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletDistanceUS()
    * @generated
    */
-  int TINKER_BRICKLET_DISTANCE_US = 182;
+  int TINKER_BRICKLET_DISTANCE_US = 183;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Voltage Current</em>' data type.
@@ -16937,7 +16974,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletVoltageCurrent()
    * @generated
    */
-  int TINKER_BRICKLET_VOLTAGE_CURRENT = 183;
+  int TINKER_BRICKLET_VOLTAGE_CURRENT = 184;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Tilt</em>' data type.
@@ -16947,7 +16984,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletTilt()
    * @generated
    */
-  int TINKER_BRICKLET_TILT = 184;
+  int TINKER_BRICKLET_TILT = 185;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet IO4</em>' data type.
@@ -16957,7 +16994,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletIO4()
    * @generated
    */
-  int TINKER_BRICKLET_IO4 = 185;
+  int TINKER_BRICKLET_IO4 = 186;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Hall Effect</em>' data type.
@@ -16967,7 +17004,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletHallEffect()
    * @generated
    */
-  int TINKER_BRICKLET_HALL_EFFECT = 186;
+  int TINKER_BRICKLET_HALL_EFFECT = 187;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Segment Display4x7</em>' data type.
@@ -16977,7 +17014,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletSegmentDisplay4x7()
    * @generated
    */
-  int TINKER_BRICKLET_SEGMENT_DISPLAY4X7 = 187;
+  int TINKER_BRICKLET_SEGMENT_DISPLAY4X7 = 188;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet LED Strip</em>' data type.
@@ -16987,7 +17024,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletLEDStrip()
    * @generated
    */
-  int TINKER_BRICKLET_LED_STRIP = 188;
+  int TINKER_BRICKLET_LED_STRIP = 189;
 
   /**
    * The meta object id for the '<em>Bricklet Joystick</em>' data type.
@@ -16997,7 +17034,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getBrickletJoystick()
    * @generated
    */
-  int BRICKLET_JOYSTICK = 189;
+  int BRICKLET_JOYSTICK = 190;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Linear Poti</em>' data type.
@@ -17007,7 +17044,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletLinearPoti()
    * @generated
    */
-  int TINKER_BRICKLET_LINEAR_POTI = 190;
+  int TINKER_BRICKLET_LINEAR_POTI = 191;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Dual Button</em>' data type.
@@ -17017,7 +17054,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletDualButton()
    * @generated
    */
-  int TINKER_BRICKLET_DUAL_BUTTON = 191;
+  int TINKER_BRICKLET_DUAL_BUTTON = 192;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet PTC</em>' data type.
@@ -17027,7 +17064,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletPTC()
    * @generated
    */
-  int TINKER_BRICKLET_PTC = 192;
+  int TINKER_BRICKLET_PTC = 193;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Industrial Dual020m A</em>' data type.
@@ -17037,7 +17074,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletIndustrialDual020mA()
    * @generated
    */
-  int TINKER_BRICKLET_INDUSTRIAL_DUAL020M_A = 193;
+  int TINKER_BRICKLET_INDUSTRIAL_DUAL020M_A = 194;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Solid State Relay</em>' data type.
@@ -17047,7 +17084,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletSolidStateRelay()
    * @generated
    */
-  int TINKER_BRICKLET_SOLID_STATE_RELAY = 194;
+  int TINKER_BRICKLET_SOLID_STATE_RELAY = 195;
 
   /**
    * The meta object id for the '<em>HSB Type</em>' data type.
@@ -17057,7 +17094,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getHSBType()
    * @generated
    */
-  int HSB_TYPE = 195;
+  int HSB_TYPE = 196;
 
   /**
    * The meta object id for the '<em>Up Down Type</em>' data type.
@@ -17067,7 +17104,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getUpDownType()
    * @generated
    */
-  int UP_DOWN_TYPE = 196;
+  int UP_DOWN_TYPE = 197;
 
   /**
    * The meta object id for the '<em>Percent Value</em>' data type.
@@ -17077,7 +17114,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getPercentValue()
    * @generated
    */
-  int PERCENT_VALUE = 197;
+  int PERCENT_VALUE = 198;
 
   /**
    * The meta object id for the '<em>Device Options</em>' data type.
@@ -17087,7 +17124,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDeviceOptions()
    * @generated
    */
-  int DEVICE_OPTIONS = 198;
+  int DEVICE_OPTIONS = 199;
 
   /**
    * The meta object id for the '<em>Percent Type</em>' data type.
@@ -17097,7 +17134,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getPercentType()
    * @generated
    */
-  int PERCENT_TYPE = 199;
+  int PERCENT_TYPE = 200;
 
   /**
    * The meta object id for the '<em>Increase Decrease Type</em>' data type.
@@ -17107,7 +17144,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getIncreaseDecreaseType()
    * @generated
    */
-  int INCREASE_DECREASE_TYPE = 200;
+  int INCREASE_DECREASE_TYPE = 201;
 
   /**
    * The meta object id for the '<em>Direction Value</em>' data type.
@@ -17117,7 +17154,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDirectionValue()
    * @generated
    */
-  int DIRECTION_VALUE = 201;
+  int DIRECTION_VALUE = 202;
 
   /**
    * The meta object id for the '<em>Enum</em>' data type.
@@ -17127,7 +17164,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getEnum()
    * @generated
    */
-  int ENUM = 202;
+  int ENUM = 203;
 
   /**
    * Returns the meta object for class '{@link org.openhab.binding.tinkerforge.internal.model.TFConfig <em>TF Config</em>}'.
@@ -17294,7 +17331,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletDualRelay()
    * @generated
    */
-  int MTINKER_BRICKLET_DUAL_RELAY = 159;
+  int MTINKER_BRICKLET_DUAL_RELAY = 160;
 
 
   /**
@@ -17305,7 +17342,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletIndustrialQuadRelay()
    * @generated
    */
-  int MTINKER_BRICKLET_INDUSTRIAL_QUAD_RELAY = 160;
+  int MTINKER_BRICKLET_INDUSTRIAL_QUAD_RELAY = 161;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet Industrial Digital In4</em>' data type.
@@ -17315,7 +17352,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletIndustrialDigitalIn4()
    * @generated
    */
-  int MTINKER_BRICKLET_INDUSTRIAL_DIGITAL_IN4 = 161;
+  int MTINKER_BRICKLET_INDUSTRIAL_DIGITAL_IN4 = 162;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet Industrial Digital Out4</em>' data type.
@@ -17325,7 +17362,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletIndustrialDigitalOut4()
    * @generated
    */
-  int MTINKER_BRICKLET_INDUSTRIAL_DIGITAL_OUT4 = 162;
+  int MTINKER_BRICKLET_INDUSTRIAL_DIGITAL_OUT4 = 163;
 
   /**
    * Returns the meta object for class '{@link org.openhab.binding.tinkerforge.internal.model.Ecosystem <em>Ecosystem</em>}'.
@@ -18144,6 +18181,17 @@ public interface ModelPackage extends EPackage
   EClass getMIndustrialDigitalIn();
 
   /**
+   * Returns the meta object for the attribute '{@link org.openhab.binding.tinkerforge.internal.model.MIndustrialDigitalIn#getDeviceType <em>Device Type</em>}'.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @return the meta object for the attribute '<em>Device Type</em>'.
+   * @see org.openhab.binding.tinkerforge.internal.model.MIndustrialDigitalIn#getDeviceType()
+   * @see #getMIndustrialDigitalIn()
+   * @generated
+   */
+  EAttribute getMIndustrialDigitalIn_DeviceType();
+
+  /**
    * Returns the meta object for class '{@link org.openhab.binding.tinkerforge.internal.model.MBrickletIndustrialDigitalOut4 <em>MBricklet Industrial Digital Out4</em>}'.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
@@ -18152,6 +18200,17 @@ public interface ModelPackage extends EPackage
    * @generated
    */
   EClass getMBrickletIndustrialDigitalOut4();
+
+  /**
+   * Returns the meta object for the attribute '{@link org.openhab.binding.tinkerforge.internal.model.MBrickletIndustrialDigitalOut4#getDeviceType <em>Device Type</em>}'.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @return the meta object for the attribute '<em>Device Type</em>'.
+   * @see org.openhab.binding.tinkerforge.internal.model.MBrickletIndustrialDigitalOut4#getDeviceType()
+   * @see #getMBrickletIndustrialDigitalOut4()
+   * @generated
+   */
+  EAttribute getMBrickletIndustrialDigitalOut4_DeviceType();
 
   /**
    * Returns the meta object for class '{@link org.openhab.binding.tinkerforge.internal.model.DigitalActorDigitalOut4 <em>Digital Actor Digital Out4</em>}'.
@@ -18173,6 +18232,17 @@ public interface ModelPackage extends EPackage
    * @generated
    */
   EAttribute getDigitalActorDigitalOut4_Pin();
+
+  /**
+   * Returns the meta object for the attribute '{@link org.openhab.binding.tinkerforge.internal.model.DigitalActorDigitalOut4#getDeviceType <em>Device Type</em>}'.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @return the meta object for the attribute '<em>Device Type</em>'.
+   * @see org.openhab.binding.tinkerforge.internal.model.DigitalActorDigitalOut4#getDeviceType()
+   * @see #getDigitalActorDigitalOut4()
+   * @generated
+   */
+  EAttribute getDigitalActorDigitalOut4_DeviceType();
 
   /**
    * Returns the meta object for class '{@link org.openhab.binding.tinkerforge.internal.model.DigitalActor <em>Digital Actor</em>}'.
@@ -21783,6 +21853,16 @@ public interface ModelPackage extends EPackage
   EEnum getIndustrialDigitalInSubIDs();
 
   /**
+   * Returns the meta object for enum '{@link org.openhab.binding.tinkerforge.internal.model.IndustrialDigitalOutSubIDs <em>Industrial Digital Out Sub IDs</em>}'.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @return the meta object for enum '<em>Industrial Digital Out Sub IDs</em>'.
+   * @see org.openhab.binding.tinkerforge.internal.model.IndustrialDigitalOutSubIDs
+   * @generated
+   */
+  EEnum getIndustrialDigitalOutSubIDs();
+
+  /**
    * Returns the meta object for enum '{@link org.openhab.binding.tinkerforge.internal.model.IndustrialQuadRelayIDs <em>Industrial Quad Relay IDs</em>}'.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
@@ -23237,6 +23317,14 @@ public interface ModelPackage extends EPackage
     EClass MINDUSTRIAL_DIGITAL_IN = eINSTANCE.getMIndustrialDigitalIn();
 
     /**
+     * The meta object literal for the '<em><b>Device Type</b></em>' attribute feature.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    EAttribute MINDUSTRIAL_DIGITAL_IN__DEVICE_TYPE = eINSTANCE.getMIndustrialDigitalIn_DeviceType();
+
+    /**
      * The meta object literal for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.MBrickletIndustrialDigitalOut4Impl <em>MBricklet Industrial Digital Out4</em>}' class.
      * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
@@ -23245,6 +23333,14 @@ public interface ModelPackage extends EPackage
      * @generated
      */
     EClass MBRICKLET_INDUSTRIAL_DIGITAL_OUT4 = eINSTANCE.getMBrickletIndustrialDigitalOut4();
+
+    /**
+     * The meta object literal for the '<em><b>Device Type</b></em>' attribute feature.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    EAttribute MBRICKLET_INDUSTRIAL_DIGITAL_OUT4__DEVICE_TYPE = eINSTANCE.getMBrickletIndustrialDigitalOut4_DeviceType();
 
     /**
      * The meta object literal for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.DigitalActorDigitalOut4Impl <em>Digital Actor Digital Out4</em>}' class.
@@ -23263,6 +23359,14 @@ public interface ModelPackage extends EPackage
      * @generated
      */
     EAttribute DIGITAL_ACTOR_DIGITAL_OUT4__PIN = eINSTANCE.getDigitalActorDigitalOut4_Pin();
+
+    /**
+     * The meta object literal for the '<em><b>Device Type</b></em>' attribute feature.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    EAttribute DIGITAL_ACTOR_DIGITAL_OUT4__DEVICE_TYPE = eINSTANCE.getDigitalActorDigitalOut4_DeviceType();
 
     /**
      * The meta object literal for the '{@link org.openhab.binding.tinkerforge.internal.model.DigitalActor <em>Digital Actor</em>}' class.
@@ -26241,6 +26345,16 @@ public interface ModelPackage extends EPackage
      * @generated
      */
     EEnum INDUSTRIAL_DIGITAL_IN_SUB_IDS = eINSTANCE.getIndustrialDigitalInSubIDs();
+
+    /**
+     * The meta object literal for the '{@link org.openhab.binding.tinkerforge.internal.model.IndustrialDigitalOutSubIDs <em>Industrial Digital Out Sub IDs</em>}' enum.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @see org.openhab.binding.tinkerforge.internal.model.IndustrialDigitalOutSubIDs
+     * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getIndustrialDigitalOutSubIDs()
+     * @generated
+     */
+    EEnum INDUSTRIAL_DIGITAL_OUT_SUB_IDS = eINSTANCE.getIndustrialDigitalOutSubIDs();
 
     /**
      * The meta object literal for the '{@link org.openhab.binding.tinkerforge.internal.model.IndustrialQuadRelayIDs <em>Industrial Quad Relay IDs</em>}' enum.

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/DigitalActorDigitalOut4Impl.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/DigitalActorDigitalOut4Impl.java
@@ -61,6 +61,7 @@ import com.tinkerforge.TimeoutException;
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.DigitalActorDigitalOut4Impl#getSubId <em>Sub Id</em>}</li>
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.DigitalActorDigitalOut4Impl#getMbrick <em>Mbrick</em>}</li>
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.DigitalActorDigitalOut4Impl#getPin <em>Pin</em>}</li>
+ *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.DigitalActorDigitalOut4Impl#getDeviceType <em>Device Type</em>}</li>
  * </ul>
  * </p>
  *
@@ -207,6 +208,26 @@ public class DigitalActorDigitalOut4Impl extends MinimalEObjectImpl.Container im
    * @ordered
    */
   protected int pin = PIN_EDEFAULT;
+
+  /**
+   * The default value of the '{@link #getDeviceType() <em>Device Type</em>}' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #getDeviceType()
+   * @generated
+   * @ordered
+   */
+  protected static final String DEVICE_TYPE_EDEFAULT = "digital_4out";
+
+  /**
+   * The cached value of the '{@link #getDeviceType() <em>Device Type</em>}' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #getDeviceType()
+   * @generated
+   * @ordered
+   */
+  protected String deviceType = DEVICE_TYPE_EDEFAULT;
 
   private int mask;
 
@@ -440,6 +461,16 @@ public class DigitalActorDigitalOut4Impl extends MinimalEObjectImpl.Container im
   /**
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
+   * @generated
+   */
+  public String getDeviceType()
+  {
+    return deviceType;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
    * @generated NOT
    */
   public void init()
@@ -601,6 +632,8 @@ public class DigitalActorDigitalOut4Impl extends MinimalEObjectImpl.Container im
         return getMbrick();
       case ModelPackage.DIGITAL_ACTOR_DIGITAL_OUT4__PIN:
         return getPin();
+      case ModelPackage.DIGITAL_ACTOR_DIGITAL_OUT4__DEVICE_TYPE:
+        return getDeviceType();
     }
     return super.eGet(featureID, resolve, coreType);
   }
@@ -707,6 +740,8 @@ public class DigitalActorDigitalOut4Impl extends MinimalEObjectImpl.Container im
         return getMbrick() != null;
       case ModelPackage.DIGITAL_ACTOR_DIGITAL_OUT4__PIN:
         return pin != PIN_EDEFAULT;
+      case ModelPackage.DIGITAL_ACTOR_DIGITAL_OUT4__DEVICE_TYPE:
+        return DEVICE_TYPE_EDEFAULT == null ? deviceType != null : !DEVICE_TYPE_EDEFAULT.equals(deviceType);
     }
     return super.eIsSet(featureID);
   }
@@ -855,6 +890,8 @@ public class DigitalActorDigitalOut4Impl extends MinimalEObjectImpl.Container im
     result.append(subId);
     result.append(", pin: ");
     result.append(pin);
+    result.append(", deviceType: ");
+    result.append(deviceType);
     result.append(')');
     return result.toString();
   }

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/MBrickletIndustrialDigitalOut4Impl.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/MBrickletIndustrialDigitalOut4Impl.java
@@ -58,6 +58,7 @@ import com.tinkerforge.IPConnection;
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.MBrickletIndustrialDigitalOut4Impl#getName <em>Name</em>}</li>
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.MBrickletIndustrialDigitalOut4Impl#getBrickd <em>Brickd</em>}</li>
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.MBrickletIndustrialDigitalOut4Impl#getMsubdevices <em>Msubdevices</em>}</li>
+ *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.MBrickletIndustrialDigitalOut4Impl#getDeviceType <em>Device Type</em>}</li>
  * </ul>
  * </p>
  *
@@ -264,6 +265,26 @@ public class MBrickletIndustrialDigitalOut4Impl extends MinimalEObjectImpl.Conta
    * @ordered
    */
   protected EList<DigitalActorDigitalOut4> msubdevices;
+
+  /**
+   * The default value of the '{@link #getDeviceType() <em>Device Type</em>}' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #getDeviceType()
+   * @generated
+   * @ordered
+   */
+  protected static final String DEVICE_TYPE_EDEFAULT = "bricklet_industrial_digital_4out";
+
+  /**
+   * The cached value of the '{@link #getDeviceType() <em>Device Type</em>}' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #getDeviceType()
+   * @generated
+   * @ordered
+   */
+  protected String deviceType = DEVICE_TYPE_EDEFAULT;
 
   /**
    * <!-- begin-user-doc -->
@@ -578,6 +599,16 @@ public class MBrickletIndustrialDigitalOut4Impl extends MinimalEObjectImpl.Conta
   /**
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
+   * @generated
+   */
+  public String getDeviceType()
+  {
+    return deviceType;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
    * @generated NOT
    */
   public void initSubDevices()
@@ -718,6 +749,8 @@ public class MBrickletIndustrialDigitalOut4Impl extends MinimalEObjectImpl.Conta
         return getBrickd();
       case ModelPackage.MBRICKLET_INDUSTRIAL_DIGITAL_OUT4__MSUBDEVICES:
         return getMsubdevices();
+      case ModelPackage.MBRICKLET_INDUSTRIAL_DIGITAL_OUT4__DEVICE_TYPE:
+        return getDeviceType();
     }
     return super.eGet(featureID, resolve, coreType);
   }
@@ -858,6 +891,8 @@ public class MBrickletIndustrialDigitalOut4Impl extends MinimalEObjectImpl.Conta
         return getBrickd() != null;
       case ModelPackage.MBRICKLET_INDUSTRIAL_DIGITAL_OUT4__MSUBDEVICES:
         return msubdevices != null && !msubdevices.isEmpty();
+      case ModelPackage.MBRICKLET_INDUSTRIAL_DIGITAL_OUT4__DEVICE_TYPE:
+        return DEVICE_TYPE_EDEFAULT == null ? deviceType != null : !DEVICE_TYPE_EDEFAULT.equals(deviceType);
     }
     return super.eIsSet(featureID);
   }
@@ -976,6 +1011,8 @@ public class MBrickletIndustrialDigitalOut4Impl extends MinimalEObjectImpl.Conta
     result.append(deviceIdentifier);
     result.append(", name: ");
     result.append(name);
+    result.append(", deviceType: ");
+    result.append(deviceType);
     result.append(')');
     return result.toString();
   }

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/MIndustrialDigitalInImpl.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/MIndustrialDigitalInImpl.java
@@ -51,6 +51,7 @@ import com.tinkerforge.TimeoutException;
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.MIndustrialDigitalInImpl#getSubId <em>Sub Id</em>}</li>
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.MIndustrialDigitalInImpl#getMbrick <em>Mbrick</em>}</li>
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.MIndustrialDigitalInImpl#getSensorValue <em>Sensor Value</em>}</li>
+ *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.MIndustrialDigitalInImpl#getDeviceType <em>Device Type</em>}</li>
  * </ul>
  * </p>
  *
@@ -167,6 +168,26 @@ public class MIndustrialDigitalInImpl extends MinimalEObjectImpl.Container imple
    * @ordered
    */
   protected HighLowValue sensorValue;
+
+  /**
+   * The default value of the '{@link #getDeviceType() <em>Device Type</em>}' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #getDeviceType()
+   * @generated
+   * @ordered
+   */
+  protected static final String DEVICE_TYPE_EDEFAULT = "digital_4in";
+
+  /**
+   * The cached value of the '{@link #getDeviceType() <em>Device Type</em>}' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #getDeviceType()
+   * @generated
+   * @ordered
+   */
+  protected String deviceType = DEVICE_TYPE_EDEFAULT;
 
   private short inNum;
 
@@ -379,6 +400,16 @@ private int mask;
   }
 
   /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public String getDeviceType()
+  {
+    return deviceType;
+  }
+
+  /**
    * <!-- begin-user-doc --> <!-- end-user-doc -->
    * 
    * @generated NOT
@@ -538,6 +569,8 @@ private int mask;
         return getMbrick();
       case ModelPackage.MINDUSTRIAL_DIGITAL_IN__SENSOR_VALUE:
         return getSensorValue();
+      case ModelPackage.MINDUSTRIAL_DIGITAL_IN__DEVICE_TYPE:
+        return getDeviceType();
     }
     return super.eGet(featureID, resolve, coreType);
   }
@@ -636,6 +669,8 @@ private int mask;
         return getMbrick() != null;
       case ModelPackage.MINDUSTRIAL_DIGITAL_IN__SENSOR_VALUE:
         return sensorValue != null;
+      case ModelPackage.MINDUSTRIAL_DIGITAL_IN__DEVICE_TYPE:
+        return DEVICE_TYPE_EDEFAULT == null ? deviceType != null : !DEVICE_TYPE_EDEFAULT.equals(deviceType);
     }
     return super.eIsSet(featureID);
   }
@@ -746,6 +781,8 @@ private int mask;
     result.append(subId);
     result.append(", sensorValue: ");
     result.append(sensorValue);
+    result.append(", deviceType: ");
+    result.append(deviceType);
     result.append(')');
     return result.toString();
   }

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/MIndustrialQuadRelayImpl.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/MIndustrialQuadRelayImpl.java
@@ -187,7 +187,7 @@ public class MIndustrialQuadRelayImpl extends MinimalEObjectImpl.Container imple
    * @generated
    * @ordered
    */
-  protected static final String DEVICE_TYPE_EDEFAULT = "industrial_quad_relay";
+  protected static final String DEVICE_TYPE_EDEFAULT = "quad_relay";
 
   /**
    * The cached value of the '{@link #getDeviceType() <em>Device Type</em>}' attribute.

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/ModelFactoryImpl.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/ModelFactoryImpl.java
@@ -233,6 +233,8 @@ public class ModelFactoryImpl extends EFactoryImpl implements ModelFactory
         return createNoSubIdsFromString(eDataType, initialValue);
       case ModelPackage.INDUSTRIAL_DIGITAL_IN_SUB_IDS:
         return createIndustrialDigitalInSubIDsFromString(eDataType, initialValue);
+      case ModelPackage.INDUSTRIAL_DIGITAL_OUT_SUB_IDS:
+        return createIndustrialDigitalOutSubIDsFromString(eDataType, initialValue);
       case ModelPackage.INDUSTRIAL_QUAD_RELAY_IDS:
         return createIndustrialQuadRelayIDsFromString(eDataType, initialValue);
       case ModelPackage.SERVO_SUB_IDS:
@@ -398,6 +400,8 @@ public class ModelFactoryImpl extends EFactoryImpl implements ModelFactory
         return convertNoSubIdsToString(eDataType, instanceValue);
       case ModelPackage.INDUSTRIAL_DIGITAL_IN_SUB_IDS:
         return convertIndustrialDigitalInSubIDsToString(eDataType, instanceValue);
+      case ModelPackage.INDUSTRIAL_DIGITAL_OUT_SUB_IDS:
+        return convertIndustrialDigitalOutSubIDsToString(eDataType, instanceValue);
       case ModelPackage.INDUSTRIAL_QUAD_RELAY_IDS:
         return convertIndustrialQuadRelayIDsToString(eDataType, instanceValue);
       case ModelPackage.SERVO_SUB_IDS:
@@ -1880,6 +1884,28 @@ public class ModelFactoryImpl extends EFactoryImpl implements ModelFactory
    * @generated
    */
   public String convertIndustrialDigitalInSubIDsToString(EDataType eDataType, Object instanceValue)
+  {
+    return instanceValue == null ? null : instanceValue.toString();
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public IndustrialDigitalOutSubIDs createIndustrialDigitalOutSubIDsFromString(EDataType eDataType, String initialValue)
+  {
+    IndustrialDigitalOutSubIDs result = IndustrialDigitalOutSubIDs.get(initialValue);
+    if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
+    return result;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public String convertIndustrialDigitalOutSubIDsToString(EDataType eDataType, Object instanceValue)
   {
     return instanceValue == null ? null : instanceValue.toString();
   }

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/ModelPackageImpl.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/ModelPackageImpl.java
@@ -62,6 +62,7 @@ import org.openhab.binding.tinkerforge.internal.model.IO4Device;
 import org.openhab.binding.tinkerforge.internal.model.IO4SubIds;
 import org.openhab.binding.tinkerforge.internal.model.IODevice;
 import org.openhab.binding.tinkerforge.internal.model.IndustrialDigitalInSubIDs;
+import org.openhab.binding.tinkerforge.internal.model.IndustrialDigitalOutSubIDs;
 import org.openhab.binding.tinkerforge.internal.model.IndustrialDual020mASubIds;
 import org.openhab.binding.tinkerforge.internal.model.IndustrialQuadRelayIDs;
 import org.openhab.binding.tinkerforge.internal.model.InterruptListener;
@@ -1203,6 +1204,13 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
    * @generated
    */
   private EEnum industrialDigitalInSubIDsEEnum = null;
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  private EEnum industrialDigitalOutSubIDsEEnum = null;
 
   /**
    * <!-- begin-user-doc -->
@@ -2650,9 +2658,29 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
    * <!-- end-user-doc -->
    * @generated
    */
+  public EAttribute getMIndustrialDigitalIn_DeviceType()
+  {
+    return (EAttribute)mIndustrialDigitalInEClass.getEStructuralFeatures().get(0);
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
   public EClass getMBrickletIndustrialDigitalOut4()
   {
     return mBrickletIndustrialDigitalOut4EClass;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public EAttribute getMBrickletIndustrialDigitalOut4_DeviceType()
+  {
+    return (EAttribute)mBrickletIndustrialDigitalOut4EClass.getEStructuralFeatures().get(0);
   }
 
   /**
@@ -2673,6 +2701,16 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
   public EAttribute getDigitalActorDigitalOut4_Pin()
   {
     return (EAttribute)digitalActorDigitalOut4EClass.getEStructuralFeatures().get(0);
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public EAttribute getDigitalActorDigitalOut4_DeviceType()
+  {
+    return (EAttribute)digitalActorDigitalOut4EClass.getEStructuralFeatures().get(1);
   }
 
   /**
@@ -6100,6 +6138,16 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
    * <!-- end-user-doc -->
    * @generated
    */
+  public EEnum getIndustrialDigitalOutSubIDs()
+  {
+    return industrialDigitalOutSubIDsEEnum;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
   public EEnum getIndustrialQuadRelayIDs()
   {
     return industrialQuadRelayIDsEEnum;
@@ -6935,11 +6983,14 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
     createEAttribute(mBrickletIndustrialDigitalIn4EClass, MBRICKLET_INDUSTRIAL_DIGITAL_IN4__DEVICE_TYPE);
 
     mIndustrialDigitalInEClass = createEClass(MINDUSTRIAL_DIGITAL_IN);
+    createEAttribute(mIndustrialDigitalInEClass, MINDUSTRIAL_DIGITAL_IN__DEVICE_TYPE);
 
     mBrickletIndustrialDigitalOut4EClass = createEClass(MBRICKLET_INDUSTRIAL_DIGITAL_OUT4);
+    createEAttribute(mBrickletIndustrialDigitalOut4EClass, MBRICKLET_INDUSTRIAL_DIGITAL_OUT4__DEVICE_TYPE);
 
     digitalActorDigitalOut4EClass = createEClass(DIGITAL_ACTOR_DIGITAL_OUT4);
     createEAttribute(digitalActorDigitalOut4EClass, DIGITAL_ACTOR_DIGITAL_OUT4__PIN);
+    createEAttribute(digitalActorDigitalOut4EClass, DIGITAL_ACTOR_DIGITAL_OUT4__DEVICE_TYPE);
 
     mBrickletSegmentDisplay4x7EClass = createEClass(MBRICKLET_SEGMENT_DISPLAY4X7);
     createEAttribute(mBrickletSegmentDisplay4x7EClass, MBRICKLET_SEGMENT_DISPLAY4X7__DEVICE_TYPE);
@@ -7289,6 +7340,7 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
     // Create enums
     noSubIdsEEnum = createEEnum(NO_SUB_IDS);
     industrialDigitalInSubIDsEEnum = createEEnum(INDUSTRIAL_DIGITAL_IN_SUB_IDS);
+    industrialDigitalOutSubIDsEEnum = createEEnum(INDUSTRIAL_DIGITAL_OUT_SUB_IDS);
     industrialQuadRelayIDsEEnum = createEEnum(INDUSTRIAL_QUAD_RELAY_IDS);
     servoSubIDsEEnum = createEEnum(SERVO_SUB_IDS);
     barometerSubIDsEEnum = createEEnum(BAROMETER_SUB_IDS);
@@ -8435,17 +8487,20 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
     initEAttribute(getMIndustrialQuadRelayBricklet_DeviceType(), theEcorePackage.getEString(), "deviceType", "bricklet_quad_relay", 0, 1, MIndustrialQuadRelayBricklet.class, !IS_TRANSIENT, !IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(mIndustrialQuadRelayEClass, MIndustrialQuadRelay.class, "MIndustrialQuadRelay", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-    initEAttribute(getMIndustrialQuadRelay_DeviceType(), theEcorePackage.getEString(), "deviceType", "industrial_quad_relay", 0, 1, MIndustrialQuadRelay.class, !IS_TRANSIENT, !IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+    initEAttribute(getMIndustrialQuadRelay_DeviceType(), theEcorePackage.getEString(), "deviceType", "quad_relay", 0, 1, MIndustrialQuadRelay.class, !IS_TRANSIENT, !IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(mBrickletIndustrialDigitalIn4EClass, MBrickletIndustrialDigitalIn4.class, "MBrickletIndustrialDigitalIn4", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
     initEAttribute(getMBrickletIndustrialDigitalIn4_DeviceType(), theEcorePackage.getEString(), "deviceType", "bricklet_industrial_digital_4in", 0, 1, MBrickletIndustrialDigitalIn4.class, !IS_TRANSIENT, !IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(mIndustrialDigitalInEClass, MIndustrialDigitalIn.class, "MIndustrialDigitalIn", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+    initEAttribute(getMIndustrialDigitalIn_DeviceType(), theEcorePackage.getEString(), "deviceType", "digital_4in", 0, 1, MIndustrialDigitalIn.class, !IS_TRANSIENT, !IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(mBrickletIndustrialDigitalOut4EClass, MBrickletIndustrialDigitalOut4.class, "MBrickletIndustrialDigitalOut4", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+    initEAttribute(getMBrickletIndustrialDigitalOut4_DeviceType(), theEcorePackage.getEString(), "deviceType", "bricklet_industrial_digital_4out", 0, 1, MBrickletIndustrialDigitalOut4.class, !IS_TRANSIENT, !IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(digitalActorDigitalOut4EClass, DigitalActorDigitalOut4.class, "DigitalActorDigitalOut4", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
     initEAttribute(getDigitalActorDigitalOut4_Pin(), theEcorePackage.getEInt(), "pin", null, 0, 1, DigitalActorDigitalOut4.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+    initEAttribute(getDigitalActorDigitalOut4_DeviceType(), theEcorePackage.getEString(), "deviceType", "digital_4out", 0, 1, DigitalActorDigitalOut4.class, !IS_TRANSIENT, !IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(mBrickletSegmentDisplay4x7EClass, MBrickletSegmentDisplay4x7.class, "MBrickletSegmentDisplay4x7", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
     initEAttribute(getMBrickletSegmentDisplay4x7_DeviceType(), theEcorePackage.getEString(), "deviceType", "bricklet_segmentdisplay4x7", 0, 1, MBrickletSegmentDisplay4x7.class, !IS_TRANSIENT, !IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -8850,6 +8905,12 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
     addEEnumLiteral(industrialDigitalInSubIDsEEnum, IndustrialDigitalInSubIDs.IN1);
     addEEnumLiteral(industrialDigitalInSubIDsEEnum, IndustrialDigitalInSubIDs.IN2);
     addEEnumLiteral(industrialDigitalInSubIDsEEnum, IndustrialDigitalInSubIDs.IN3);
+
+    initEEnum(industrialDigitalOutSubIDsEEnum, IndustrialDigitalOutSubIDs.class, "IndustrialDigitalOutSubIDs");
+    addEEnumLiteral(industrialDigitalOutSubIDsEEnum, IndustrialDigitalOutSubIDs.OUT0);
+    addEEnumLiteral(industrialDigitalOutSubIDsEEnum, IndustrialDigitalOutSubIDs.OUT1);
+    addEEnumLiteral(industrialDigitalOutSubIDsEEnum, IndustrialDigitalOutSubIDs.OUT2);
+    addEEnumLiteral(industrialDigitalOutSubIDsEEnum, IndustrialDigitalOutSubIDs.OUT3);
 
     initEEnum(industrialQuadRelayIDsEEnum, IndustrialQuadRelayIDs.class, "IndustrialQuadRelayIDs");
     addEEnumLiteral(industrialQuadRelayIDsEEnum, IndustrialQuadRelayIDs.RELAY0);


### PR DESCRIPTION
Fix handling of device aliases for: dual_relay, quad_relay, joystick_xposition, joystick_yposition, digital_4in and digital_4out.
