### PR TITLE
Added Insteon Device Type model 2457D2  - LampLinc Dimmer

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
@@ -299,5 +299,11 @@ Example entry:
      <feature name="mastercontrol">ThermostatMasterControl</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
-
+ 
+ <device productKey="F00.00.19">
+     <model>2457D2</model>
+     <description>LampLinc Dimmer</description>
+     <feature name="dimmer">GenericDimmer</feature>
+     <feature name="lastheardfrom">GenericLastTime</feature>
+ </device>
 </xml>


### PR DESCRIPTION
Added a device type for an Insteon device that did not exist. I tested this on my 2457D2.