### PR TITLE
code cleanup, remove skeleton Action from Prowl that does nothing

### DIFF
--- a/bundles/action/org.openhab.action.prowl/src/main/java/org/openhab/action/prowl/internal/Prowl.java
+++ b/bundles/action/org.openhab.action.prowl/src/main/java/org/openhab/action/prowl/internal/Prowl.java
@@ -30,26 +30,11 @@ import org.slf4j.LoggerFactory;
 public class Prowl {
 
 	private static final Logger logger = LoggerFactory.getLogger(Prowl.class);
-
-	// provide public static methods here
-	
-	// Example
-	@ActionDoc(text="A cool method that does some Prowl", 
-			returns="<code>true</code>, if successful and <code>false</code> otherwise.")
-	public static boolean doProwl(@ParamDoc(name="something", text="the something to do") String something) {
-		if (!ProwlActionService.isProperlyConfigured) {
-			logger.debug("Prowl action is not yet configured - execution aborted!");
-			return false;
-		}
-		// now do something cool
-		return true;
-	}
 	
 	static String url = null;
 	static String apiKey = null;
 	static int priority = 0;
-	
-	
+		
 	/**
 	 * Pushes a Prowl notification with the configured api
 	 * key and takes the default priority into account


### PR DESCRIPTION
During looking around who to implement Actions i stumbled across a method remaining from the skeleton build. I think it can be deleted.

@teichsta Is it ok for you to do pull request for such small cleanups or do you prefer to have a bigger pull request with a collection of them? I am just asking, to fit better into your way of development.