### PR TITLE
OpenSprinkler Bugfix: Addon Silently Fails to Load When numberOfSprinklers is Defined

### DIFF
--- a/bundles/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/OpenSprinklerBinding.java
+++ b/bundles/binding/org.openhab.binding.opensprinkler/src/main/java/org/openhab/binding/opensprinkler/internal/OpenSprinklerBinding.java
@@ -10,6 +10,7 @@ package org.openhab.binding.opensprinkler.internal;
 
 import static org.openhab.binding.opensprinkler.internal.OpenSprinklerBinding.OpenSprinklerMode.HTTP;
 
+import java.util.Arrays;
 import java.util.Dictionary;
 
 import net.jonathangiles.opensprinkler.OpenSprinkler;
@@ -37,7 +38,9 @@ import org.slf4j.LoggerFactory;
  * @since 1.3.0
  */
 public class OpenSprinklerBinding extends AbstractActiveBinding<OpenSprinklerBindingProvider> implements ManagedService {
-
+	
+	private static String[] VALID_STATION_NUMBER_LIST = {"8", "16", "24", "32", "40", "48"};
+	
 	private static String RAIN_SENSOR_CONTACT_VALUE = "rs";
 	
 	private static final Logger logger = 
@@ -204,8 +207,11 @@ public class OpenSprinklerBinding extends AbstractActiveBinding<OpenSprinklerBin
 			// parameter to openhab.cfg like openSprinkler:numberOfStations=<count>
 			String numberOfStationsString = (String) config.get("numberOfStations");
 			if (StringUtils.isNotBlank(numberOfStationsString)) {
-				numberOfStations = Integer.parseInt(numberOfStationsString);
-				openSprinkler.setNumberOfStations(numberOfStations);
+			    if (Arrays.asList(VALID_STATION_NUMBER_LIST).contains(numberOfStationsString)) {
+					numberOfStations = Integer.parseInt(numberOfStationsString);
+				} else {
+					logger.warn(numberOfStationsString + " is not a valid number of stations OpenSprinkler supports. Defaulting to 8.");
+				}
 			}
 			
 			// read further config parameters here ...


### PR DESCRIPTION
- Fixed bug where defining the "numberOfSprinklers" parameter makes the add-on silently fail to load.
- Added number of stations parameter validation.