### PR TITLE
make RFXComMessageFactory message creation type-safe at compile time

### DIFF
--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComBaseMessage.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComBaseMessage.java
@@ -10,6 +10,8 @@ package org.openhab.binding.rfxcom.internal.messages;
 
 import javax.xml.bind.DatatypeConverter;
 
+import org.openhab.binding.rfxcom.internal.RFXComException;
+
 /**
  * Base class for RFXCOM data classes. All other data classes should extend this class.
  * 
@@ -19,40 +21,40 @@ import javax.xml.bind.DatatypeConverter;
 public abstract class RFXComBaseMessage implements RFXComMessageInterface {
 
 	public enum PacketType {
-		INTERFACE_CONTROL(0),
-		INTERFACE_MESSAGE(1),
-		TRANSMITTER_MESSAGE(2),
-		UNDECODED_RF_MESSAGE(3),
-		LIGHTING1(16),
-		LIGHTING2(17),
+		INTERFACE_CONTROL(0) { public RFXComControlMessage createMessage() { return new RFXComControlMessage(); }},
+		INTERFACE_MESSAGE(1) { public RFXComInterfaceMessage createMessage() { return new RFXComInterfaceMessage(); }},
+		TRANSMITTER_MESSAGE(2) { public RFXComTransmitterMessage createMessage() { return new RFXComTransmitterMessage(); }},
+		UNDECODED_RF_MESSAGE(3), 
+		LIGHTING1(16) { public RFXComLighting1Message createMessage() { return new RFXComLighting1Message(); }},
+		LIGHTING2(17) { public RFXComLighting2Message createMessage() { return new RFXComLighting2Message(); }},
 		LIGHTING3(18),
-		LIGHTING4(19),
-		LIGHTING5(20),
-		LIGHTING6(21),
+		LIGHTING4(19) { public RFXComLighting4Message createMessage() { return new RFXComLighting4Message(); }},
+		LIGHTING5(20) { public RFXComLighting5Message createMessage() { return new RFXComLighting5Message(); }},
+		LIGHTING6(21) { public RFXComLighting6Message createMessage() { return new RFXComLighting6Message(); }},
 		CHIME(22),
 		FAN(23),
-		CURTAIN1(24),
-		BLINDS1(25),
-		RFY(26),
-		SECURITY1(32),
+		CURTAIN1(24) { public RFXComCurtain1Message createMessage() { return new RFXComCurtain1Message(); }},
+		BLINDS1(25) { public RFXComBlinds1Message createMessage() { return new RFXComBlinds1Message(); }},
+		RFY(26) { public RFXComRfyMessage createMessage() { return new RFXComRfyMessage(); }},
+		SECURITY1(32) { public RFXComSecurity1Message createMessage() { return new RFXComSecurity1Message(); }},
 		CAMERA1(40),
 		REMOTE_CONTROL(48),
-		THERMOSTAT1(64),
+		THERMOSTAT1(64) { public RFXComThermostat1Message createMessage() { return new RFXComThermostat1Message(); }},
 		THERMOSTAT2(65),
 		THERMOSTAT3(66),
 		BBQ1(78),
 		TEMPERATURE_RAIN(79),
-		TEMPERATURE(80),
-		HUMIDITY(81),
-		TEMPERATURE_HUMIDITY(82),
+		TEMPERATURE(80) { public RFXComTemperatureMessage createMessage() { return new RFXComTemperatureMessage(); }},
+		HUMIDITY(81) { public RFXComHumidityMessage createMessage() { return new RFXComHumidityMessage(); }},
+		TEMPERATURE_HUMIDITY(82) { public RFXComTemperatureHumidityMessage createMessage() { return new RFXComTemperatureHumidityMessage(); }},
 		BAROMETRIC(83),
 		TEMPERATURE_HUMIDITY_BAROMETRIC(84),
-		RAIN(85),
-		WIND(86),
+		RAIN(85) { public RFXComRainMessage createMessage() { return new RFXComRainMessage(); }},
+		WIND(86) { public RFXComWindMessage createMessage() { return new RFXComWindMessage(); }},
 		UV(87),
 		DATE_TIME(88),
 		CURRENT(89),
-		ENERGY(90),
+		ENERGY(90) { public RFXComEnergyMessage createMessage() { return new RFXComEnergyMessage(); }},
 		CURRENT_ENERGY(91),
 		POWER(92),
 		WEIGHT(93),
@@ -79,8 +81,11 @@ public abstract class RFXComBaseMessage implements RFXComMessageInterface {
 			return (byte) packetType;
 		}
 		
+		public RFXComMessageInterface createMessage() throws RFXComException {
+			throw new RFXComException("the message for " + name() + " is not implemented");
+		}
 	}
-
+	
 	public byte[] rawMessage;
 	public PacketType packetType = PacketType.UNKNOWN;
 	public byte packetId = 0;

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComMessageFactory.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComMessageFactory.java
@@ -8,11 +8,6 @@
  */
 package org.openhab.binding.rfxcom.internal.messages;
 
-import java.lang.reflect.Constructor;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.openhab.binding.rfxcom.internal.RFXComException;
 import org.openhab.binding.rfxcom.internal.messages.RFXComBaseMessage.PacketType;
 
@@ -20,56 +15,6 @@ public class RFXComMessageFactory {
 	
 	final static String classUrl = "org.openhab.binding.rfxcom.internal.messages.";
 	
-	@SuppressWarnings("serial")
-	private static final Map<PacketType, String> messageClasses = Collections
-			.unmodifiableMap(new HashMap<PacketType, String>() {
-				{
-					put(PacketType.INTERFACE_CONTROL, "RFXComControlMessage");
-					put(PacketType.INTERFACE_MESSAGE, "RFXComInterfaceMessage");
-					put(PacketType.TRANSMITTER_MESSAGE, "RFXComTransmitterMessage");
-					put(PacketType.UNDECODED_RF_MESSAGE, "RFXComUndecodedRFMessage");
-					put(PacketType.LIGHTING1, "RFXComLighting1Message");
-					put(PacketType.LIGHTING2, "RFXComLighting2Message");
-					put(PacketType.LIGHTING3, "RFXComLighting3Message");
-					put(PacketType.LIGHTING4, "RFXComLighting4Message");
-					put(PacketType.LIGHTING5, "RFXComLighting5Message");
-					put(PacketType.LIGHTING6, "RFXComLighting6Message");
-					put(PacketType.CHIME,"RFXComChimeMessage");
-					put(PacketType.FAN,"RFXComFanMessage");
-					put(PacketType.CURTAIN1, "RFXComCurtain1Message");
-					put(PacketType.BLINDS1, "RFXComBlinds1Message");
-					put(PacketType.RFY, "RFXComRfyMessage");
-					put(PacketType.SECURITY1, "RFXComSecurity1Message");
-					put(PacketType.CAMERA1, "RFXComCamera1Message");
-					put(PacketType.REMOTE_CONTROL, "RFXComRemoteControlMessage");
-					put(PacketType.THERMOSTAT1, "RFXComThermostat1Message");
-					put(PacketType.THERMOSTAT2, "RFXComThermostat2Message");
-					put(PacketType.THERMOSTAT3, "RFXComThermostat3Message");
-					put(PacketType.BBQ1,"RFXComBBQMessage");
-					put(PacketType.TEMPERATURE_RAIN, "RFXComTemperatureRainMessage");
-					put(PacketType.TEMPERATURE, "RFXComTemperatureMessage");
-					put(PacketType.HUMIDITY, "RFXComHumidityMessage");
-					put(PacketType.TEMPERATURE_HUMIDITY, "RFXComTemperatureHumidityMessage");
-					put(PacketType.BAROMETRIC, "RFXComBarometricMessage");
-					put(PacketType.TEMPERATURE_HUMIDITY_BAROMETRIC, "RFXComTemperatureHumidityBarometricMessage");
-					put(PacketType.RAIN, "RFXComRainMessage");
-					put(PacketType.WIND, "RFXComWindMessage");
-					put(PacketType.UV, "RFXComUVMessage");
-					put(PacketType.DATE_TIME, "RFXComDateTimeMessage");
-					put(PacketType.CURRENT, "RFXComCurrentMessage");
-					put(PacketType.ENERGY, "RFXComEnergyMessage");
-					put(PacketType.CURRENT_ENERGY, "RFXComCurrentEnergyMessage");
-					put(PacketType.POWER, "RFXComPowerMessage");
-					put(PacketType.WEIGHT, "RFXComWeightMessage");
-					put(PacketType.GAS, "RFXComGasMessage");
-					put(PacketType.WATER, "RFXComWaterMessage");
-					put(PacketType.RFXSENSOR, "RFXComRFXSensorMessage");
-					put(PacketType.RFXMETER, "RFXComRFXMeterMessage");
-					put(PacketType.FS20, "RFXComFS20Message");
-					put(PacketType.IO_LINES, "RFXComIOLinesMessage");
-				}
-			});
-				
 	/**
 	 * Command to reset RFXCOM controller.
 	 * 
@@ -93,36 +38,12 @@ public class RFXComMessageFactory {
 
 	
 	public static RFXComMessageInterface getMessageInterface(PacketType packetType) throws RFXComException {
-		
-		try {
-			String className = messageClasses.get(packetType);
-			Class<?> cl = Class.forName(classUrl + className);
-			return (RFXComMessageInterface) cl.newInstance();
-			
-		} catch (ClassNotFoundException e) {
-			throw new RFXComException("Message " + packetType + " not implemented", e);
-			
-		} catch (Exception e) {
-			throw new RFXComException(e);
-		} 
+		return packetType.createMessage();
 	}
 	
 	public static RFXComMessageInterface getMessageInterface(byte[] packet) throws RFXComException {
-		
-		PacketType packetType = getPacketType(packet[1]);
-		
-		try {
-			String className = messageClasses.get(packetType);
-			Class<?> cl = Class.forName(classUrl + className);
-			Constructor<?> c = cl.getConstructor(byte[].class);
-			return (RFXComMessageInterface) c.newInstance(packet);
-		
-		} catch (ClassNotFoundException e) {
-			throw new RFXComException("Message " + packetType + " not implemented", e);
-			
-		} catch (Exception e) {
-			throw new RFXComException(e);
-		} 
+		final PacketType packetType = getPacketType(packet[1]);
+		return getMessageInterface(packetType);
 	}
 
 	public static PacketType convertPacketType(String packetType)


### PR DESCRIPTION
This makes not-implemented messages much more visible in the code, the existing solution did not provide this.