### PR TITLE
RADIUS binding

### DIFF
--- a/bundles/binding/org.openhab.binding.radius/.classpath
+++ b/bundles/binding/org.openhab.binding.radius/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/binding/org.openhab.binding.radius/.project
+++ b/bundles/binding/org.openhab.binding.radius/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.radius</name>
+	<comment>This is the Radius binding of the open Home Automation Bus (openHAB)</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/binding/org.openhab.binding.radius/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.radius/META-INF/MANIFEST.MF
@@ -1,0 +1,29 @@
+Manifest-Version: 1.0
+Private-Package: org.openhab.binding.radius.internal
+Ignore-Package: org.openhab.binding.radius.internal
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-Name: openHAB Radius Binding
+Bundle-SymbolicName: org.openhab.binding.radius
+Bundle-Vendor: openHAB.org
+Bundle-Version: 1.7.0
+Bundle-ManifestVersion: 2
+Bundle-Description: This is the Radius binding of the open Home Aut
+ omation Bus (openHAB)
+Import-Package: org.apache.commons.lang,
+ org.openhab.core.binding,
+ org.openhab.core.events,
+ org.openhab.core.items,
+ org.openhab.core.library.items,
+ org.openhab.core.library.types,
+ org.openhab.core.types,
+ org.openhab.model.item.binding,
+ org.osgi.framework,
+ org.osgi.service.cm;version="1.4.0",
+ org.osgi.service.component,
+ org.osgi.service.event,
+ org.slf4j
+Export-Package: org.openhab.binding.radius
+Bundle-DocURL: http://www.openhab.org
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Service-Component: OSGI-INF/binding.xml, OSGI-INF/genericbindingprovider.xml
+Bundle-ClassPath: .

--- a/bundles/binding/org.openhab.binding.radius/OSGI-INF/binding.xml
+++ b/bundles/binding/org.openhab.binding.radius/OSGI-INF/binding.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2010-2015, openHAB.org and others. All rights reserved. 
+	This program and the accompanying materials are made available under the 
+	terms of the Eclipse Public License v1.0 which accompanies this distribution, 
+	and is available at http://www.eclipse.org/legal/epl-v10.html -->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0"
+	
+	name="org.openhab.binding.radius.binding" immediate="true"
+	configuration-pid="org.openhab.radius" configuration-policy="require">
+	<implementation class="org.openhab.binding.radius.internal.RadiusBinding" />
+
+	<service>
+		<provide interface="org.osgi.service.event.EventHandler" />
+		<provide interface="org.osgi.service.cm.ManagedService" />
+
+	</service>
+
+	<property name="service-pid" type="String" value="org.openhab.radius" />
+	<property name="event.topics" type="String" value="openhab/command/*" />
+
+	<reference bind="setEventPublisher" cardinality="1..1"
+		interface="org.openhab.core.events.EventPublisher" name="EventPublisher"
+		policy="dynamic" unbind="unsetEventPublisher" />
+	<reference bind="addBindingProvider" cardinality="1..n"
+		interface="org.openhab.binding.radius.RadiusBindingProvider" name="RadiusBindingProvider"
+		policy="dynamic" unbind="removeBindingProvider" />
+
+</scr:component>

--- a/bundles/binding/org.openhab.binding.radius/OSGI-INF/genericbindingprovider.xml
+++ b/bundles/binding/org.openhab.binding.radius/OSGI-INF/genericbindingprovider.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2015, openHAB.org and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.openhab.binding.radius.genericbindingprovider">
+   <implementation class="org.openhab.binding.radius.internal.RadiusGenericBindingProvider"/>
+   
+   <service>
+      <provide interface="org.openhab.model.item.binding.BindingConfigReader"/>
+      <provide interface="org.openhab.binding.radius.RadiusBindingProvider"/>
+   </service>
+   
+</scr:component>

--- a/bundles/binding/org.openhab.binding.radius/build.properties
+++ b/bundles/binding/org.openhab.binding.radius/build.properties
@@ -1,0 +1,6 @@
+source.. = src/main/java/,\
+           src/main/resources/
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/
+output.. = target/classes/

--- a/bundles/binding/org.openhab.binding.radius/pom.xml
+++ b/bundles/binding/org.openhab.binding.radius/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<parent>
+		<groupId>org.openhab.bundles</groupId>
+		<artifactId>binding</artifactId>
+		<version>1.7.0-SNAPSHOT</version>
+	</parent>
+
+	<properties>
+		<bundle.symbolicName>org.openhab.binding.radius</bundle.symbolicName>
+		<bundle.namespace>org.openhab.binding.radius</bundle.namespace>
+		<deb.name>openhab-addon-binding-Radius</deb.name>
+		<deb.description>openhab addon binding Radius</deb.description>
+	</properties>
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.openhab.binding</groupId>
+	<artifactId>org.openhab.binding.radius</artifactId>
+
+	<name>openHAB Radius Binding</name>
+
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.vafer</groupId>
+				<artifactId>jdeb</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/bundles/binding/org.openhab.binding.radius/src/main/java/org/openhab/binding/radius/RadiusBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.radius/src/main/java/org/openhab/binding/radius/RadiusBindingProvider.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.radius;
+
+import org.openhab.core.binding.BindingProvider;
+import org.openhab.core.items.Item;
+import java.util.List;
+
+/**
+ * @author Jan N. Klug
+ * @since 1.8.0
+ */
+public interface RadiusBindingProvider extends BindingProvider {
+
+	/**
+	 * Returns the Type of the Item identified by {@code itemName}
+	 * 
+	 * @param itemName
+	 *            the name of the item to find the type for
+	 * @return the type of the Item identified by {@code itemName}
+	 */
+	Class<? extends Item> getItemType(String itemName);
+
+	/**
+	 * Returns the RADIUS packet type of the Item identified by {@code itemName}
+	 * 
+	 * @param itemName
+	 *            the name of the item to find the type for
+	 * @return the RADIUS packet type of the Item identified by {@code itemName}
+	 */
+	public byte getRadiusType(String itemName);
+
+	/**
+	 * Returns the RADIUS attribute of the Item identified by {@code itemName}
+	 * 
+	 * @param itemName
+	 *            the name of the item to find the attribute for
+	 * @return the RADIUS attribute of the Item identified by {@code itemName}
+	 */
+	public byte getRadiusAttribute(String itemName);
+
+	/**
+	 * Returns the username for the Item identified by {@code itemName}
+	 * 
+	 * @param itemName
+	 *            the name of the item to find the username for
+	 * @return the username for the Item identified by {@code itemName}
+	 */
+
+	public String getUserName(String itemName);
+
+	/**
+	 * Returns the password for the Item identified by {@code itemName}
+	 * 
+	 * @param itemName
+	 *            the name of the item to find the password for
+	 * @return the password for the Item identified by {@code itemName}
+	 */
+	public String getPassword(String itemName);
+
+	/**
+	 * Returns all items which are mapped to a RADIUS-In-Binding
+	 * 
+	 * @return item which are mapped to a RADIUS-In-Binding
+	 */
+	List<String> getInBindingItemNames();
+
+}

--- a/bundles/binding/org.openhab.binding.radius/src/main/java/org/openhab/binding/radius/internal/Radius.java
+++ b/bundles/binding/org.openhab.binding.radius/src/main/java/org/openhab/binding/radius/internal/Radius.java
@@ -1,0 +1,461 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.openhab.binding.radius.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+import java.util.HashMap;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * This class defines RADIUS packet type codes
+ * 
+ * @author Jan N. Klug
+ * @since 1.8.0
+ */
+
+class RadiusTypeCode {
+	public static final byte ACCESS_REQUEST = 1;
+	public static final byte ACCESS_ACCEPT = 2;
+	public static final byte ACCESS_REJECT = 3;
+	public static final byte ACCOUNTING_REQUEST = 4;
+	public static final byte ACCOUNTING_RESPONSE = 5;
+	public static final byte ACCESS_CHALLENGE = 11;
+	public static final byte STATUS_SERVER = 12;
+	public static final byte STATUS_CLIENT = 13;
+
+	private static final Map<String, Byte> codeMap = Collections.unmodifiableMap(new HashMap<String, Byte>() {
+		private static final long serialVersionUID = -3311245286019033513L;
+		{
+			put("ACCESS_REQUEST", ACCESS_REQUEST);
+			put("ACCESS_ACCEPT", ACCESS_ACCEPT);
+			put("ACCESS_REJECT", ACCESS_REJECT);
+			put("ACCOUNTING_REQUEST", ACCOUNTING_REQUEST);
+			put("ACCOUNTING_RESPONSE", ACCOUNTING_RESPONSE);
+			put("ACCESS_CHALLENGE", ACCESS_CHALLENGE);
+			put("STATUS_SERVER", STATUS_SERVER);
+			put("STATUS_CLIENT", STATUS_CLIENT);
+		}
+	});
+
+	/**
+	 * get RADIUS type code value from string
+	 * 
+	 * @param code
+	 *            string representation of type code
+	 * @return numeric type code value or 0 if invalid
+	 */
+	public static byte getCode(final String code) {
+		if (codeMap.containsKey(code)) {
+			return codeMap.get(code);
+		} else {
+			return 0;
+		}
+	}
+
+}
+
+/**
+ * This class defines RADIUS packet type attributes.
+ * 
+ * @author Jan N. Klug
+ * @since 1.8.0
+ */
+
+class RadiusAttribute {
+	public static final byte USER_NAME = 1;
+	public static final byte USER_PASSWORD = 2;
+	public static final byte CHAP_PASSWORD = 3;
+	public static final byte NAS_IP_ADDRESS = 3;
+	public static final byte NAS_PORT = 5;
+	public static final byte SERVICE_TYPE = 6;
+	public static final byte FRAMED_PROTOCOL = 7;
+	public static final byte FRAMED_IP_ADDRESS = 8;
+	public static final byte FRAMED_IP_NETMASK = 9;
+	public static final byte FRAMED_ROUTING = 10;
+	public static final byte FILTER_ID = 11;
+	public static final byte FRAMED_MTU = 12;
+	public static final byte FRAMED_COMPRESSION = 13;
+	public static final byte LOGIN_IP_HOST = 14;
+	public static final byte LOGIN_SERVICE = 15;
+	public static final byte LOGIN_TCP_PORT = 16;
+	public static final byte REPLY_MESSAGE = 18;
+	public static final byte CALLBACK_NUMBER = 19;
+	public static final byte CALLBACK_ID = 20;
+	public static final byte FRAMED_ROUTE = 22;
+	public static final byte FRAMED_IPX_NETWORK = 23;
+	public static final byte STATE = 24;
+	public static final byte CLASS = 25;
+	public static final byte VENDOR_SPECIFIC = 26;
+	public static final byte SESSION_TIMEOUT = 27;
+	public static final byte IDLE_TIMEOUT = 28;
+	public static final byte TERMINATION_ACTION = 29;
+	public static final byte CALLED_STATION_ID = 30;
+	public static final byte CALLING_STATION_ID = 31;
+	public static final byte NAS_IDENTIFIER = 32;
+	public static final byte PROXY_STATE = 33;
+	public static final byte LOGIN_LAT_SERVICE = 34;
+	public static final byte LOGIN_LAT_NODE = 35;
+	public static final byte LOGIN_LAT_GROUP = 36;
+	public static final byte FRAMED_APPLETALK_LINK = 37;
+	public static final byte FRAMED_APPLETALK_NETWORK = 38;
+	public static final byte FRAMED_APPLETALK_ZONE = 39;
+	public static final byte CHAP_CHALLENGE = 60;
+	public static final byte NAS_PORT_TYPE = 61;
+	public static final byte PORT_LIMIT = 62;
+	public static final byte LOGIN_LAT_PORT = 63;
+
+	private static final Map<String, Byte> attributeMap = Collections.unmodifiableMap(new HashMap<String, Byte>() {
+		private static final long serialVersionUID = -7167689293970183229L;
+		{
+			// TODO: add ACCOUNTING attributes
+			put("USER_NAME", USER_NAME);
+			put("USER_PASSWORD", USER_PASSWORD);
+			put("CHAP_PASSWORD", CHAP_PASSWORD);
+			put("NAS_IP_ADDRESS", NAS_IP_ADDRESS);
+			put("NAS_PORT", NAS_PORT);
+			put("SERVICE_TYPE", SERVICE_TYPE);
+			put("FRAMED_PROTOCOL", FRAMED_PROTOCOL);
+			put("FRAMED_IP_ADDRESS", FRAMED_IP_ADDRESS);
+			put("FRAMED_IP_NETMASK", FRAMED_IP_NETMASK);
+			put("FRAMED_ROUTING", FRAMED_ROUTING);
+			put("FILTER_ID", FILTER_ID);
+			put("FRAMED_MTU", FRAMED_MTU);
+			put("FRAMED_COMPRESSION", FRAMED_COMPRESSION);
+			put("LOGIN_IP_HOST", LOGIN_IP_HOST);
+			put("LOGIN_SERVICE", LOGIN_SERVICE);
+			put("LOGIN_TCP_PORT", LOGIN_TCP_PORT);
+			put("REPLY_MESSAGE", REPLY_MESSAGE);
+			put("CALLBACK_NUMBER", CALLBACK_NUMBER);
+			put("CALLBACK_ID", CALLBACK_ID);
+			put("FRAMED_ROUTE", FRAMED_ROUTE);
+			put("FRAMED_IPX_NETWORK", FRAMED_IPX_NETWORK);
+			put("STATE", STATE);
+			put("CLASS", CLASS);
+			put("VENDOR_SPECIFIC", VENDOR_SPECIFIC);
+			put("SESSION_TIMEOUT", SESSION_TIMEOUT);
+			put("IDLE_TIMEOUT", IDLE_TIMEOUT);
+			put("TERMINATION_ACTION", TERMINATION_ACTION);
+			put("CALLED_STATION_ID", CALLED_STATION_ID);
+			put("CALLING_STATION_ID", CALLING_STATION_ID);
+			put("NAS_IDENTIFIER", NAS_IDENTIFIER);
+			put("PROXY_STATE", PROXY_STATE);
+			put("LOGIN_LAT_SERVICE", LOGIN_LAT_SERVICE);
+			put("LOGIN_LAT_NODE", LOGIN_LAT_NODE);
+			put("LOGIN_LAT_GROUP", LOGIN_LAT_GROUP);
+			put("FRAMED_APPLETALK_LINK", FRAMED_APPLETALK_LINK);
+			put("FRAMED_APPLETALK_NETWORK", FRAMED_APPLETALK_NETWORK);
+			put("FRAMED_APPLETALK_ZONE", FRAMED_APPLETALK_ZONE);
+			put("CHAP_CHALLENGE", CHAP_CHALLENGE);
+			put("NAS_PORT_TYPE", NAS_PORT_TYPE);
+			put("PORT_LIMIT", PORT_LIMIT);
+			put("LOGIN_LAT_PORT", LOGIN_LAT_PORT);
+		}
+	});
+
+	/**
+	 * get attribute value from string
+	 * 
+	 * @param attribute
+	 *            string representation of attribute
+	 * @return numeric attribute value or 0 if invalid
+	 */
+	public static byte getAttribute(final String attribute) {
+		if (attributeMap.containsKey(attribute)) {
+			return attributeMap.get(attribute);
+		} else {
+			return 0;
+		}
+	}
+
+}
+
+/**
+ * This class defines an attribute value pair for RADIUS
+ * 
+ * @author Jan N. Klug
+ * @since 1.8.0
+ */
+
+class RadiusAVP {
+	private byte attribute;
+	private byte[] value;
+
+	public RadiusAVP(byte attribute, String value) {
+		this.attribute = attribute;
+		this.value = value.getBytes();
+	}
+
+	public RadiusAVP(byte attribute, byte[] value) {
+		this.attribute = attribute;
+		this.value = value;
+	}
+
+	public byte length() {
+		return (byte) (2 + value.length);
+	}
+
+	public byte getType() {
+		return attribute;
+	}
+
+	public byte[] getRawValue() {
+		return value;
+	}
+
+	public String getValueString() {
+		return new String(value);
+	}
+
+	public long getValueLong() {
+		long ret = 0;
+		for (int i = 0; i < value.length; i++) {
+			ret = (ret << 8) + (value[i] & 0xff);
+		}
+		return ret;
+	}
+
+	public byte[] getAVPBytes() {
+		byte length = length();
+		byte[] avpBytes = new byte[length];
+		avpBytes[0] = attribute;
+		avpBytes[1] = length;
+		System.arraycopy(value, 0, avpBytes, 2, value.length);
+		return avpBytes;
+	}
+
+	public String toString() {
+		String s = "";
+		for (byte b : getAVPBytes()) {
+			s += String.format("%02X ", b);
+		}
+		return s;
+	}
+}
+
+/**
+ * This class defines a RADIUS packet
+ * 
+ * @author Jan N. Klug
+ * @since 1.8.0
+ */
+
+class RadiusPacket {
+	private byte typeCode;
+	private byte identifier;
+	private byte[] authenticator;
+	private ArrayList<RadiusAVP> avps;
+
+	private static byte nextIdentifier = 0;
+
+	/**
+	 * initialize new packet of type {@code typeCode}
+	 * 
+	 * @param typeCode
+	 *            a valid RADIUS packet type code
+	 */
+	public RadiusPacket(byte typeCode) {
+		authenticator = new byte[16];
+		System.arraycopy(String.format("%16d", System.currentTimeMillis() / 1000L).getBytes(), 0, authenticator, 0, 16);
+		this.typeCode = typeCode;
+		identifier = nextIdentifier++;
+		avps = new ArrayList<RadiusAVP>();
+	}
+
+	/**
+	 * parse an existing raw packet
+	 * 
+	 * @param rawData
+	 *            a valid full RADIUS packet
+	 */
+	public RadiusPacket(byte[] rawData) {
+		int len = rawData[2] * 256 + rawData[3];
+		int cnt = 20;
+		typeCode = rawData[0];
+		identifier = rawData[1];
+		authenticator = new byte[16];
+		System.arraycopy(rawData, 4, authenticator, 0, 16);
+		avps = new ArrayList<RadiusAVP>();
+		while (cnt < len) {
+			byte alen = rawData[cnt + 1];
+			byte attribute = rawData[cnt];
+			byte[] value = new byte[alen - 2];
+			System.arraycopy(rawData, cnt + 2, value, 0, alen - 2);
+			addAttribute(new RadiusAVP(attribute, value));
+			cnt += alen;
+		}
+	}
+
+	/**
+	 * get the RADIUS type code of this packet
+	 * 
+	 * @return the RADIUS type code
+	 */
+	public byte getTypeCode() {
+		return typeCode;
+	}
+
+	/**
+	 * add a new attribute to this RADIUS packet
+	 * 
+	 * @param avp
+	 *            a valid RADIUS attribute-value pair
+	 */
+	public void addAttribute(RadiusAVP avp) {
+		avps.add(avp);
+	}
+
+	/**
+	 * add special attribute PAP password
+	 * 
+	 * @param password
+	 *            clear-text password
+	 * @param secret
+	 *            shared secret with the server
+	 */
+	public void encodePapPassword(String password, String secret) {
+		int length;
+		byte[] bn = new byte[16];
+		MessageDigest md5;
+
+		// get length as multiple of 16, maximum 128
+		if (password.length() % 16 == 0) {// already multiple of 16
+			length = password.length();
+		} else {
+			length = ((int) (password.length() / 16) + 1) * 16;
+		}
+		if (length > 128) {
+			length = 128;
+		}
+		// copy old value and pad
+		byte[] value = new byte[length];
+		System.arraycopy(password.getBytes(), 0, value, 0, password.length());
+		for (int i = password.length(); i < length; i++) {
+			value[i] = 0;
+		}
+		try {
+			md5 = MessageDigest.getInstance("MD5");
+			md5.update(secret.getBytes());
+			md5.update(authenticator);
+			for (int i = 0; i < length; i += 16) {
+				bn = md5.digest();
+				md5.reset();
+				md5.update(secret.getBytes());
+				for (int j = 0; j < 16; j++) {
+					value[i + j] = (byte) (value[i + j] ^ bn[j]);
+					md5.update(value[i + j]);
+				}
+			}
+			addAttribute(new RadiusAVP(RadiusAttribute.USER_PASSWORD, value));
+		} catch (NoSuchAlgorithmException e) {
+		}
+	}
+
+	/**
+	 * show RADIUS attributes of this package
+	 * 
+	 * @return hex string of all attributes (one per line)
+	 */
+	public String showAttributes() {
+		String s = "";
+		for (RadiusAVP avp : avps) {
+			s += avp.toString() + "\n";
+		}
+		return s;
+	}
+
+	/**
+	 * get total length of the full RADIUS packet
+	 * 
+	 * @return packet length
+	 */
+	public int getRawPacketLength() {
+		int length = 20; // 1 byte type, 1 byte identifier, 2 bytes length, 16 bytes authentictor
+		for (RadiusAVP avp : avps) {
+			length += avp.length();
+		}
+		return length;
+	}
+
+	/**
+	 * get the full RADIUS packet as byte-array
+	 * 
+	 * @return full packet data
+	 */
+	public byte[] getRawPacket() {
+		int next = 20;
+		int length = getRawPacketLength();
+
+		byte[] packet = new byte[length];
+
+		packet[0] = typeCode;
+		packet[1] = identifier;
+		packet[2] = (byte) (length / 256);
+		packet[3] = (byte) (length % 256);
+		System.arraycopy(authenticator, 0, packet, 4, 16);
+
+		for (RadiusAVP avp : avps) {
+			int len = avp.length();
+			System.arraycopy(avp.getAVPBytes(), 0, packet, next, len);
+			next += len;
+		}
+
+		return packet;
+	}
+
+	/**
+	 * get a attribute value pair from this packet
+	 * 
+	 * @param attributeCode
+	 *            of attribute
+	 * @return attribute-value pair or null if not found
+	 */
+	public RadiusAVP getAttribute(byte attributeCode) {
+		for (RadiusAVP avp : avps) {
+			if (avp.getType() == attributeCode) {
+				return avp;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * check if attribute exists in this package
+	 * 
+	 * @param attributeCode
+	 *            attribute to check
+	 * @return true if exists
+	 */
+	public boolean hasAttribute(byte attributeCode) {
+		for (RadiusAVP avp : avps) {
+			if (avp.getType() == attributeCode) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * convert full packet to string
+	 * 
+	 * @return hex string and total number of bytes
+	 */
+	public String toString() {
+		String s = "";
+		for (byte b : getRawPacket()) {
+			s += String.format("%02X ", b);
+		}
+		s += "(" + getRawPacketLength() + " b)";
+		return s;
+	}
+
+}

--- a/bundles/binding/org.openhab.binding.radius/src/main/java/org/openhab/binding/radius/internal/RadiusBinding.java
+++ b/bundles/binding/org.openhab.binding.radius/src/main/java/org/openhab/binding/radius/internal/RadiusBinding.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.radius.internal;
+
+import org.openhab.binding.radius.RadiusBindingProvider;
+
+import org.apache.commons.lang.StringUtils;
+import org.openhab.core.binding.AbstractActiveBinding;
+import org.openhab.core.items.Item;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.SwitchItem;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.types.UnDefType;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.osgi.service.cm.ManagedService;
+import org.osgi.service.cm.ConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.net.DatagramSocket;
+import java.net.DatagramPacket;
+import java.io.IOException;
+import java.util.Dictionary;
+
+/**
+ * RADIUS server communication.
+ * 
+ * @author Jan N. Klug
+ * @since 1.8
+ */
+public class RadiusBinding extends AbstractActiveBinding<RadiusBindingProvider> implements ManagedService {
+
+	private static final Logger logger = LoggerFactory.getLogger(RadiusBinding.class);
+
+	/**
+	 * the refresh interval which is used to poll values from the Radius server (optional, defaults to 60000ms)
+	 */
+	private long refreshInterval = 60000;
+
+	/**
+	 * the address of the Radius servers (optional, defaults to 127.0.0.1)
+	 */
+	InetAddress radiusServer;
+
+	/**
+	 * the shared secret for the Radius server (required)
+	 */
+	private String sharedSecret = "";
+
+	public RadiusBinding() {
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public void updated(Dictionary<String, ?> configuration) throws ConfigurationException {
+		String refreshIntervalString = (String) configuration.get("refresh");
+		if (StringUtils.isNotBlank(refreshIntervalString)) {
+			refreshInterval = Long.parseLong(refreshIntervalString);
+		}
+
+		try {
+			String radiusServerAddress = (String) configuration.get("server");
+			if (StringUtils.isNotBlank(radiusServerAddress)) {
+				radiusServer = InetAddress.getByName(radiusServerAddress);
+			} else {
+				radiusServer = InetAddress.getByName("127.0.0.1");
+			}
+		} catch (UnknownHostException e) {
+			logger.warn("Could not determine RADIUS server address");
+		}
+
+		sharedSecret = (String) configuration.get("sharedSecret");
+
+		if (StringUtils.isNotBlank(sharedSecret)) {
+			setProperlyConfigured(true);
+		} else {
+			setProperlyConfigured(false);
+		}
+
+		logger.debug("server={}, secret={}, refresh={}", radiusServer, sharedSecret, refreshInterval);
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	protected long getRefreshInterval() {
+		return refreshInterval;
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	protected String getName() {
+		return "Radius Refresh Service";
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	protected void execute() {
+		for (RadiusBindingProvider provider : providers) {
+			for (String itemName : provider.getInBindingItemNames()) {
+				logger.debug("Item '{}' is about to be refreshed", itemName);
+				RadiusPacket p = new RadiusPacket(provider.getRadiusType(itemName));
+				RadiusPacket pRet = null;
+				p.addAttribute(new RadiusAVP(RadiusAttribute.USER_NAME, provider.getUserName(itemName)));
+				p.encodePapPassword(provider.getPassword(itemName), sharedSecret);
+				try {
+					DatagramSocket clientSocket = new DatagramSocket();
+
+					byte[] receiveData = new byte[1024];
+					DatagramPacket sendPacket = new DatagramPacket(p.getRawPacket(), p.getRawPacketLength(),
+							radiusServer, 1812);
+					logger.trace("Sent: {}", p);
+					clientSocket.send(sendPacket);
+					DatagramPacket receivePacket = new DatagramPacket(receiveData, receiveData.length);
+					clientSocket.receive(receivePacket);
+					clientSocket.close();
+					pRet = new RadiusPacket(receivePacket.getData());
+					logger.trace("Received: {}", pRet);
+				} catch (IOException e) {
+					logger.warn("Error while sending packet to server");
+				}
+
+				if (pRet == null) {
+					logger.warn("Received empty or no packet");
+					return;
+				}
+
+				Class<? extends Item> itemType = provider.getItemType(itemName);
+				State state = null;
+				byte attr = provider.getRadiusAttribute(itemName);
+
+				if ((attr == 0) || pRet.hasAttribute(attr)) {
+					if (itemType.isAssignableFrom(StringItem.class)) {
+						if (attr == 0) {
+							state = UnDefType.UNDEF;
+						} else {
+							state = new StringType(pRet.getAttribute(attr).getValueString());
+						}
+					} else if (itemType.isAssignableFrom(NumberItem.class)) {
+						if (attr == 0) {
+							state = UnDefType.UNDEF;
+						} else {
+							state = new DecimalType(pRet.getAttribute(attr).getValueLong());
+						}
+					} else if (itemType.isAssignableFrom(SwitchItem.class)) {
+						if (p.getTypeCode() == RadiusTypeCode.ACCESS_REQUEST) {
+							if (pRet.getTypeCode() == RadiusTypeCode.ACCESS_ACCEPT) {
+								state = OnOffType.ON;
+							} else if (pRet.getTypeCode() == RadiusTypeCode.ACCESS_REJECT) {
+								state = OnOffType.OFF;
+							} else {
+								state = UnDefType.UNDEF;
+							}
+						}
+					}
+				} else {
+					state = UnDefType.UNDEF;
+				}
+
+				eventPublisher.postUpdate(itemName, state);
+
+			}
+
+		}
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	protected void internalReceiveCommand(String itemName, Command command) {
+		// TODO: add out-binding
+		logger.debug("internalReceiveCommand({},{}) is called!", itemName, command);
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	protected void internalReceiveUpdate(String itemName, State newState) {
+		// TODO: add OUT binding
+		logger.debug("internalReceiveUpdate({},{}) is called!", itemName, newState);
+	}
+
+}

--- a/bundles/binding/org.openhab.binding.radius/src/main/java/org/openhab/binding/radius/internal/RadiusGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.radius/src/main/java/org/openhab/binding/radius/internal/RadiusGenericBindingProvider.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.radius.internal;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.openhab.binding.radius.RadiusBindingProvider;
+import org.openhab.core.binding.BindingConfig;
+import org.openhab.core.items.Item;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.SwitchItem;
+import org.openhab.model.item.binding.AbstractGenericBindingProvider;
+import org.openhab.model.item.binding.BindingConfigParseException;
+
+import java.util.List;
+import java.util.ArrayList;
+
+/**
+ * This class is responsible for parsing the binding configuration.
+ * 
+ * @author Jan N. Klug
+ * @since 1.8.0
+ */
+public class RadiusGenericBindingProvider extends AbstractGenericBindingProvider implements RadiusBindingProvider {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public String getBindingType() {
+		return "radius";
+	}
+
+	/** {@link Pattern} which matches an In-Binding */
+	private static final Pattern IN_BINDING_PATTERN = Pattern
+			.compile("<([0-9.:a-zA-Z]+),([0-9.a-zA-Z]+),(ACCESS_REQUEST)");
+	private static final Pattern IN_BINDING_ATTRIBUTE_PATTERN = Pattern
+			.compile("<([0-9.:a-zA-Z]+),([0-9.a-zA-Z]+),(ACCESS_REQUEST),([_0-9.a-zA-Z]+)");
+
+	// TODO add OUT binding
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	public void validateItemType(Item item, String bindingConfig) throws BindingConfigParseException {
+		if (!(item instanceof StringItem || item instanceof NumberItem || item instanceof SwitchItem)) {
+			throw new BindingConfigParseException(
+					"Item '"
+							+ item.getName()
+							+ "' is of type '"
+							+ item.getClass().getSimpleName()
+							+ "', only StringItems, NumberItems and SwitchItems are allowed - please check your *.items configuration");
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void processBindingConfiguration(String context, Item item, String bindingConfig)
+			throws BindingConfigParseException {
+		super.processBindingConfiguration(context, item, bindingConfig);
+
+		if (bindingConfig != null) {
+			RadiusBindingConfig config = new RadiusBindingConfig();
+
+			Matcher matcher = IN_BINDING_ATTRIBUTE_PATTERN.matcher(bindingConfig);
+
+			if (!matcher.matches()) { // is without attribute
+				matcher = IN_BINDING_PATTERN.matcher(bindingConfig);
+				if (!matcher.matches()) { // does not match anythig at all: invalid config
+					throw new BindingConfigParseException("bindingConfig '" + bindingConfig
+							+ "' doesn't contain a valid binding configuration");
+				}
+			}
+
+			config.itemType = item.getClass();
+			config.direction = RadiusBindingConfig.IN;
+			config.user = matcher.group(1).toString();
+			config.password = matcher.group(2).toString();
+			config.radiusType = RadiusTypeCode.getCode(matcher.group(3).toString());
+
+			if (matcher.groupCount() == 4) {
+				config.radiusAttribute = RadiusAttribute.getAttribute(matcher.group(4).toString().toUpperCase());
+			} else {
+				config.radiusAttribute = 0;
+			}
+
+			addBindingConfig(item, config);
+		}
+
+	}
+
+	/**
+	 * This is a helper class holding binding specific configuration details
+	 * 
+	 * @author Jan N. Klug
+	 * @since 1.8.0
+	 */
+	class RadiusBindingConfig implements BindingConfig {
+		// put member fields here which holds the parsed values
+		public static final byte IN = 0;
+		public static final byte OUT = 1;
+
+		Class<? extends Item> itemType;
+		public String user;
+		public String password;
+		public byte radiusType;
+		public byte radiusAttribute;
+		public byte direction;
+
+		/**
+		 * put whole configuration in String
+		 * 
+		 * @return configuration string
+		 */
+		public String toString() {
+			return "itemType=" + itemType + " user=" + user + " pass=" + password + "type=" + radiusType + "attribute="
+					+ radiusAttribute;
+		}
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	public Class<? extends Item> getItemType(String itemName) {
+		RadiusBindingConfig config = (RadiusBindingConfig) bindingConfigs.get(itemName);
+		return config != null ? config.itemType : null;
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	public byte getRadiusType(String itemName) {
+		RadiusBindingConfig config = (RadiusBindingConfig) bindingConfigs.get(itemName);
+		return config != null ? config.radiusType : 0;
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	public byte getRadiusAttribute(String itemName) {
+		RadiusBindingConfig config = (RadiusBindingConfig) bindingConfigs.get(itemName);
+		return config != null ? config.radiusAttribute : 0;
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	public String getUserName(String itemName) {
+		RadiusBindingConfig config = (RadiusBindingConfig) bindingConfigs.get(itemName);
+		return config != null ? config.user : "";
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	public String getPassword(String itemName) {
+		RadiusBindingConfig config = (RadiusBindingConfig) bindingConfigs.get(itemName);
+		return config != null ? config.password : "";
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	public List<String> getInBindingItemNames() {
+		List<String> inBindings = new ArrayList<String>();
+		for (String itemName : bindingConfigs.keySet()) {
+			RadiusBindingConfig radiusConfig = (RadiusBindingConfig) bindingConfigs.get(itemName);
+			if (radiusConfig.direction == RadiusBindingConfig.IN) {
+				inBindings.add(itemName);
+			}
+		}
+		return inBindings;
+	}
+
+}

--- a/bundles/binding/org.openhab.binding.radius/src/main/resources/readme.txt
+++ b/bundles/binding/org.openhab.binding.radius/src/main/resources/readme.txt
@@ -1,0 +1,1 @@
+Bundle resources go in here!


### PR DESCRIPTION
This PR is not considered to be ready for merging. This is to get review and comments to the general design.

openhab.cfg:
    radius.server=<address of server, required>
    radius.sharedsecret=<shared secret of the server, required>
    radius.refresh=<refresh-interval, defaults to 60000, optional>

Item:
  radius="<username,password,ACCESS_REQUEST,optional:attribute"

Currently only ACCESS_REQUEST is supported, later versions may include STATUS_SERVER or ACCOUNTING_REQUEST. Only PAP is supported for authentication.

SwitchItem: ON if ACCESS_ACCEPT, OFF if ACCESS_REJECT
NumberItem/StringItem: if the optional attribute parameter is present, the value of the atttribute in the response-message is stored in the item

Later version may include accounting, with > as direction parameter or CHAP as authentication method.

(should be merged in 1.8.0 develop)