### PR TITLE
quick-fix for issue #2552, as suggest as option 2

### DIFF
--- a/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/internal/engine/RuleTriggerManager.java
+++ b/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/internal/engine/RuleTriggerManager.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.openhab.core.items.Item;
+import org.openhab.core.library.items.StringItem;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
@@ -206,13 +207,21 @@ public class RuleTriggerManager {
 							ChangedEventTrigger ct = (ChangedEventTrigger) t;						
 							if(ct.getItem().equals(item.getName())) {
 								if(ct.getOldState()!=null) {
-									State triggerOldState = TypeParser.parseState(item.getAcceptedDataTypes(), ct.getOldState());
+									String stateString = ct.getOldState();
+									if (stateString.startsWith("\"") && stateString.endsWith("\"") && (item instanceof StringItem)) {
+										stateString = stateString.substring(1,stateString.length()-1);
+									}
+									State triggerOldState = TypeParser.parseState(item.getAcceptedDataTypes(), stateString);
 									if(!oldState.equals(triggerOldState)) {
 										continue;
 									}								
 								}
 								if(ct.getNewState()!=null) {
-									State triggerNewState = TypeParser.parseState(item.getAcceptedDataTypes(), ct.getNewState());
+									String stateString = ct.getNewState();
+									if (stateString.startsWith("\"") && stateString.endsWith("\"") && (item instanceof StringItem)) {
+										stateString = stateString.substring(1,stateString.length()-1);
+									}
+									State triggerNewState = TypeParser.parseState(item.getAcceptedDataTypes(), stateString);
 									if(!newState.equals(triggerNewState)) {
 										continue;
 									}								


### PR DESCRIPTION
This enables openHAB to behave as expected for changed-from-to-triggers in rules with string items. If present, double-quotes at the end and beginning of the states are removed.