### PR TITLE
Zwave reinitialise node

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
@@ -314,6 +314,7 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 
 				// Add the action buttons
 				record.addAction("Heal", "Heal Node");
+				record.addAction("Initialise", "Reinitialise Node");
 				
 				// Add the delete button if the node is not "operational"
 				if(canDelete) {
@@ -961,6 +962,16 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 					// Write the node to disk
 					ZWaveNodeSerializer nodeSerializer = new ZWaveNodeSerializer();
 					nodeSerializer.SerializeNode(node);
+				}
+
+				if (action.equals("Initialise")) {
+					logger.debug("NODE {}: re-initialising node", nodeId);
+
+					// Delete the saved XML
+					ZWaveNodeSerializer nodeSerializer = new ZWaveNodeSerializer();
+					nodeSerializer.DeleteNode(nodeId);
+					
+					this.zController.reinitialiseNode(nodeId);
 				}
 
 				if (action.equals("Delete")) {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
@@ -321,9 +321,6 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 					record.addAction("Delete", "Delete Node");
 				}
 				records.add(record);
-
-				// This needs to be removed - temporary only until it's added to initialisation code.
-				record.addAction("Version", "Version Info");
 			}
 			return records;
 		}
@@ -977,20 +974,6 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 				if (action.equals("Delete")) {
 					logger.debug("NODE {}: Delete node", nodeId);
 					this.zController.requestRemoveFailedNode(nodeId);
-				}
-
-				// This is temporary
-				// It should be in the startup code, but that needs refactoring
-				if (action.equals("Version")) {
-					logger.debug("NODE {}: Get node version", nodeId);
-					ZWaveVersionCommandClass versionCommandClass = (ZWaveVersionCommandClass) node
-							.getCommandClass(CommandClass.VERSION);
-					if (versionCommandClass == null) {
-						return;
-					}
-
-					// Request the version report for this node
-					this.zController.sendData(versionCommandClass.getVersionMessage());
 				}
 
 				// Return here as afterwards we assume there are more elements

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -508,7 +508,16 @@ public class ZWaveController {
 		}
 		logger.info("Disconnected from serial port");
 	}
-	
+
+	/**
+	 * Removes the node, and restarts the initialisation sequence
+	 * @param nodeId
+	 */
+	public void reinitialiseNode(int nodeId) {
+		this.zwaveNodes.remove(nodeId);
+		addNode(nodeId);
+	}
+
 	/**
 	 * Add a node to the controller
 	 * @param nodeId the node number to add


### PR DESCRIPTION
This provides a function within HABmin to allow a node to be reinitialised without restarting the binding.