### PR TITLE
InsteonPLM binding: support the standard pre-2014 InsteonHub

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/IOStream.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/IOStream.java
@@ -8,14 +8,18 @@
  */
 package org.openhab.binding.insteonplm.internal.driver;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
 import org.openhab.binding.insteonplm.internal.driver.hub.HubIOStream;
+import org.openhab.binding.insteonplm.internal.driver.hub.OldHubIOStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abstract class for implementation for I/O stream with anything that looks
- * like a PLM (e.g. the insteon hub)
+ * like a PLM (e.g. the insteon hubs, serial/usb connection etc)
  * 
  * @author Bernd Pfrommer
  * @author Daniel Pfrommer
@@ -23,18 +27,56 @@ import org.openhab.binding.insteonplm.internal.driver.hub.HubIOStream;
  */
 
 public abstract class IOStream {
+	private static final Logger logger = LoggerFactory.getLogger(IOStream.class);
 	protected InputStream	m_in	= null;
 	protected OutputStream	m_out	= null;
+
 	/**
-	 * Getter for input stream from modem/hub
-	 * @return input stream for incoming data
+	 * read data from iostream
+	 * @param b byte array (output)
+	 * @param offset offset for placement into byte array
+	 * @param readSize size to read
+	 * @return number of bytes read
 	 */
-	public InputStream in() { return m_in; }
+	public int read(byte [] b, int offset, int readSize) {
+		int len = 0;
+		while (len < 1) {
+			try {
+				len = m_in.read(b, offset, readSize);
+			} catch (IOException e) {
+				logger.trace("got exception while reading: {}", e.getMessage());
+				while (!reconnect()) {
+					try {
+						logger.trace("sleeping before reconnecting");
+						Thread.sleep(10000);
+					} catch (InterruptedException ie) {
+						logger.warn("interrupted while sleeping on read reconnect");
+					}
+				}
+			}
+		}
+		return (len);
+	}
+
 	/**
-	 * Getter for output stream for outgoing data to the modem/hub
-	 * @return
+	 * Write data to iostream
+	 * @param b byte array to write
 	 */
-	public OutputStream out() { return m_out; }
+	public void write(byte [] b) {
+		try {
+			m_out.write(b);
+		} catch (IOException e) {
+			logger.trace("got exception while writing: {}", e.getMessage());
+			while (!reconnect()) {
+				try {
+					logger.trace("sleeping before reconnecting");
+					Thread.sleep(10000);
+				} catch (InterruptedException ie) {
+					logger.warn("interrupted while sleeping on write reconnect");
+				}
+			}
+		}
+	}
 	
 	/**
 	 * Opens the IOStream
@@ -45,6 +87,16 @@ public abstract class IOStream {
 	 * Closes the IOStream
 	 */
 	public abstract void close();
+
+	
+	/**
+	 * reconnects the stream
+	 * @return true if reconnect succeeded
+	 */
+	private synchronized boolean reconnect() {
+		close();
+		return (open());
+	}
 	
 	/**
 	 * Creates an IOStream from an allowed config string:
@@ -53,7 +105,7 @@ public abstract class IOStream {
 	 * 
 	 * /hub2/user:password@myinsteonhub.mydomain.com:25105,poll_time=1000 (insteon hub2 (2014))
 	 * 
-	 * /hub/user:password@myinsteonhub.mydomain.com:9761    (pre-2014 hub with raw tcp PLM access)
+	 * /hub/myinsteonhub.mydomain.com:9761
 	 * 
 	 * @param config
 	 * @return reference to IOStream
@@ -61,40 +113,60 @@ public abstract class IOStream {
 
 	public static IOStream s_create(String config) {
 		if (config.startsWith("/hub2/")) {
-			config = config.substring(6); //Get rid of the /hub2/ part
-			
-			String user 	= null;
-			String pass 	= null;
-			String host 	= null;
-			int port		= 25105;
-			int pollTime	= 1000; // poll time in milliseconds
-			
-			String[] parts = config.split(","); // split off options at the end
-			
-			//Parse the first part, the address
-			String[] adr = parts[0].split("@");
-			String[] hostPort;
-			if (adr.length > 1) {
-				String[] userPass = adr[0].split(":");
-				user = userPass[0];
-				pass = userPass[1];
-				hostPort = adr[1].split(":");
-			} else {
-				hostPort = parts[0].split(":");
-			}
-			
-			host = hostPort[0];
-			if (hostPort.length > 1) port = Integer.parseInt(hostPort[1]);
-			
-			// check if additional options are given
-			if (parts.length > 1) {
-				if (parts[1].trim().startsWith("poll_time")) {
-					pollTime = Integer.parseInt(parts[1].split("=")[1].trim());
-				}
-			}
-			return new HubIOStream(host, port, pollTime, user, pass);
+			return makeHub2014Stream(config);
 		} else if (config.startsWith("/hub/")) {
-			throw new IllegalArgumentException("old-style hub not implemented yet!");
+			return makeOldHubStream(config);
 		} else return new SerialIOStream(config);
+	}
+	
+	private static HubIOStream makeHub2014Stream(String config) {
+		config = config.substring(6); //Get rid of the /hub2/ part
+		String user 	= null;
+		String pass 	= null;
+		int pollTime	= 1000; // poll time in milliseconds
+		
+		String[] parts = config.split(","); // split off options at the end
+		
+		//Parse the first part, the address
+		String[] adr = parts[0].split("@");
+		String[] hostPort;
+		if (adr.length > 1) {
+			String[] userPass = adr[0].split(":");
+			user = userPass[0];
+			pass = userPass[1];
+			hostPort = adr[1].split(":");
+		} else {
+			hostPort = parts[0].split(":");
+		}
+		HostPort hp = new HostPort(hostPort, 25105);
+		// check if additional options are given
+		if (parts.length > 1) {
+			if (parts[1].trim().startsWith("poll_time")) {
+				pollTime = Integer.parseInt(parts[1].split("=")[1].trim());
+			}
+		}
+		return new HubIOStream(hp.host, hp.port, pollTime, user, pass);
+	}
+
+	private static OldHubIOStream makeOldHubStream(String config) {
+		config 	= config.substring(5);		//Get rid of the /hub/ part
+		String[] parts = config.split(","); // split off options at the end, if any
+		String[] hostPort = parts[0].split(":");
+		HostPort hp = new HostPort(hostPort, 9761);
+		return new OldHubIOStream(hp.host, hp.port);
+	}
+
+	private static class HostPort {
+		public	String	host = "localhost";
+		public	int		port = -1;
+		HostPort(String[] hostPort, int defaultPort) {
+			port = defaultPort;
+			host = hostPort[0];
+			try {
+				if (hostPort.length > 1) port = Integer.parseInt(hostPort[1]);
+			} catch (NumberFormatException e) {
+				logger.error("bad format for port {} ", hostPort[1], e);
+			}
+		}
 	}
 }

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/hub/OldHubIOStream.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/hub/OldHubIOStream.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.insteonplm.internal.driver.hub;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import org.openhab.binding.insteonplm.internal.driver.IOStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implements IOStream for the older hubs (pre 2014)
+ * @author Bernd Pfrommer
+ * @since 1.7.0
+ *
+ */
+public class OldHubIOStream extends IOStream {
+	private static final Logger logger = LoggerFactory.getLogger(OldHubIOStream.class);
+
+	private String	m_host 						= null;
+	private int		m_port 						= -1;
+	private Socket	m_socket					= null;
+
+	/**
+	 * Constructor
+	 * @param host	host name of hub device
+	 * @param port	port to connect to
+	 */
+	public OldHubIOStream(String host, int port) {
+		m_host		= host;
+		m_port		= port;
+	}
+	
+	@Override
+	public boolean open() {
+		if (m_host == null || m_port < 0) {
+			logger.error("tcp connection to hub not properly configured!");
+			return (false);
+		}
+		try {
+			m_socket = new Socket(m_host, m_port);
+			m_in	 = m_socket.getInputStream();
+			m_out 	 = m_socket.getOutputStream();
+		} catch (UnknownHostException e) {
+			logger.error("unknown host name: {}", m_host, e);
+			return (false);
+		} catch (IOException e) {
+			logger.error("cannot open connection to {} port {}: ", m_host, m_port, e);
+			return (false);
+		}
+		return true;
+	}
+
+	@Override
+	public void close() {
+		try {
+			if (m_in != null) m_in.close();
+			if (m_out != null) m_out.close();
+			if (m_socket != null) m_socket.close();
+		} catch (IOException e) {
+			logger.error("failed to close streams", e);
+		}
+	}
+}

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1414,13 +1414,17 @@ tcp:refreshinterval=250
 # insteonplm:port_0=/dev/ttyS0    (Linux, with plain old serial modem)
 # insteonplm:port_0=/dev/ttyUSB0  (Linux, with usb based PLM modem)
 # insteonplm:port_0=COM1	  (Windows, with serial/usb modem on COM1)
+
 #
 # to connect to an Insteon Hub2 (the 2014 version) on port 25105, with
 # a poll interval of 1000ms = 1sec:
 #
 # insteonplm:port_0=/hub2/my_user_name:my_password@myinsteonhub.mydomain:25105,poll_time=1000
+
 #
-#insteonplm:port_0=/dev/insteon
+# to connect to the raw tcp feed on an older Insteon Hub (pre 2014 version) on port 9761
+#
+# insteonplm:port_0=/hub/localhost:9761
 
 # Poll interval (optional, in milliseconds, defaults to 300000).
 # Poll too often and you will overload the insteon network,


### PR DESCRIPTION
The InsteonPLM binding now also supports the "old" InsteonHub via its raw tcp port. (The 2014 Hub is already supported, but only through its http interface). The following line in openhab.cfg will connect to the raw tcp feed of the insteonhub:

insteonplm:port_0=/hub/localhost:9761