### PR TITLE
Set max value of saturation and brightness to 254 as defined by Hue API

### DIFF
--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBinding.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBinding.java
@@ -144,7 +144,7 @@ public class HueBinding extends AbstractActiveBinding<HueBindingProvider> implem
 							if (deviceConfig.getType().equals(BindingType.brightness)) {
 								if ((bulb.getIsOn() == true) && (bulb.getIsReachable() == true)) {
 									// Only postUpdate when bulb is on, otherwise dimmer item is not retaining state and shows to max brightness value
-									PercentType newPercent = new PercentType((int)Math.round((bulb.getBrightness() * (double)100) / (double)255));
+									PercentType newPercent = new PercentType((int)Math.round((bulb.getBrightness() * (double)100) / (double) HueBulb.MAX_BRIGHTNESS));
 									if ((deviceConfig.itemStatePercentType == null) || (deviceConfig.itemStatePercentType.equals(newPercent) == false)) {
 										eventPublisher.postUpdate(hueItemName, newPercent);
 										deviceConfig.itemStatePercentType = newPercent;
@@ -154,8 +154,8 @@ public class HueBinding extends AbstractActiveBinding<HueBindingProvider> implem
 								if ((bulb.getIsOn() == true) && (bulb.getIsReachable() == true)) {
 									// Only postUpdate when bulb is on, otherwise color item is not retaining state and shows to max brightness value
 									DecimalType decimalHue = new DecimalType(bulb.getHue() / (double)182);
-									PercentType percentBrightness = new PercentType((int)Math.round((bulb.getBrightness() * (double)100) / (double)255));
-									PercentType percentSaturation = new PercentType((int)Math.round((bulb.getSaturation() * (double)100) / (double)255));
+									PercentType percentBrightness = new PercentType((int)Math.round((bulb.getBrightness() * (double)100) / (double) HueBulb.MAX_BRIGHTNESS));
+									PercentType percentSaturation = new PercentType((int)Math.round((bulb.getSaturation() * (double)100) / (double) HueBulb.MAX_SATURATION));
 									HSBType newHsb = new HSBType(decimalHue, percentSaturation, percentBrightness);
 									if ((deviceConfig.itemStateHSBType == null) || (deviceConfig.itemStateHSBType.equals(newHsb) == false)) {
 										eventPublisher.postUpdate(hueItemName, newHsb);
@@ -234,7 +234,7 @@ public class HueBinding extends AbstractActiveBinding<HueBindingProvider> implem
 				int resultingValue = bulb.decreaseBrightness(deviceConfig.getStepSize());
 				eventPublisher.postUpdate(itemName, new PercentType(resultingValue));
 			} else if ((command instanceof PercentType) && !(command instanceof HSBType)) {
-				bulb.setBrightness((int)Math.round((double)255 / (double)100 * ((PercentType) command).intValue()));
+				bulb.setBrightness((int)Math.round((double)HueBulb.MAX_BRIGHTNESS / (double)100 * ((PercentType) command).intValue()));
 			}
 		}
 

--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java
@@ -144,7 +144,7 @@ public class HueSettings {
 	 * 
 	 * @param deviceId
 	 *            The bulb id the bridge has filed the bulb under.
-	 * @return The brightness as a value from 0 - 255
+	 * @return The brightness as a value from 0 - {@link HueBulb#MAX_BRIGHTNESS}
 	 */
 	public int getBrightness(String deviceId) {
 		if (settingsData == null) {
@@ -184,7 +184,7 @@ public class HueSettings {
 	 * 
 	 * @param deviceId
 	 *            The bulb id the bridge has filed the bulb under.
-	 * @return The saturation as a value from 0 - 254
+	 * @return The saturation as a value from 0 - {@link HueBulb#MAX_BRIGHTNESS}
 	 */
 	public int getSaturation(String deviceId) {
 		if (settingsData == null) {

--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBulb.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBulb.java
@@ -41,10 +41,15 @@ public class HueBulb {
 	private String deviceId;
 	private boolean isOn = false;
 	private boolean isReachable = false;
-	private int brightness = 0; // possible values are 0 - 255
+	private int brightness = 0; // possible values are 0 - 254
 	private int colorTemperature = 154; // possible values are 154 - 500
 	private int hue = 0; // 0 - 65535
-	private int saturation = 0; // 0 - 255
+	private int saturation = 0; // 0 - 254
+	
+	/** The maximum brightness value of the Hue bulb */
+	public static final int MAX_BRIGHTNESS = 254;
+	/** The maximum saturation value of the Hue bulb */
+	public static final int MAX_SATURATION = 254;
 
 	private Client client;
 
@@ -103,9 +108,9 @@ public class HueBulb {
 		int newHueCalculated = new Long(Math.round(newHue * 360.0 * 182.0))
 				.intValue();
 		int newSaturationCalculated = new Long(
-				Math.round(newSaturation * 255.0)).intValue();
+				Math.round(newSaturation * MAX_SATURATION)).intValue();
 		int newBrightnessCalculated = new Long(
-				Math.round(newBrightness * 255.0)).intValue();
+				Math.round(newBrightness * MAX_BRIGHTNESS)).intValue();
 
 		colorizeByHSBInternally(newHueCalculated, newSaturationCalculated,
 				newBrightnessCalculated);
@@ -113,7 +118,7 @@ public class HueBulb {
 
 	/**
 	 * Increases the brightness of the bulb by the given amount to a maximum of
-	 * 255. If the bulb is not switched on this will be done implicitly.
+	 * {@link #MAX_BRIGHTNESS}. If the bulb is not switched on this will be done implicitly.
 	 * 
 	 * @param amount
 	 *            The amount by which the brightness shall be increased.
@@ -147,7 +152,7 @@ public class HueBulb {
 
 		this.brightness = brightness;
 		this.brightness = this.brightness < 0 ? 0 : this.brightness;
-		this.brightness = this.brightness > 255 ? 255 : this.brightness;
+		this.brightness = this.brightness > MAX_BRIGHTNESS ? MAX_BRIGHTNESS : this.brightness;
 
 		if (this.brightness > 0) {
 			this.isOn = true;
@@ -157,7 +162,7 @@ public class HueBulb {
 			executeMessage("{\"on\":false}");
 		}
 
-		return (int) Math.round((100.0 / 255.0) * this.brightness);
+		return (int) Math.round((100.0 / MAX_BRIGHTNESS) * this.brightness);
 
 	}
 	
@@ -215,9 +220,6 @@ public class HueBulb {
 				: this.colorTemperature;
 
 		executeMessage("{\"ct\":" + this.colorTemperature + "}");
-
-//		return (int) Math.round((100.0 / (500.0 - 154.0)) * (this.colorTemperature - 154.0));
-
 	}
 
 	/**
@@ -229,9 +231,9 @@ public class HueBulb {
 	 */
 	public void setOnAtFullBrightness(boolean newState) {
 		if (newState) {
-			increaseBrightness(255);
+			increaseBrightness(MAX_BRIGHTNESS);
 		} else {
-			decreaseBrightness(255);
+			decreaseBrightness(MAX_BRIGHTNESS);
 		}
 	}
 
@@ -241,9 +243,9 @@ public class HueBulb {
 	 * @param hue
 	 *            The hue of the color. (0..65535)
 	 * @param saturation
-	 *            The saturation of the color. (0..255)
+	 *            The saturation of the color. (0..{@link #MAX_SATURATION})
 	 * @param brightness
-	 *            The brightness of the color. (0..255)
+	 *            The brightness of the color. (0..{@link #MAX_BRIGHTNESS})
 	 */
 	private void colorizeByHSBInternally(int hue, int saturation, int brightness) {
 


### PR DESCRIPTION
FIx for issue #2470.
Introduced constants for max brightness and saturation and changes both max values from 255 to 254.