### PR TITLE
[Withings] allow multiple withings accounts

### DIFF
--- a/bundles/binding/org.openhab.binding.withings/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.withings/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Bundle-Version: 1.7.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Withings binding of the open Home Aut
  omation Bus (openHAB)
-Import-Package: org.apache.commons.lang,
+Import-Package: org.apache.commons.io,
+ org.apache.commons.lang,
  org.openhab.core.binding,
  org.openhab.core.events,
  org.openhab.core.items,

--- a/bundles/binding/org.openhab.binding.withings/OSGI-INF/authenticator.xml
+++ b/bundles/binding/org.openhab.binding.withings/OSGI-INF/authenticator.xml
@@ -14,10 +14,9 @@
 	terms of the Eclipse Public License v1.0 which accompanies this distribution, 
 	and is available at http://www.eclipse.org/legal/epl-v10.html -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
-	activate="activate" deactivate="deactivate" immediate="true"
-	name="org.openhab.binding.withings.authenticator">
-	<implementation
-		class="org.openhab.binding.withings.internal.api.WithingsAuthenticator" />
+	activate="activate" deactivate="deactivate" immediate="true" name="org.openhab.binding.withings.authenticator">
+	
+	<implementation class="org.openhab.binding.withings.internal.api.WithingsAuthenticator" />
 
 	<property name="osgi.command.scope" type="String" value="withings" />
 	<property name="osgi.command.function">
@@ -26,8 +25,9 @@
 	</property>
 
 	<service>
-  <provide interface="org.osgi.service.cm.ManagedService"/>
+		<provide interface="org.osgi.service.cm.ManagedService"/>
 	</service>
- <property name="service.pid" type="String" value="org.openhab.withings-oauth"/>
+	
+	<property name="service.pid" type="String" value="org.openhab.withings-oauth"/>
 
 </scr:component>

--- a/bundles/binding/org.openhab.binding.withings/OSGI-INF/binding.xml
+++ b/bundles/binding/org.openhab.binding.withings/OSGI-INF/binding.xml
@@ -13,11 +13,9 @@
 	<implementation class="org.openhab.binding.withings.internal.WithingsBinding" />
 
 	<service>
-		<provide interface="org.osgi.service.event.EventHandler" />
 		<provide interface="org.osgi.service.cm.ManagedService" />
 	</service>
 
-	<property name="event.topics" type="String" value="openhab/command/*" />
 	<property name="service.pid" type="String" value="org.openhab.withings" />
    
 	<reference bind="setEventPublisher" cardinality="1..1"
@@ -25,7 +23,9 @@
 		policy="dynamic" unbind="unsetEventPublisher" />
 	<reference bind="addBindingProvider" cardinality="1..n"
 		interface="org.openhab.binding.withings.WithingsBindingProvider" name="WithingsBindingProvider"
-		policy="dynamic" unbind="removeBindingProvider" />
- <reference bind="addWithingsApiClient" cardinality="0..n" interface="org.openhab.binding.withings.internal.api.WithingsApiClient" name="WithingsApiClient" policy="dynamic" unbind="removeWithingsApiClient"/>
+		policy="dynamic" unbind="removeBindingProvider" />	
+	<reference bind="addWithingsApiClient" cardinality="0..n"
+		interface="org.openhab.binding.withings.internal.api.WithingsApiClient" name="WithingsApiClient"
+		policy="dynamic" unbind="removeWithingsApiClient"/>
 	
 </scr:component>

--- a/bundles/binding/org.openhab.binding.withings/src/main/java/org/openhab/binding/withings/WithingsBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.withings/src/main/java/org/openhab/binding/withings/WithingsBindingConfig.java
@@ -20,15 +20,17 @@ import org.openhab.core.binding.BindingConfig;
  */
 public class WithingsBindingConfig implements BindingConfig {
 
+	public String accountId;
 	public MeasureType measureType;
 
-	public WithingsBindingConfig(MeasureType measureType) {
+	public WithingsBindingConfig(String accountId, MeasureType measureType) {
+		this.accountId = accountId;
 		this.measureType = measureType;
 	}
 
 	@Override
 	public String toString() {
-		return "WithingsBindingConfig [measureType=" + measureType + "]";
+		return "WithingsBindingConfig [accountId=" + accountId + ", measureType=" + measureType + "]";
 	}
 
 }

--- a/bundles/binding/org.openhab.binding.withings/src/main/java/org/openhab/binding/withings/internal/WithingsBinding.java
+++ b/bundles/binding/org.openhab.binding.withings/src/main/java/org/openhab/binding/withings/internal/WithingsBinding.java
@@ -27,8 +27,6 @@ import org.openhab.binding.withings.internal.model.MeasureType;
 import org.openhab.core.binding.AbstractActiveBinding;
 import org.openhab.core.binding.BindingProvider;
 import org.openhab.core.library.types.DecimalType;
-import org.openhab.core.types.Command;
-import org.openhab.core.types.State;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 import org.slf4j.Logger;
@@ -43,11 +41,10 @@ import org.slf4j.LoggerFactory;
  * @since 1.5.0
  */
 public class WithingsBinding extends
-		AbstractActiveBinding<WithingsBindingProvider> implements
-		ManagedService {
+		AbstractActiveBinding<WithingsBindingProvider> implements ManagedService {
 
-	private static final Logger logger = LoggerFactory
-			.getLogger(WithingsBinding.class);
+	private static final Logger logger = 
+		LoggerFactory.getLogger(WithingsBinding.class);
 
 	/**
 	 * Holds the time of last update.
@@ -61,6 +58,18 @@ public class WithingsBinding extends
 	private long refreshInterval = 3600000;
 
 	private final List<WithingsApiClient> withingsApiClients = new CopyOnWriteArrayList<WithingsApiClient>();
+	
+	
+	@Override
+	protected String getName() {
+		return "Withings Refresh Service";
+	}
+
+	@Override
+	protected long getRefreshInterval() {
+		return refreshInterval;
+	}
+	
 
 	@Override
 	public void allBindingsChanged(BindingProvider provider) {
@@ -71,37 +80,7 @@ public class WithingsBinding extends
 	}
 
 	@Override
-	public void updated(Dictionary<String, ?> config)
-			throws ConfigurationException {
-		if (config != null) {
-			String refreshInterval = (String) config.get("refresh");
-			if (StringUtils.isNotBlank(refreshInterval)) {
-				this.refreshInterval = Long.parseLong(refreshInterval);
-				if (isProperlyConfigured() && activeService.isRunning()) {
-					activeService.shutdown();
-					activeService.interrupt();
-					try {
-						// wait 5 seconds until polling thread is definitely
-						// shutdown
-						Thread.sleep(5000);
-					} catch (InterruptedException unhandled) {
-					}
-					setProperlyConfigured(isProperlyConfigured());
-				}
-			}
-		}
-	}
-
-	protected void addWithingsApiClient(WithingsApiClient withingsApiClient) {
-		this.withingsApiClients.add(withingsApiClient);
-		if (!isProperlyConfigured()) {
-			setProperlyConfigured(true);
-		}
-	}
-
-	@Override
 	protected synchronized void execute() {
-
 		Map<String, WithingsBindingConfig> withingsBindings = getWithingsBindings();
 
 		if (withingsBindings.isEmpty()) {
@@ -117,33 +96,7 @@ public class WithingsBinding extends
 		updateItemStates(withingsBindings);
 	}
 
-	@Override
-	protected String getName() {
-		return "Withings Refresh Service";
-	}
-
-	@Override
-	protected long getRefreshInterval() {
-		return refreshInterval;
-	}
-
-	@Override
-	protected void internalReceiveCommand(String itemName, Command command) {
-		logger.warn("Withings binding does not support commands");
-	}
-
-	@Override
-	protected void internalReceiveUpdate(String itemName, State newState) {
-		// nothing to do
-	}
-
-	protected void removeWithingsApiClient(WithingsApiClient withingsApiClient) {
-		this.withingsApiClients.remove(withingsApiClient);
-		if (withingsApiClients.isEmpty()) {
-			setProperlyConfigured(false);
-		}
-	}
-
+	
 	private Float findLastMeasureValue(List<MeasureGroup> measures,
 			MeasureType measureType) {
 		for (MeasureGroup measureGroup : measures) {
@@ -185,13 +138,11 @@ public class WithingsBinding extends
 		Float lastMeasureValue = findLastMeasureValue(measures, measureType);
 
 		if (lastMeasureValue != null) {
-			eventPublisher.postUpdate(itemName, new DecimalType(
-					lastMeasureValue));
+			eventPublisher.postUpdate(itemName, new DecimalType(lastMeasureValue));
 		}
 	}
 
-	private void updateItemStates(
-			Map<String, WithingsBindingConfig> withingsBindings) {
+	private void updateItemStates(Map<String, WithingsBindingConfig> withingsBindings) {
 		try {
 
 			WithingsApiClient client = this.withingsApiClients.get(0);
@@ -202,13 +153,9 @@ public class WithingsBinding extends
 				return;
 			}
 
-			for (Entry<String, WithingsBindingConfig> withingBinding : withingsBindings
-					.entrySet()) {
-
-				WithingsBindingConfig withingsBindingConfig = withingBinding
-						.getValue();
+			for (Entry<String, WithingsBindingConfig> withingBinding : withingsBindings.entrySet()) {
+				WithingsBindingConfig withingsBindingConfig = withingBinding.getValue();
 				String itemName = withingBinding.getKey();
-
 				updateItemState(itemName, withingsBindingConfig, measures);
 			}
 
@@ -219,5 +166,45 @@ public class WithingsBinding extends
 					"Cannot get Withings measure data: " + ex.getMessage(), ex);
 		}
 	}
+	
+	protected void addWithingsApiClient(WithingsApiClient withingsApiClient) {
+		this.withingsApiClients.add(withingsApiClient);
+		if (!isProperlyConfigured()) {
+			setProperlyConfigured(true);
+		}
+	}
 
+	protected void removeWithingsApiClient(WithingsApiClient withingsApiClient) {
+		this.withingsApiClients.remove(withingsApiClient);
+		if (withingsApiClients.isEmpty()) {
+			setProperlyConfigured(false);
+		}
+	}
+
+	
+	@Override
+	public void updated(Dictionary<String, ?> config) throws ConfigurationException {
+		if (config != null) {
+			String refreshInterval = (String) config.get("refresh");
+			if (StringUtils.isNotBlank(refreshInterval)) {
+				this.refreshInterval = Long.parseLong(refreshInterval);
+				restartPollingThread();
+			}
+		}
+	}
+
+	private void restartPollingThread() {
+		if (isProperlyConfigured() && activeService.isRunning()) {
+			activeService.shutdown();
+			activeService.interrupt();
+			try {
+				// wait 5 seconds until polling thread is definitely
+				// shutdown
+				Thread.sleep(5000);
+			} catch (InterruptedException unhandled) {
+			}
+			setProperlyConfigured(isProperlyConfigured());
+		}
+	}
+	
 }

--- a/bundles/binding/org.openhab.binding.withings/src/main/java/org/openhab/binding/withings/internal/WithingsGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.withings/src/main/java/org/openhab/binding/withings/internal/WithingsGenericBindingProvider.java
@@ -41,15 +41,29 @@ public class WithingsGenericBindingProvider extends
 			String bindingConfig) throws BindingConfigParseException {
 		super.processBindingConfiguration(context, item, bindingConfig);
 
-		MeasureType measureType = MeasureType.valueOf(bindingConfig
-				.toUpperCase());
+		String[] configElements = bindingConfig.split(":");
+		
+		String accountId = null;
+		MeasureType measureType = null;
+		
+		if (configElements.length == 1) {
+			measureType = MeasureType.valueOf(configElements[1].toUpperCase());
+		}
+		else if (configElements.length == 2) {
+			accountId = configElements[0];
+			measureType = MeasureType.valueOf(configElements[1].toUpperCase());
+		}
+		else {
+			throw new BindingConfigParseException("Unknown Binding configuration '{}'. The Binding "
+				+ "configuration should consists of either one or two elements.");
+		}
 
 		if (measureType == null) {
 			throw new BindingConfigParseException("Could not convert string '"
 					+ bindingConfig + "' to according measure type.");
 		}
 
-		WithingsBindingConfig config = new WithingsBindingConfig(measureType);
+		WithingsBindingConfig config = new WithingsBindingConfig(accountId, measureType);
 
 		addBindingConfig(item, config);
 	}

--- a/bundles/binding/org.openhab.binding.withings/src/main/java/org/openhab/binding/withings/internal/api/WithingsAccount.java
+++ b/bundles/binding/org.openhab.binding.withings/src/main/java/org/openhab/binding/withings/internal/api/WithingsAccount.java
@@ -1,0 +1,229 @@
+/**
+ * Copyright (c) 2010-2014, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.withings.internal.api;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import oauth.signpost.OAuthConsumer;
+import oauth.signpost.basic.DefaultOAuthConsumer;
+import oauth.signpost.http.HttpParameters;
+import oauth.signpost.signature.AuthorizationHeaderSigningStrategy;
+import oauth.signpost.signature.HmacSha1MessageSigner;
+
+import org.apache.commons.io.IOUtils;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class holds the Withings Account Credentials. It can also load 
+ * and store the credentials the either the {@code openhab.cfg} (legacy)
+ * or the {@code services/withings-ouath.cfg} file. Where to store values
+ * is decided whether {@code openhab.cfg} contains already keys 
+ * starting with {@code withings-oauth} or not.
+ * 
+ * Note: We'd decided to reimplement {@code store} and {@code load} rather
+ * than using the {@link java.util.Properties} class because our keys can
+ * contain ":" which unfortunately is a reserved delimiter in 
+ * {@link java.util.Properties}. 
+ * 
+ * @author Thomas.Eichstaedt-Engelen
+ * @since 1.7.0
+ */
+public final class WithingsAccount {
+	
+	private static final Logger logger = 
+		LoggerFactory.getLogger(WithingsAccount.class);
+
+	private static final String SERVICE_NAME = "withings-oauth";
+
+	private static final String CONFIG_DIR = "." + File.separator + "configurations";
+
+	private static final String CONTENT_DIR = CONFIG_DIR + File.separator + "services";
+
+	private String accountId;
+	
+	String userId;
+	String consumerKey;
+	String consumerSecret;
+	String token;
+	String tokenSecret;
+	
+	OAuthConsumer consumer;
+	
+	ServiceRegistration<?> clientServiceRegistration;
+
+	public WithingsAccount(String accountId, String consumerKey, String consumerSecret) {
+		this.accountId = accountId;
+		this.consumerKey = consumerKey;
+		this.consumerSecret = consumerSecret;
+	}
+
+	public boolean isValid() {
+		return isNotBlank(consumerKey) && isNotBlank(consumerSecret);
+	}
+	
+	public void registerAccount(BundleContext bundleContext) {
+		
+		Dictionary<String, Object> serviceProperties = new Hashtable<String, Object>();
+			serviceProperties.put("withings.accountid", accountId);
+			serviceProperties.put("withings.userid", userId);
+
+		if (this.clientServiceRegistration != null) {
+			this.clientServiceRegistration.unregister();
+		}
+
+		this.clientServiceRegistration = bundleContext.registerService(
+				WithingsApiClient.class.getName(), 
+				new WithingsApiClient(consumer, userId), serviceProperties);
+	}
+
+	public boolean isAuthenticated() {
+		return isNotBlank(userId)
+			&& isNotBlank(consumerKey) && isNotBlank(consumerSecret)
+			&& isNotBlank(token) && isNotBlank(tokenSecret);
+	}
+	
+	public OAuthConsumer createConsumer() {
+		consumer = new DefaultOAuthConsumer(consumerKey, consumerSecret);
+		consumer.setSigningStrategy(new AuthorizationHeaderSigningStrategy());
+		consumer.setMessageSigner(new HmacSha1MessageSigner());
+		return consumer;
+	}
+	
+	public void setOuathToken(String token, String tokenSecret) {
+		this.token = token;
+		this.tokenSecret = tokenSecret;
+		consumer.setTokenWithSecret(token, tokenSecret);
+		consumer.setAdditionalParameters(new HttpParameters());
+	}
+	
+	public void unregisterAccount() {
+		if (this.clientServiceRegistration != null) {
+			this.clientServiceRegistration.unregister();
+		}
+	}
+	
+	public void persist() {
+		File file = null;
+		String prefix = "";
+					
+		try {
+			// store properties either to openhab.cfg (legacy) or
+			// services/withings-oauth.cfg
+			if (isLegacyConfiguration()) {
+				file = new File(CONFIG_DIR + File.separator + "openhab.cfg");
+				// in legacy case each property has to be prefixed with 
+				prefix = SERVICE_NAME + ":";
+			} else {
+				file = new File(CONTENT_DIR + File.separator + SERVICE_NAME + ".cfg");
+			}
+			
+			if (!file.exists()) {
+				file.getParentFile().mkdirs();
+				file.createNewFile();
+			}
+			
+			// if an account different from the default account is used
+			// it get's prefixed separated by "."
+			if (!WithingsAuthenticator.DEFAULT_ACCOUNT_ID.equals(accountId)) {
+				prefix += accountId + ".";
+			}
+			
+			Map<String, String> config = load(file);
+			
+			config.put(prefix + "userid", userId);
+			config.put(prefix + "token", token);
+			config.put(prefix + "tokensecret", tokenSecret);
+			
+			store(config, file);
+			
+			logger.debug("Saved WithingsAccount to file '{}'.", file.getAbsolutePath());
+		}
+		catch (IOException ioe) {
+			logger.error("Couldn't write WithingsAccount to file '{}'.", file.getAbsolutePath());
+		}
+	}
+	
+	/**
+	 * Checks whether the Binding configuration has been store to
+	 * openhab.cfg rather than the /services/withings-oauth.cfg dir
+	 *  
+	 * @return true, if there is a configuration key like "withings-oauth"
+	 * in openhab.cfg and false in all other cases. 
+	 */
+	private boolean isLegacyConfiguration() {
+		File file = new File(CONFIG_DIR + File.separator + "openhab.cfg");
+		
+		try {
+			if (file.exists()) {
+				Map<String, String> config = load(file);
+				for (Object key : config.keySet()) {
+					if (key.toString().startsWith(SERVICE_NAME)) {
+						return true;
+					}
+				}
+			}
+		} catch (IOException e) {
+			logger.warn("Couldn't open Configuration File '{}'", file.getAbsolutePath());
+		}
+		
+		return false;
+	}
+	
+	private Map<String, String> load(File file) throws IOException {
+		Map<String, String> config = new LinkedHashMap<String, String>();
+		FileInputStream is = new FileInputStream(file);
+		List<String> lines = IOUtils.readLines(is);
+		for (String line : lines) {
+			String[] parameterPair = line.split("=");
+			if (parameterPair.length == 2) {
+				config.put(parameterPair[0].trim(), parameterPair[1].trim());
+			} else {
+				config.put(parameterPair[0], "");
+			}
+		}
+		IOUtils.closeQuietly(is);
+		return config;
+	}
+
+	private Map<String, String> store(Map<String, String> config, File file) throws IOException {
+		FileOutputStream os = new FileOutputStream(file);
+		
+		List<String> lines = new ArrayList<String>();
+		for (Entry<String, String> line: config.entrySet()) {
+			String value = isBlank(line.getValue()) ? "" : "=" + line.getValue();
+			lines.add(line.getKey() + value);
+		}
+		
+		IOUtils.writeLines(lines, System.getProperty("line.separator"), os);
+		IOUtils.closeQuietly(os);
+		return config;
+	}
+	
+	@Override
+	public String toString() {
+		return "WithingsAccount [userId=" + userId + ", token=" + token + ", tokenSecret=" + tokenSecret + "]";
+	}
+	
+}

--- a/bundles/binding/org.openhab.binding.withings/src/main/java/org/openhab/binding/withings/internal/api/WithingsApiClient.java
+++ b/bundles/binding/org.openhab.binding.withings/src/main/java/org/openhab/binding/withings/internal/api/WithingsApiClient.java
@@ -56,6 +56,7 @@ public class WithingsApiClient {
 
 	private final String userId;
 
+	
 	public WithingsApiClient(OAuthConsumer consumer, String userId) {
 		this.consumer = consumer;
 		this.userId = userId;
@@ -73,8 +74,7 @@ public class WithingsApiClient {
 	 *             if a connection, server or authorization error occurs
 	 * @see http://www.withings.com/de/api#bodymetrics
 	 */
-	public List<MeasureGroup> getMeasures() throws OAuthException,
-			WithingsConnectionException {
+	public List<MeasureGroup> getMeasures() throws OAuthException, WithingsConnectionException {
 		return getMeasures(0);
 	}
 
@@ -94,8 +94,7 @@ public class WithingsApiClient {
 	public List<MeasureGroup> getMeasures(int startTime) throws OAuthException,
 			WithingsConnectionException {
 
-		String url = getServiceUrl(API_ENDPOINT_MEASURE,
-				API_METHOD_GET_MEASURES);
+		String url = getServiceUrl(API_ENDPOINT_MEASURE, API_METHOD_GET_MEASURES);
 		if (startTime > 0) {
 			url = url + "&startdate=" + startTime;
 		}
@@ -125,15 +124,13 @@ public class WithingsApiClient {
 			UnsupportedEncodingException {
 
 		HttpURLConnection httpURLConnection;
-		httpURLConnection = (HttpURLConnection) new URL(signedUrl)
-				.openConnection();
+		httpURLConnection = (HttpURLConnection) new URL(signedUrl).openConnection();
 		httpURLConnection.connect();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
 		if (responseCode != HttpURLConnection.HTTP_OK) {
-			throw new WithingsConnectionException("Illegal response code: "
-					+ responseCode);
+			throw new WithingsConnectionException("Illegal response code: " + responseCode);
 		}
 
 		Reader reader = null;
@@ -156,18 +153,17 @@ public class WithingsApiClient {
 
 	private GsonBuilder createGsonBuilder() {
 		GsonBuilder gsonBuilder = new GsonBuilder();
-		gsonBuilder.registerTypeAdapter(MeasureType.class,
-				new JsonDeserializers.MeasureTypeJsonDeserializer());
-		gsonBuilder.registerTypeAdapter(Category.class,
-				new JsonDeserializers.CategoryJsonDeserializer());
-		gsonBuilder.registerTypeAdapter(Attribute.class,
-				new JsonDeserializers.AttributeJsonDeserializer());
+		gsonBuilder.registerTypeAdapter(
+			MeasureType.class, new JsonDeserializers.MeasureTypeJsonDeserializer());
+		gsonBuilder.registerTypeAdapter(
+			Category.class, new JsonDeserializers.CategoryJsonDeserializer());
+		gsonBuilder.registerTypeAdapter(
+			Attribute.class, new JsonDeserializers.AttributeJsonDeserializer());
 		return gsonBuilder;
 	}
 
 	private String getServiceUrl(String endpoint, String method) {
-		return API_URL + endpoint + "?action=" + method + "&userid="
-				+ this.userId;
+		return API_URL + endpoint + "?action=" + method + "&userid=" + this.userId;
 	}
 
 }

--- a/bundles/binding/org.openhab.binding.withings/src/main/java/org/openhab/binding/withings/internal/api/WithingsAuthenticator.java
+++ b/bundles/binding/org.openhab.binding.withings/src/main/java/org/openhab/binding/withings/internal/api/WithingsAuthenticator.java
@@ -8,33 +8,18 @@
  */
 package org.openhab.binding.withings.internal.api;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInput;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutput;
-import java.io.ObjectOutputStream;
-import java.io.OutputStream;
-import java.io.Serializable;
 import java.util.Dictionary;
-import java.util.Hashtable;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import oauth.signpost.OAuthConsumer;
 import oauth.signpost.OAuthProvider;
-import oauth.signpost.basic.DefaultOAuthConsumer;
 import oauth.signpost.basic.DefaultOAuthProvider;
 import oauth.signpost.exception.OAuthException;
-import oauth.signpost.http.HttpParameters;
-import oauth.signpost.signature.AuthorizationHeaderSigningStrategy;
-import oauth.signpost.signature.HmacSha1MessageSigner;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceRegistration;
+import org.apache.commons.lang.StringUtils;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 import org.osgi.service.component.ComponentContext;
@@ -54,55 +39,26 @@ import org.slf4j.LoggerFactory;
  * {@link WithingsAuthenticator#contentDir} folder.
  * 
  * @see http://www.withings.com/de/api/oauthguide
+ * 
  * @author Dennis Nobel
+ * @author Thomas.Eichstaedt-Engelen
  * @since 1.5.0
  */
 public class WithingsAuthenticator implements ManagedService {
+	
+	private static final Logger logger = 
+		LoggerFactory.getLogger(WithingsAuthenticator.class);
 
-	public static final class OAuthTokens implements Serializable {
-
-		private static final long serialVersionUID = 6071735616022465845L;
-
-		public String token;
-
-		public String tokenSecret;
-
-		public OAuthTokens() {
-		}
-
-		public OAuthTokens(String token, String tokenSecret) {
-			this.token = token;
-			this.tokenSecret = tokenSecret;
-		}
-	}
-
-	/**
-	 * Default OAuth consumer key
-	 */
+	/** Default OAuth consumer key */
 	private static final String DEFAULT_CONSUMER_KEY = "74c0e77021ef5be1ec8dcb4dd88c15539f9541c86799dcbbfcb8fc8b236";
-	/**
-	 * Default OAuth consumer secret
-	 */
+	
+	/** Default OAuth consumer secret */
 	private static final String DEFAULT_CONSUMER_SECRET = "25f1098263e511711b3287288f90740ff45532cef91658c5043db0b0e0c851c";
 
-	/**
-	 * Default content dir for data storage
-	 */
-	private static final String DEFAULT_CONTENT_DIR = "data/withings";
-
-	/**
-	 * Default Redirect URL to which the user is redirected after the login
-	 */
+	/** Default Redirect URL to which the user is redirected after the login */
 	private static final String DEFAULT_REDIRECT_URL = "http://www.openhab.org/oauth/withings";
 
-	private static final String FILE_NAME_OAUTH_TOKEN = "oauth_tokens";
-
-	private static final String FILE_NAME_USER_ID = "user";
-
 	private static final String LINE = "#########################################################################################";
-
-	private static final Logger logger = LoggerFactory
-			.getLogger(WithingsAuthenticator.class);
 
 	private static final String OAUTH_ACCESS_TOKEN_ENDPOINT_URL = "https://oauth.withings.com/account/access_token";
 
@@ -110,30 +66,62 @@ public class WithingsAuthenticator implements ManagedService {
 
 	private static final String OAUTH_REQUEST_TOKEN_ENDPOINT = "https://oauth.withings.com/account/request_token";
 
-	private BundleContext bundleContext;
+	static final String DEFAULT_ACCOUNT_ID = "DEFAULT_ACCOUNT_ID";
 
-	private ServiceRegistration<?> clientServiceRegistration;
-
-	private OAuthConsumer consumer;
-
-	/**
-	 * OAuth consumer key
-	 */
+	/** Redirect URL to which the user is redirected after the login */
+	private String redirectUrl = DEFAULT_REDIRECT_URL;
+	
 	private String consumerKey = DEFAULT_CONSUMER_KEY;
-
-	/**
-	 * OAuth consumer secret
-	 */
 	private String consumerSecret = DEFAULT_CONSUMER_SECRET;
-
-	private String contentDir = DEFAULT_CONTENT_DIR;
-
+	
 	private OAuthProvider provider;
 
+	private ComponentContext componentContext;
+	
+	private Map<String, WithingsAccount> accountsCache =
+		new HashMap<String, WithingsAccount>();
+	
+	
+	protected void activate(ComponentContext componentContext) {
+		this.componentContext = componentContext;
+	}
+
+	protected void deactivate(ComponentContext componentContext) {
+		this.componentContext = null;
+		unregisterAccounts();
+	}
+	
+	
+	private WithingsAccount getAccount(String accountId) {
+		return accountsCache.get(accountId);
+	}
+	
+	
 	/**
-	 * Redirect URL to which the user is redirected after the login
+	 * Starts the OAuth authentication flow.
 	 */
-	private String redirectUrl = DEFAULT_REDIRECT_URL;
+	public synchronized void startAuthentication(String accountId) {
+
+		WithingsAccount withingsAccount = getAccount(accountId);
+		if (withingsAccount == null) {
+			logger.warn("Couldn't find Credentials of Account '{}'. Please check openhab.cfg or withings.cfg.", accountId);
+			return;
+		}
+		
+		OAuthConsumer consumer = withingsAccount.createConsumer();
+
+		provider = new DefaultOAuthProvider(OAUTH_REQUEST_TOKEN_ENDPOINT,
+				OAUTH_ACCESS_TOKEN_ENDPOINT_URL, OAUTH_AUTHORIZE_ENDPOINT_URL);
+
+		try {
+			String url = provider.retrieveRequestToken(consumer, this.redirectUrl);
+			printSetupInstructions(url);
+		} catch (OAuthException ex) {
+			logger.error(ex.getMessage(), ex);
+			printAuthenticationFailed(ex);
+		}
+
+	}
 
 	/**
 	 * Finishes the OAuth authentication flow.
@@ -143,8 +131,15 @@ public class WithingsAuthenticator implements ManagedService {
 	 * @param userId
 	 *            user id
 	 */
-	public synchronized void finishAuthentication(String verificationCode,
-			String userId) {
+	public synchronized void finishAuthentication(String accountId, String verificationCode, String userId) {
+
+		WithingsAccount withingsAccount = getAccount(accountId);
+		if (withingsAccount == null) {
+			logger.warn("Couldn't find Credentials of Account '{}'. Please check openhab.cfg or withings.cfg.", accountId);
+			return;
+		}
+
+		OAuthConsumer consumer = withingsAccount.consumer;
 
 		if (provider == null || consumer == null) {
 			logger.warn("Could not finish authentication. Please execute 'startAuthentication' first.");
@@ -156,113 +151,31 @@ public class WithingsAuthenticator implements ManagedService {
 		} catch (OAuthException ex) {
 			logger.error(ex.getMessage(), ex);
 			printAuthenticationFailed(ex);
+			return;
 		}
 
-		OAuthTokens oAuthTokens = new OAuthTokens(consumer.getToken(),
-				consumer.getTokenSecret());
-
-		writeToFile(oAuthTokens, FILE_NAME_OAUTH_TOKEN);
-		writeToFile(userId, FILE_NAME_USER_ID);
-
-		registerClientAsService(userId);
+		withingsAccount.userId = userId;
+		withingsAccount.setOuathToken(consumer.getToken(), consumer.getTokenSecret());
+		withingsAccount.registerAccount(componentContext.getBundleContext());
+		withingsAccount.persist();
 
 		printAuthenticationSuccessful();
 	}
 
-	/**
-	 * Starts the OAuth authentication flow.
-	 */
-	public synchronized void startAuthentication() {
 
-		this.consumer = createConsumer();
-
-		provider = new DefaultOAuthProvider(OAUTH_REQUEST_TOKEN_ENDPOINT,
-				OAUTH_ACCESS_TOKEN_ENDPOINT_URL, OAUTH_AUTHORIZE_ENDPOINT_URL);
-
-		try {
-			String url = provider.retrieveRequestToken(consumer,
-					this.redirectUrl);
-			printSetupInstructions(url);
-		} catch (OAuthException ex) {
-			logger.error(ex.getMessage(), ex);
-			printAuthenticationFailed(ex);
-		}
-
-	}
-
-	@Override
-	public void updated(Dictionary<String, ?> properties)
-			throws ConfigurationException {
-		if (properties != null) {
-
-			String redirectUrl = (String) properties.get("redirectUrl");
-			if (redirectUrl != null) {
-				this.redirectUrl = redirectUrl;
-			}
-
-			String consumerKey = (String) properties.get("consumerKey");
-			if (consumerKey != null) {
-				this.consumerKey = consumerKey;
-			}
-
-			String consumerSecret = (String) properties.get("consumerSecret");
-			if (consumerSecret != null) {
-				this.consumerSecret = consumerSecret;
-			}
-
-			String contentDir = (String) properties.get("contentDir");
-			if (contentDir != null) {
-				this.contentDir = contentDir;
-			}
-		}
-	}
-
-	protected void activate(ComponentContext componentContext) {
-		this.bundleContext = componentContext.getBundleContext();
-
-		OAuthTokens oAuthTokens = (OAuthTokens) readFromFile(FILE_NAME_OAUTH_TOKEN);
-		String userId = (String) readFromFile(FILE_NAME_USER_ID);
-
-		if (oAuthTokens != null) {
-			this.consumer = createConsumer();
-			this.consumer.setTokenWithSecret(oAuthTokens.token,
-					oAuthTokens.tokenSecret);
-			this.consumer.setAdditionalParameters(new HttpParameters());
-
-			registerClientAsService(userId);
-
-			logger.info("Withings OAuth tokens successfully restored.");
-			logger.info("Withings Binding is ready to work.");
-		} else {
-			printAuthenticationInfo();
-		}
-	}
-
-	protected void deactivate(ComponentContext componentContext) {
-		if (this.clientServiceRegistration != null) {
-			this.clientServiceRegistration.unregister();
-		}
-	}
-
-	private OAuthConsumer createConsumer() {
-		OAuthConsumer consumer = new DefaultOAuthConsumer(this.consumerKey,
-				this.consumerSecret);
-		consumer.setSigningStrategy(new AuthorizationHeaderSigningStrategy());
-		consumer.setMessageSigner(new HmacSha1MessageSigner());
-		return consumer;
-	}
-
-	private void printAuthenticationFailed(OAuthException ex) {
+	private void printSetupInstructions(String url) {
 		logger.info(LINE);
-		logger.info("# Withings authentication FAILED: " + ex.getMessage());
-		logger.info("# Try to restart authentication by executing 'withings:startAuthentication'");
+		logger.info("# Withings Binding Setup: ");
+		logger.info("# 1. Open URL '" + url + "' in your webbrowser");
+		logger.info("# 2. Login, choose your user and allow openHAB to access your Withings data");
+		logger.info("# 3. Execute 'withings:finishAuthentication \"<accountId>\" \"<verifier>\" \"<userId>\"' on OSGi console");
 		logger.info(LINE);
 	}
-
-	private void printAuthenticationInfo() {
+	
+	private void printAuthenticationInfo(String accountId) {
 		logger.info(LINE);
-		logger.info("# Withings Binding needs authentication.");
-		logger.info("# Execute 'withings:startAuthentication' on OSGi console.");
+		logger.info("# Withings Binding needs authentication of Account '{}'.", accountId);
+		logger.info("# Execute 'withings:startAuthentication' \"<accountId>\" on OSGi console.");
 		logger.info(LINE);
 	}
 
@@ -271,86 +184,105 @@ public class WithingsAuthenticator implements ManagedService {
 		logger.info("# Withings authentication SUCCEEDED. Binding is now ready to work.");
 		logger.info(LINE);
 	}
-
-	private void printSetupInstructions(String url) {
+	
+	private void printAuthenticationFailed(OAuthException ex) {
 		logger.info(LINE);
-		logger.info("# Withings Binding Setup: ");
-		logger.info("# 1. Open URL '" + url + "' in your webbrowser");
-		logger.info("# 2. Login, choose your user and allow openHAB to access your Withings data");
-		logger.info("# 3. Execute 'withings:finishAuthentication \"<verifier>\" \"<userId>\"' on OSGi console");
+		logger.info("# Withings authentication FAILED: " + ex.getMessage());
+		logger.info("# Try to restart authentication by executing 'withings:startAuthentication'");
 		logger.info(LINE);
 	}
+		
+	
+	@Override
+	public void updated(Dictionary<String, ?> config) throws ConfigurationException {
+		if (config != null) {
+			
+			String redirectUrl = (String) config.get("redirectUrl");
+			if (StringUtils.isNotBlank(redirectUrl)) {
+				this.redirectUrl = redirectUrl;
+			}
+			
+			String consumerKeyString = (String) config.get("consumerkey");
+			if (StringUtils.isNotBlank(consumerKeyString)) {
+				this.consumerKey = consumerKeyString;
+			}
+			
+			String consumerSecretString = (String) config.get("consumersecret");
+			if (StringUtils.isNotBlank(consumerSecretString)) {
+				this.consumerSecret = consumerSecretString;
+			}
 
-	private Object readFromFile(String fileName) {
-		File file = new File(contentDir + File.separator + fileName);
+			Enumeration<String> configKeys = config.keys();
+			while (configKeys.hasMoreElements()) {
+				String configKey = (String) configKeys.nextElement();
+				
+				// the config-key enumeration contains additional keys that we
+				// don't want to process here ...
+				if ("redirectUrl".equals(configKey) ||
+					"consumerkey".equals(configKey) ||
+					"consumersecret".equals(configKey) ||
+					"service.pid".equals(configKey)) {
+					
+					continue;
+				}
 
-		if (file.exists()) {
-			logger.debug("Loading object from file '{}'",
-					file.getAbsolutePath());
+				String accountId;
+				String configKeyTail;
+				
+				if (configKey.contains(".")) {
+					String[] keyElements = configKey.split("\\.");
+					accountId = keyElements[0];
+					configKeyTail = keyElements[1];
+					
+				} else {
+					accountId = DEFAULT_ACCOUNT_ID;
+					configKeyTail = configKey;
+				}
 
-			ObjectInput input = null;
-			try {
-				InputStream fis = new FileInputStream(file);
-				InputStream buffer = new BufferedInputStream(fis);
-				input = new ObjectInputStream(buffer);
-				return input.readObject();
-			} catch (Exception ex) {
-				logger.error(
-						"Could not load object from file: " + ex.getMessage(),
-						ex);
-				return null;
-			} finally {
-				try {
-					if (input != null) {
-						input.close();
-					}
-				} catch (IOException ignored) {
+
+				WithingsAccount account = accountsCache.get(accountId);
+				if (account == null) {
+					account = new WithingsAccount(accountId, consumerKey, consumerSecret);
+					accountsCache.put(accountId, account);
+				}
+
+				String value = (String) config.get(configKeyTail);
+				
+				if ("userid".equals(configKeyTail)) {
+					account.userId = value;
+				} else if ("token".equals(configKeyTail)) {
+					account.token = value;
+				} else if ("tokensecret".equals(configKeyTail)) {
+					account.tokenSecret = value;
+				} else {
+					throw new ConfigurationException(configKey, "The given configuration key is unknown!");
 				}
 			}
-		} else {
-			logger.debug("File '{}' does not exists.", fileName);
-			return null;
+			
+			registerAccounts();
 		}
 	}
-
-	private void registerClientAsService(String userId) {
-		Dictionary<String, Object> serviceProperties = new Hashtable<String, Object>();
-		serviceProperties.put("withings.userid", userId);
-
-		if (this.clientServiceRegistration != null) {
-			this.clientServiceRegistration.unregister();
-		}
-
-		this.clientServiceRegistration = this.bundleContext.registerService(
-				WithingsApiClient.class.getName(), new WithingsApiClient(
-						consumer, userId), serviceProperties);
-	}
-
-	private void writeToFile(Serializable object, String fileName) {
-		File file = new File(this.contentDir + File.separator + fileName);
-		try {
-			file.getParentFile().mkdirs();
-			file.createNewFile();
-		} catch (IOException ex) {
-			logger.error("Could not file: " + ex.getMessage(), ex);
-		}
-		logger.debug("Storing object to file '{}'", file.getAbsolutePath());
-		ObjectOutput output = null;
-		try {
-			OutputStream out = new FileOutputStream(file);
-			OutputStream buffer = new BufferedOutputStream(out);
-			output = new ObjectOutputStream(buffer);
-			output.writeObject(object);
-		} catch (IOException ex) {
-			logger.error("Could not store file: " + ex.getMessage(), ex);
-		} finally {
-			try {
-				if (output != null) {
-					output.close();
-				}
-			} catch (IOException ignored) {
+	
+	private void registerAccounts() {
+		for (Entry<String, WithingsAccount> entry : accountsCache.entrySet()) {
+			
+			String accountId = entry.getKey();
+			WithingsAccount account = entry.getValue();
+			
+			if (account.isAuthenticated()) {
+				account.registerAccount(componentContext.getBundleContext());
+			} else if (account.isValid()) {
+				printAuthenticationInfo(accountId);
+			} else {
+				logger.warn("Configuration details of Account '{}' are invalid please check openhab.cfg or withings.cfg.", accountId);
 			}
 		}
 	}
-
+	
+	private void unregisterAccounts() {
+		for (WithingsAccount account : accountsCache.values()) {
+			account.unregisterAccount();
+		}
+	}
+	
 }


### PR DESCRIPTION
this PR supersedes #1695


The main change lies in parsing the openhab.cfg file differently. One can simply add the needed parameters like this

```
withings-oauth:userid=4866592
withings-oauth:consumerkey=74c0e77021ef5be1ec8dcb4dd88c1xckusadwe92f9541c86799dcbbfcb8fc8b236
withings-oauth:consumersecret=25f1098209xns511711b3287288f90740ff45532cef91658c5043db0b0e0c851c
withings-oauth:token=e587df2b08fec066c7643081c649e8517987f6c25d8089d4230987399e28d6
withings-oauth:tokensecret=7c16e5f2f1f5fd784211bfff7c1435jh2d9419e503c5d079e114719b66dcef9
```
or additionally add an user id to which this credentials belong to like:

```
withings-oauth:thomas.token=74c0e77021ef5be1ec8dcb4dd88c1xckusadwe92f9541c86799dcbbfcb8fc8b236
withings-oauth:thomas.tokensecret=25f1098209xns511711b3287288f90740ff45532cef91658c5043db0b0e0c851c
...
withings-oauth:peter.token=74c0e77021ef5be1ec8dcb4dd88c1xckusadwe92f9541c86799dcbbfcb8fc8b236
withings-oauth:peter.tokensecret=25f1098209xns511711b3287288f90740ff45532cef91658c5043db0b0e0c851c
```

Furthermore: if there were no values stored into openhab.cfg yet the Binding store it's values into the file services/withings-oauth.cfg which goes into the ESH way of storing config values. Since this specific file is only meant to configure withings values no prefix is needed. An example file look like:

```
thomas.token=74c0e77021ef5be1ec8dcb4dd88c1xckusadwe92f9541c86799dcbbfcb8fc8b236
thomas.tokensecret=25f1098209xns511711b3287288f90740ff45532cef91658c5043db0b0e0c851c
...
peter.token=74c0e77021ef5be1ec8dcb4dd88c1xckusadwe92f9541c86799dcbbfcb8fc8b236
peter.tokensecret=25f1098209xns511711b3287288f90740ff45532cef91658c5043db0b0e0c851c
```

Signed-off-by: Thomas Eichstädt-Engelen <thomas@openhab.org>