### PR TITLE
JPA persistence: Avoid null pointer exception if no user/password defined

### DIFF
--- a/bundles/persistence/org.openhab.persistence.jpa/java/org/openhab/persistence/jpa/internal/JpaPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.jpa/java/org/openhab/persistence/jpa/internal/JpaPersistenceService.java
@@ -211,8 +211,15 @@ public class JpaPersistenceService implements QueryablePersistenceService {
 		Map<String, String> properties = new HashMap<String, String>();
 		properties.put("javax.persistence.jdbc.url", JpaConfiguration.dbConnectionUrl);
 		properties.put("javax.persistence.jdbc.driver", JpaConfiguration.dbDriverClass);
-		properties.put("javax.persistence.jdbc.user", JpaConfiguration.dbUserName);
-		properties.put("javax.persistence.jdbc.password", JpaConfiguration.dbPassword);
+		if(JpaConfiguration.dbUserName != null) {
+		    properties.put("javax.persistence.jdbc.user", JpaConfiguration.dbUserName);
+		}
+		if(JpaConfiguration.dbPassword != null) {
+		    properties.put("javax.persistence.jdbc.password", JpaConfiguration.dbPassword);
+		}
+		if(JpaConfiguration.dbUserName != null && JpaConfiguration.dbPassword == null) {
+			logger.warn("JPA persistence - it is recommended to use a password to protect data store");
+		}
 		
 		EntityManagerFactory fac = Persistence.createEntityManagerFactory(getPersistenceUnitName(), properties);
 		logger.debug("Creating EntityManagerFactory...done");


### PR DESCRIPTION
An NPE is thrown if no user/password is supplied. This might be the case if an embedded database is used where the user/pass is not needed as it's linked in with no net access (or I guess if you're silly enough to have a server with no password, but I guess not too many people do that!)...