### PR TITLE
Change logging for not found item from error to debug

### DIFF
--- a/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/items/ItemUIRegistryImpl.java
@@ -225,7 +225,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 		try {
 			item = getItem(itemName);
 		} catch (ItemNotFoundException e) {
-			logger.error("Cannot retrieve item {} for widget {}", itemName, w.eClass().getInstanceTypeName());
+			logger.debug("Cannot retrieve item {} for widget {}", itemName, w.eClass().getInstanceTypeName());
 		}
 		return formatLabel(item, itemName, label);
 	}


### PR DESCRIPTION
Fixes #2617.
I don't think this is the best solution as there is no reason to try looking up the item if we already know it is not there (because it is null) and also possible 'real' errors are now logged on debug level.
But then again the previous solution (`label.contains("[")`) wasn't so neat either and the if-check was probably removed for a reason so I didn't want to change it back.

Therefore the logging on debug level is probably a good compromise until somebody comes up with a better solution :-)