### PR TITLE
Add anchor to proxy URL

### DIFF
--- a/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/resources/SitemapResource.java
+++ b/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/resources/SitemapResource.java
@@ -423,6 +423,9 @@ public class SitemapResource {
 					throw new RuntimeException(ex.getMessage(), ex);
 				}
 			}
+			if(uri.getFragment() != null) {
+				sb.append("#" + uri.getFragment());
+			}
 			sbBaseUrl.append(sb.toString());
 			bean.url = sbBaseUrl.toString();
     	}


### PR DESCRIPTION
URLs for WebView using /proxy are missing the anchor/fragment attribute.

Check e.g. rest/sitemaps/ours/0102 (which must contain a webview with anchor (alias fragement) specified using #

In my case:

    Webview url="http://www.sample.com/?test&sp=IGERS72#forecast"

becomes

    http://192.168.0.78:93/proxy?sitemap=ours.sitemap&widgetId=01020300

however, it should be:

    http://192.168.0.78:93/proxy?sitemap=ours.sitemap&widgetId=01020300#forecast

This is fixed by this tiny PR.

Please test first! I was not able to compile openHAB due to some weird mvn errors...

Without this, the Android client cannot handle the anchors. (Browser view is not affected.)