### PR TITLE
Update openhab_default.cfg

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1789,7 +1789,6 @@ tcp:refreshinterval=250
 # encryption key (optional, if empty communication is not encrypted)
 #satel:encryption_key=
 
-<<<<<<< HEAD
 ############################## eBus Binding ###########################################
 #
 


### PR DESCRIPTION
remove line to fix warning while parsing config file