### PR TITLE
InsteonPLM: fixed faulty message definition for 0x56 

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/msg_definitions.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/msg_definitions.xml
@@ -93,12 +93,11 @@
 			<byte name = "Cmd">0x55</byte>
 		</header>
 	</msg>
-	<msg name = "ALLLinkCleanupFailureReport" length = "7" direction = "FROM_MODEM">
+	<msg name = "ALLLinkCleanupFailureReport" length = "6" direction = "FROM_MODEM">
 		<header length="2">
 			<byte>0x02</byte>
 			<byte name = "Cmd">0x56</byte>
 		</header>
-		<byte name = "indicator">0x01</byte>
 		<byte name = "ALLLinkGroup"/>
 		<address name = "address"/>
 	</msg>


### PR DESCRIPTION
The message template for ALLLinkCleanupFailureReport (code 0x56) is incorrect due to documentation error.

This bug fix addresses parsing errors reported here:
https://groups.google.com/forum/#!category-topic/openhab/insteon/S3uncGTopKo