### PR TITLE
Re-enable CORS for REST API

### DIFF
--- a/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/RESTApplication.java
+++ b/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/RESTApplication.java
@@ -197,6 +197,7 @@ public class RESTApplication extends Application {
         // use the default interceptors without PaddingAtmosphereInterceptor
         // see: https://groups.google.com/forum/#!topic/openhab/Z-DVBXdNiYE
         final String[] interceptors = {
+    			"org.atmosphere.interceptor.CorsInterceptor",
 			"org.atmosphere.interceptor.CacheHeadersInterceptor",
 			"org.atmosphere.interceptor.AndroidAtmosphereInterceptor",
 			"org.atmosphere.interceptor.SSEAtmosphereInterceptor",


### PR DESCRIPTION
Support for Cross-Origin Resource Sharing (CORS) in the REST API was lost in 1.7.0 because of the update of Atmosphere. This again adds the necessary interceptor. 
