### PR TITLE
Fix for NullPointerException in jsr223 add-on. This would happen if a…

### DIFF
--- a/bundles/core/org.openhab.core.jsr223/src/main/java/org/openhab/core/jsr223/internal/engine/scriptmanager/ScriptManager.java
+++ b/bundles/core/org.openhab.core.jsr223/src/main/java/org/openhab/core/jsr223/internal/engine/scriptmanager/ScriptManager.java
@@ -185,13 +185,15 @@ public class ScriptManager {
 	}
 
 	private void removeScript(String scriptName) {
-		Script script = scripts.remove(scriptName);
+		if(scripts.containsKey(scriptName)) {
+			Script script = scripts.remove(scriptName);
 
-		List<Rule> allRules = script.getRules();
+			List<Rule> allRules = script.getRules();
 
-		triggerManager.removeRuleModel(allRules);
-		for (Rule rule : allRules) {
-			ruleMap.remove(rule);
+			triggerManager.removeRuleModel(allRules);
+			for (Rule rule : allRules) {
+				ruleMap.remove(rule);
+			}
 		}
 	}
 


### PR DESCRIPTION
…n exception was throws during evaluation of the script.

If an exception was throws during evaluation, the script wasn't added to a map.
The removeScript() method however was removing the script from the map nevertheless.
The getRules() method was then called on a null reference.