### PR TITLE
Fix to YamahaReceiver binding MANIFEST.MF bundle-version

### DIFF
--- a/bundles/binding/org.openhab.binding.yamahareceiver/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.yamahareceiver/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB YamahaReceiver Binding
 Bundle-SymbolicName: org.openhab.binding.yamahareceiver
-Bundle-Version: 1.5.0.qualifier
+Bundle-Version: 1.7.1.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.openhab.binding.yamahareceiver.internal.YamahaReceiverActivator
 Bundle-Vendor: openHAB.org


### PR DESCRIPTION
This somehow got missed and in the current 1.7 release the Yamaha binding is stamped as v1.5! Whoops!