### PR TITLE
Add support for "Manual" ModeType (StellaZ)

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatModeCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatModeCommandClass.java
@@ -304,7 +304,8 @@ ZWaveCommandClassDynamicState {
 		AUTO_CHANGEOVER(10,"Auto Changeover"),
 		HEAT_ECON(11,"Heat Econ"),
 		COOL_ECON(12,"Cool Econ"),
-		AWAY(13,"Away");
+		AWAY(13,"Away"),
+		MANUAL(31, "Manual");
 
 		/**
 		 * A mapping between the integer code and its corresponding mode type


### PR DESCRIPTION
Hi, I'm trying to integrate my StellaZ thermostatic valves. I just realized that the "Manual" ModeType is missing in OpenHab Thermostat Mode Z-Wave binding. Manual mode is fundamental when using these kind of valves because without setting the Thermostat Mode to manual one could not adjust the dimming point apart from using the valve's internal mechanism (which is based on the valve temperature sensor).

Setting the dimming point on these valves is possible only after having set their thermostat mode to "Manual", which is an option currently unsupported in OpenHab's Z-Wave binding. This commit adds the missing ModeType to make it work.