### PR TITLE
Fix for issue #2671: Added empty property list to getCulHandler method

### DIFF
--- a/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/CULManager.java
+++ b/bundles/io/org.openhab.io.transport.cul/src/main/java/org/openhab/io/transport/cul/CULManager.java
@@ -51,7 +51,7 @@ public class CULManager {
 	 * @throws CULDeviceException
 	 */
 	public static CULHandler getOpenCULHandler(String deviceName, CULMode mode) throws CULDeviceException {
-		return getOpenCULHandler(deviceName, mode, null);
+		return getOpenCULHandler(deviceName, mode, new HashMap<String, Object>());
 	}
 	
 	/**


### PR DESCRIPTION
I have created a fix to patch issue #2671. Please see also https://groups.google.com/forum/#!category-topic/openhab/discussions/430B_IhTXDw

BR
André