### PR TITLE
Increase compatibility with some thermostats

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -313,33 +313,37 @@ public abstract class ZWaveCommandClass {
 	 */
 	protected byte[] encodeValue(BigDecimal value) throws ArithmeticException {
 		
-		if (value.unscaledValue().compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0) {
+		// Remove any trailing zero's so we send the least amount of bytes possible
+		BigDecimal normalizedValue = value.stripTrailingZeros();
+
+		// Make our scale at least 0, precision cannot be more than 7 but
+		// this is guarded by the Integer min / max values already.
+		if (normalizedValue.scale() < 0)
+		{
+			normalizedValue = normalizedValue.setScale(0);
+		}
+
+		if (normalizedValue.unscaledValue().compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0) {
 			throw new ArithmeticException();
-		} else if (value.unscaledValue().compareTo(BigInteger.valueOf(Integer.MIN_VALUE)) < 0)
+		} else if (normalizedValue.unscaledValue().compareTo(BigInteger.valueOf(Integer.MIN_VALUE)) < 0)
 			throw new ArithmeticException();
 		
 		// default size = 4
 		int size = 4;
 		
 		// it might fit in a byte or short
-		if (value.unscaledValue().intValue() >= Byte.MIN_VALUE && value.unscaledValue().intValue() <= Byte.MAX_VALUE) {
+		if (normalizedValue.unscaledValue().intValue() >= Byte.MIN_VALUE && normalizedValue.unscaledValue().intValue() <= Byte.MAX_VALUE) {
 			size = 1;
-		} else if (value.unscaledValue().intValue() >= Short.MIN_VALUE && value.unscaledValue().intValue() <= Short.MAX_VALUE) {
+		} else if (normalizedValue.unscaledValue().intValue() >= Short.MIN_VALUE && normalizedValue.unscaledValue().intValue() <= Short.MAX_VALUE) {
 			size = 2;
 		}
 		
-		int precision = value.scale();
-		
-		// precision cannot be negative, cannot be more than 7 as well, 
-		// but this is guarded by the Integer min / max values already.
-		if (precision < 0) {
-			throw new ArithmeticException();
-		}
-		
+		int precision = normalizedValue.scale();
+
 		byte[] result = new byte[size + 1];
 		// precision + scale (unused) + size
 		result[0] = (byte) ((precision << PRECISION_SHIFT) | size);
-		int unscaledValue = value.unscaledValue().intValue(); // ie. 22.5 = 225
+		int unscaledValue = normalizedValue.unscaledValue().intValue(); // ie. 22.5 = 225
 		for (int i = 0; i < size; i++) {
 			result[size - i] = (byte) ((unscaledValue >> (i * 8)) & 0xFF);
 		}


### PR DESCRIPTION
Some thermostats (Trane) do not support setpoint values other than integers.  This change will strip any trailing zeros on BigDecimal numbers to ensure a minimum scale.