### PR TITLE
Ecobee bug: Only update item if we know we retrieved the thermostat it refers to.

### DIFF
--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
@@ -339,7 +339,8 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 		// Iterate through bindings and update all inbound values.
 		for (final EcobeeBindingProvider provider : this.providers) {
 			for (final String itemName : provider.getItemNames()) {
-				if (provider.isInBound(itemName) && credentialsMatch(provider, itemName, oauthCredentials)) {
+				if (provider.isInBound(itemName) && credentialsMatch(provider, itemName, oauthCredentials)
+						&& thermostats.containsKey(provider.getThermostatIdentifier(itemName))) {
 					final State newState = getState(provider, thermostats, itemName);
 
 					logger.debug("readEcobee: Updating itemName '{}' with newState '{}'", itemName, newState);


### PR DESCRIPTION
For users of the Ecobee binding who have more than one thermostat that are managed under the same account at ecobee.com, this is an important bugfix that ought to be in 1.7.1.  The `readEcobee` method was iterating through all in-bound items from that account and setting their states, even if the thermostat that that item refers to had not changed and was therefore not in the payload returned from ecobee, resulting in sometimes Uninitialized items.