### PR TITLE
added indication of input encoding for google tts service

### DIFF
--- a/bundles/action/org.openhab.action.squeezebox/src/main/java/org/openhab/action/squeezebox/internal/Squeezebox.java
+++ b/bundles/action/org.openhab.action.squeezebox/src/main/java/org/openhab/action/squeezebox/internal/Squeezebox.java
@@ -39,7 +39,7 @@ public class Squeezebox {
 	// handle to the Squeeze Server connection
 	public static SqueezeServer squeezeServer;
 
-	private final static String GOOGLE_TRANSLATE_URL = "http://translate.google.com/translate_tts?tl=%s&q=";
+	private final static String GOOGLE_TRANSLATE_URL = "http://translate.google.com/translate_tts?tl=%s&ie=UTF-8&q=";
 	private final static int MAX_SENTENCE_LENGTH = 100;
 
 	private static boolean isReady() {


### PR DESCRIPTION
seems that without this option, google api has problems with proper handling of non-ascii characters in query string