### PR TITLE
onewire binding: fixed bug to make onewire:tempscale work

### DIFF
--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/connection/OneWireConnection.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/connection/OneWireConnection.java
@@ -139,7 +139,7 @@ public class OneWireConnection {
 			String lvTempScaleString = (String) pvConfig.get("tempscale");
 			if (StringUtils.isNotBlank(lvTempScaleString)) {
 				try {
-					cvTempScale = OwTemperatureScale.valueOf("tempScaleString");
+					cvTempScale = OwTemperatureScale.valueOf(lvTempScaleString);
 				} catch (IllegalArgumentException iae) {
 					throw new ConfigurationException("onewire:tempscale", "Unknown temperature scale '" + lvTempScaleString + "'. Valid values are CELSIUS, FAHRENHEIT, KELVIN or RANKIN.");
 				}


### PR DESCRIPTION
fixed a bug in the onewire binding so the onewire:tempscale=FAHRENHEIT is parsed correctly.