### PR TITLE
added outputmode 51 for led dimmers like GE-UMV200

### DIFF
--- a/bundles/binding/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/client/constants/OutputModeEnum.java
+++ b/bundles/binding/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/client/constants/OutputModeEnum.java
@@ -20,6 +20,7 @@ public enum OutputModeEnum {
 	DISABLED	(0),
 	SWITCHED	(16),
 	DIMMED		(22),
+	DIMMED_2	(51),
 	UP_DOWN		(33),
 	SWITCHED_2	(35),
 	SWITCH		(39),

--- a/bundles/binding/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/client/entity/impl/JSONDeviceImpl.java
+++ b/bundles/binding/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/client/entity/impl/JSONDeviceImpl.java
@@ -247,7 +247,7 @@ public class JSONDeviceImpl implements Device {
 		if (outputMode == null) {
 			return false;
 		}
-		return outputMode.equals(OutputModeEnum.DIMMED);
+		return outputMode.equals(OutputModeEnum.DIMMED) || outputMode.equals(OutputModeEnum.DIMMED_2);
 	}
 
 	@Override


### PR DESCRIPTION
Small change to support LED dimmers which have another output mode on Digitalstrom than "normal" dimmers.