### PR TITLE
allow using PersistenceExtensions by using object "pe".

### DIFF
--- a/bundles/core/org.openhab.core.jsr223/META-INF/MANIFEST.MF
+++ b/bundles/core/org.openhab.core.jsr223/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Vendor: openHAB.org
 Bundle-Version: 1.8.0.qualifier
 Bundle-SymbolicName: org.openhab.core.jsr223;singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.openhab.model.item
+Require-Bundle: org.openhab.model.item,
+ org.openhab.core.persistence
 Import-Package: com.google.common.collect,
  org.joda.time,
  org.joda.time.base,

--- a/bundles/core/org.openhab.core.jsr223/build.properties
+++ b/bundles/core/org.openhab.core.jsr223/build.properties
@@ -2,3 +2,4 @@ source.. = src/,
 bin.includes = META-INF/,\
                .,\
                OSGI-INF,\
+               OSGI-INF/jsr223engine.xml,\

--- a/bundles/core/org.openhab.core.jsr223/src/main/java/org/openhab/core/jsr223/internal/engine/scriptmanager/Script.java
+++ b/bundles/core/org.openhab.core.jsr223/src/main/java/org/openhab/core/jsr223/internal/engine/scriptmanager/Script.java
@@ -101,6 +101,7 @@ public class Script {
 		engine.put("ItemRegistry", scriptManager.getItemRegistry());
 		engine.put("DateTime", org.joda.time.DateTime.class);
 		engine.put("oh", Openhab.class);
+		engine.put("pe", org.openhab.core.persistence.extensions.PersistenceExtensions.class);
 
 		// default types, TODO: auto import would be nice
 		engine.put("DateTimeType", DateTimeType.class);


### PR DESCRIPTION
I've added the ability to use the PersistenceExtensions in jsr223.

In addition, this pull request adds jsr223engine.xml to build.properties and hopefully fixes the automatically built jar file.