### PR TITLE
Check if configuration is needed before reporting error

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeStageAdvancer.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeStageAdvancer.java
@@ -745,13 +745,19 @@ public class ZWaveNodeStageAdvancer implements ZWaveEventListener {
 				ZWaveConfigurationCommandClass configurationCommandClass = (ZWaveConfigurationCommandClass) node
 						.getCommandClass(CommandClass.CONFIGURATION);
 
+				// If there are no configuration entries for this node, then continue.
+				List<ZWaveDbConfigurationParameter> configList = database.getProductConfigParameters();
+				if(configList.size() == 0) {
+					break;
+				}
+
+				// If the node doesn't support configuration class, then we better let people know!
 				if (configurationCommandClass == null) {
 					logger.error("NODE {}: Node advancer: GET_CONFIGURATION - CONFIGURATION class not supported", node.getNodeId());
 					break;
 				}
 
 				// Request all parameters for this node
-				List<ZWaveDbConfigurationParameter> configList = database.getProductConfigParameters();
 				for (ZWaveDbConfigurationParameter parameter : configList) {
 					// Some parameters don't return anything, so don't request them!
 					if(parameter.WriteOnly != null && parameter.WriteOnly == true) {


### PR DESCRIPTION
This just moves the error to only be displayed if configuration is required, and the configuration class isn't supported.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>