### PR TITLE
Added support to Netatmo for unit system and pressure unit

### DIFF
--- a/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoBinding.java
+++ b/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoBinding.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
  * @author Andreas Brenk
  * @author Thomas.Eichstaedt-Engelen
  * @author Gaël L'hopital
+ * @author Rob Nielsen
  * @since 1.4.0
  */
 public class NetatmoBinding extends
@@ -63,6 +64,8 @@ public class NetatmoBinding extends
 	protected static final String CONFIG_CLIENT_SECRET = "clientsecret";
 	protected static final String CONFIG_REFRESH = "refresh";
 	protected static final String CONFIG_REFRESH_TOKEN = "refreshtoken";
+	protected static final String CONFIG_PRESSURE_UNIT = "pressureunit";
+	protected static final String CONFIG_UNIT_SYSTEM = "unitsystem";
 
 	/**
 	 * The refresh interval which is used to poll values from the Netatmo server
@@ -73,6 +76,10 @@ public class NetatmoBinding extends
 	private PointType stationPosition = null;
 
 	private Map<String, OAuthCredentials> credentialsCache = new HashMap<String, OAuthCredentials>();
+
+	private NetatmoPressureUnit pressureUnit = NetatmoPressureUnit.DEFAULT_PRESSURE_UNIT;
+
+	private NetatmoUnitSystem unitSystem = NetatmoUnitSystem.DEFAULT_UNIT_SYSTEM;
 
 	/**
 	 * {@inheritDoc}
@@ -152,11 +159,19 @@ public class NetatmoBinding extends
 						case RAIN:
 							final String requestKey = createKey(deviceId,
 									moduleId);
-							final BigDecimal value = deviceMeasureValueMap.get(
+							BigDecimal value = deviceMeasureValueMap.get(
 									requestKey).get(measureType.getMeasure());
 							// Protect that sometimes Netatmo returns null where
 							// numeric value is awaited (issue #1848)
 							if (value != null) {
+								if (measureType == NetatmoMeasureType.TEMPERATURE) {
+									value = unitSystem.convertTemp(value);
+								} else if (measureType == NetatmoMeasureType.RAIN) {
+									value = unitSystem.convertRain(value);
+								} else if (measureType == NetatmoMeasureType.PRESSURE) {
+									value = pressureUnit.convertPressure(value);
+								}
+
 								state = new DecimalType(value);
 							}
 							break;
@@ -196,8 +211,8 @@ public class NetatmoBinding extends
 													device.getLatitude()),
 											new DecimalType(device
 													.getLongitude()),
-											new DecimalType(device
-													.getAltitude()));
+											new DecimalType(Math.round(unitSystem.
+													convertAltitude(device.getAltitude()))));
 								}
 								if (device.getId().equals(deviceId)) {
 									switch (measureType) {
@@ -524,6 +539,24 @@ public class NetatmoBinding extends
 					credentials.clientSecret = value;
 				} else if (CONFIG_REFRESH_TOKEN.equals(configKeyTail)) {
 					credentials.refreshToken = value;
+				} else if (CONFIG_PRESSURE_UNIT.equals(configKeyTail)) {
+					try {
+						pressureUnit = NetatmoPressureUnit.fromString(value);
+					} catch (IllegalArgumentException e) {
+						throw new ConfigurationException(configKey,
+								"the value '" + value
+										+ "' is not valid for the configKey '"
+										+ configKey +"'");
+					}
+				} else if (CONFIG_UNIT_SYSTEM.equals(configKeyTail)) {
+					try {
+						unitSystem = NetatmoUnitSystem.fromString(value);
+					} catch (IllegalArgumentException e) {
+						throw new ConfigurationException(configKey,
+								"the value '" + value
+										+ "' is not valid for the configKey '"
+										+ configKey +"'");
+					}
 				} else {
 					throw new ConfigurationException(configKey,
 							"the given configKey '" + configKey

--- a/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoPressureUnit.java
+++ b/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoPressureUnit.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.netatmo.internal;
+
+import java.math.BigDecimal;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * @author Rob Nielsen
+ * @since 1.8.0
+ * 
+ *         This enum holds all the different pressure units for the Netatmo
+ *         binding, along with conversion methods
+ */
+public enum NetatmoPressureUnit {
+	MBAR("mbar"), INHG("inHg"), MMHG("mmHg");
+
+	public static final NetatmoPressureUnit DEFAULT_PRESSURE_UNIT = NetatmoPressureUnit.MBAR;
+	private static final BigDecimal MBAR_TO_INHG = new BigDecimal(0.02952998751);
+
+	private static final BigDecimal MBAR_TO_MMHG = new BigDecimal(0.750061683);
+
+	String pressureUnit;
+
+	private NetatmoPressureUnit(String pressureUnit) {
+		this.pressureUnit = pressureUnit;
+	}
+
+	public String getpressureUnit() {
+		return pressureUnit;
+	}
+
+	public static NetatmoPressureUnit fromString(String pressureUnit) {
+		if (!StringUtils.isEmpty(pressureUnit)) {
+			for (NetatmoPressureUnit pressureUnitType : NetatmoPressureUnit
+					.values()) {
+				if (pressureUnitType.toString().equalsIgnoreCase(pressureUnit)) {
+					return pressureUnitType;
+				}
+			}
+		}
+		throw new IllegalArgumentException("Invalid pressureUnit: "
+				+ pressureUnit);
+	}
+	
+	public BigDecimal convertPressure(BigDecimal value) {
+		if (this == DEFAULT_PRESSURE_UNIT) {
+			return value;
+		} else if (this == INHG) {
+			return value.multiply(MBAR_TO_INHG);
+		} else { // MMGH
+			return value.multiply(MBAR_TO_MMHG);
+		}
+	}
+}

--- a/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoUnitSystem.java
+++ b/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoUnitSystem.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.netatmo.internal;
+
+import java.math.BigDecimal;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * @author Rob Nielsen
+ * @since 1.8.0
+ *
+ *        This enum holds all the different unit systems for the Netatmo binding,
+ *        along with conversion methods
+ */
+public enum NetatmoUnitSystem {
+	M("Metric"), US("US");
+
+	public static final NetatmoUnitSystem DEFAULT_UNIT_SYSTEM = NetatmoUnitSystem.M;
+
+	private static final double METERS_TO_FEET = 3.2808399;
+
+	private static final BigDecimal MM_TO_INCHES = new BigDecimal(0.0393700787);
+
+	private static final BigDecimal ONE_POINT_EIGHT = new BigDecimal(1.8);
+
+	private static final BigDecimal THIRTY_TWO = new BigDecimal(32);
+
+	String unitSystem;
+
+	private NetatmoUnitSystem(String unitSystem) {
+		this.unitSystem = unitSystem;
+	}
+
+	public String getunitSystem() {
+		return unitSystem;
+	}
+
+	public static NetatmoUnitSystem fromString(String unitSystem) {
+		if (!StringUtils.isEmpty(unitSystem)) {
+			for (NetatmoUnitSystem unitSystemType : NetatmoUnitSystem.values()) {
+				if (unitSystemType.toString().equalsIgnoreCase(unitSystem)) {
+					return unitSystemType;
+				}
+			}
+		}
+		throw new IllegalArgumentException("Invalid unitSystem: " + unitSystem);
+	}
+	
+	public double convertAltitude(double value) {
+		if (this == DEFAULT_UNIT_SYSTEM) {
+			return value;
+		}
+		
+		return value * METERS_TO_FEET;
+	}
+	
+	public BigDecimal convertRain(BigDecimal value) {
+		if (this == DEFAULT_UNIT_SYSTEM) {
+			return value;
+		}
+		
+		return value.multiply(MM_TO_INCHES);
+	}
+	
+	public BigDecimal convertTemp(BigDecimal value) {
+		if (this == DEFAULT_UNIT_SYSTEM) {
+			return value;
+		}
+		
+		return value.multiply(ONE_POINT_EIGHT).add(THIRTY_TWO);
+	}
+}

--- a/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/messages/DeviceListRequest.java
+++ b/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/messages/DeviceListRequest.java
@@ -20,6 +20,7 @@ import org.openhab.binding.netatmo.internal.NetatmoException;
  * modules.
  * 
  * @author Andreas Brenk
+ * @author Rob Nielsen
  * @since 1.4.0
  * @see <a href="http://dev.netatmo.com/doc/restapi/devicelist">devicelist</a>
  */

--- a/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/messages/DeviceListResponse.java
+++ b/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/messages/DeviceListResponse.java
@@ -411,7 +411,7 @@ public class DeviceListResponse extends AbstractResponse {
 			return result;
 		}
 
-		public Integer getAltitude() {
+		public Double getAltitude() {
 			return this.place.altitude;
 		}
 
@@ -566,7 +566,7 @@ public class DeviceListResponse extends AbstractResponse {
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public static class Place extends AbstractMessagePart {
 
-		private Integer altitude;
+		private Double altitude;
 		private String country;
 		private List<Double> location;
 		private String timezone;
@@ -576,7 +576,7 @@ public class DeviceListResponse extends AbstractResponse {
 		 * "altitude": 33
 		 */
 		@JsonProperty("altitude")
-		public Integer getAltitude() {
+		public Double getAltitude() {
 			return this.altitude;
 		}
 

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1323,6 +1323,13 @@ tcp:refreshinterval=250
 # The Netatmo refresh token (see http://dev.netatmo.com/doc/authentication/usercred)
 #netatmo:refreshtoken=
 
+# The Netatmo unit system where M=Metric system - celsius/meters/millimeters,
+#     US=US System - fahrenheit/feet/inches (optional, defaults to M)
+#netatmo:unitsystem=
+
+# The Netatmo pressure unit values: mbar, inHg, mmHg (optional, defaults to mbar)
+#netatmo:pressureunit=
+
 ########################### HDanywhere Binding ########################################
 #
 # Optional, specify the number of input and output ports for a given HDanywhere matrix


### PR DESCRIPTION
Implemented both unit system and pressure unit in the same manner as implemented by the Netatmo apps (web, Android). Unit systems supported are Metric and US. Pressure units supported are mbar, inHg, and mmHg.