### PR TITLE
Ecobee: two cases where tokens should be ignored or discarded.

### DIFF
--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
@@ -674,6 +674,8 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 					properlyConfigured = false;
 					break;
 				}
+				// Knowing this OAuthCredentials object is complete, load its tokens from persistent storage.
+				oauthCredentials.load();
 			}
 
 			setProperlyConfigured(properlyConfigured);
@@ -832,6 +834,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 	 */
 	static class OAuthCredentials {
 
+		private static final String APP_KEY = "appKey";
 		private static final String AUTH_TOKEN = "authToken";
 		private static final String REFRESH_TOKEN = "refreshToken";
 		private static final String ACCESS_TOKEN = "accessToken";
@@ -884,13 +887,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 		private Map<String, Revision> lastRevisionMap = new HashMap<String, Revision>();
 
 		public OAuthCredentials(String userid) {
-
-			try {
-				this.userid = userid;
-				load();
-			} catch (Exception e) {
-				throw new EcobeeException("Cannot create OAuthCredentials.", e);
-			}
+			this.userid = userid;
 		}
 
 		public Map<String, Revision> getLastRevisionMap() {
@@ -907,13 +904,23 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 
 		private void load() {
 			Preferences prefs = getPrefsNode();
-			this.authToken = prefs.get(AUTH_TOKEN, null);
-			this.refreshToken = prefs.get(REFRESH_TOKEN, null);
-			this.accessToken = prefs.get(ACCESS_TOKEN, null);
+			/*
+			 * Only load the tokens if they were not saved with the app key used to create them (backwards
+			 * compatibility), or if the saved app key matches the current app key specified in openhab.cfg. This
+			 * properly ignores saved tokens when the app key has been changed.
+			 */
+			final String savedAppKey = prefs.get(APP_KEY, null);
+			if (savedAppKey == null || savedAppKey.equals(this.appKey)) {
+				this.authToken = prefs.get(AUTH_TOKEN, null);
+				this.refreshToken = prefs.get(REFRESH_TOKEN, null);
+				this.accessToken = prefs.get(ACCESS_TOKEN, null);
+			}
 		}
 
 		private void save() {
 			Preferences prefs = getPrefsNode();
+			prefs.put(APP_KEY, this.appKey);
+
 			if (this.authToken != null) {
 				prefs.put(AUTH_TOKEN, this.authToken);
 			} else {
@@ -993,6 +1000,14 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 
 				if (response.isError()) {
 					logger.error("Error retrieving tokens: {}", response.getError());
+					if ("authorization_expired".equals(response.getError())) {
+						this.refreshToken = null;
+						this.accessToken = null;
+						if (request instanceof TokenRequest) {
+							this.authToken = null;
+						}
+						save();
+					}
 					return false;
 				} else {
 					this.refreshToken = response.getRefreshToken();


### PR DESCRIPTION
_Problems:_ (1) Discovered that some users were not entering their OAuth PIN at ecobee.com within the [9-minute window](https://github.com/openhab/openhab/wiki/Ecobee-Binding#authentication), which was causing an auth token to be persisted that was not usable.  When this happens, there is no way to retrieve a new PIN unless the user knew how to find and move or delete the absurdly named and platform-specific Java Preferences file where the bad auth token was stored.  (2) Users would then attempt to [create a new app at ecobee.com](https://www.ecobee.com/developers/) and enter the new `ecobee:appkey` in openhab.cfg.  The binding would not realize that the `ecobee:appkey` had changed from when the old tokens had been stored, so this was not the solution the user was hoping it would be.

_Fixes:_ (1) The binding now discards expired tokens when an attempt to use them to get new tokens fails with "authorization_expired".  (2) The binding also now ignores persisted tokens after the user changes `ecobee:appkey` in openhab.cfg, since any persisted tokens will not work against this different app key.  The Nest binding does something similar to avoid using invalid persisted tokens.

One user discussion and fix is [here](http://www.smarthomehub.net/forums/discussion/338/ecobee-binding-for-openhab).  

I recommend that this fix be included in OpenHAB 1.7.1.  Please let me know if I should or should not merge it into the ecobee-action PR which is currently planned for 1.8.