### PR TITLE
[satel] Connection status implemented

### DIFF
--- a/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/SatelBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/SatelBindingConfig.java
@@ -39,19 +39,36 @@ public abstract class SatelBindingConfig implements BindingConfig {
 	public enum Options {
 		COMMANDS_ONLY, FORCE_ARM, INVERT_STATE
 	}
-	
+
 	private static final DecimalType DECIMAL_ONE = new DecimalType(1);
-	
+
 	private Map<String, String> options;
-	
+
+	/**
+	 * Checks whether given option is set to <code>true</code>.
+	 * 
+	 * @param option option to check
+	 * @return <code>true</code> if option is enabled
+	 */
 	public boolean hasOptionEnabled(Options option) {
 		return Boolean.parseBoolean(getOption(option));
 	}
-	
+
+	/**
+	 * Returns value of given option.
+	 * 
+	 * @param option option to get value for
+	 * @return string value or <code>null</code> if option is not present
+	 */
 	public String getOption(Options option) {
 		return this.options.get(option.name());
 	}
-	
+
+	/**
+	 * Returns string representation of option map.
+	 * 
+	 * @return string as pairs of [name]=[value] separated by comma
+	 */
 	public String optionsAsString() {
 		return this.options.toString();
 	}
@@ -89,7 +106,7 @@ public abstract class SatelBindingConfig implements BindingConfig {
 	 * @return a message to send
 	 */
 	public abstract SatelMessage buildRefreshMessage(IntegraType integraType);
-	
+
 	protected SatelBindingConfig(Map<String, String> options) {
 		this.options = options;
 	}

--- a/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/config/ConnectionStatusBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/config/ConnectionStatusBindingConfig.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.satel.config;
+
+import java.util.Calendar;
+import java.util.Map;
+
+import org.openhab.binding.satel.SatelBindingConfig;
+import org.openhab.binding.satel.internal.event.ConnectionStatusEvent;
+import org.openhab.binding.satel.internal.event.SatelEvent;
+import org.openhab.binding.satel.internal.protocol.SatelMessage;
+import org.openhab.binding.satel.internal.types.IntegraType;
+import org.openhab.core.items.Item;
+import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.openhab.core.types.UnDefType;
+import org.openhab.model.item.binding.BindingConfigParseException;
+
+/**
+ * This class implements binding configuration for various connection status values.
+ * 
+ * Supported options:
+ * <ul>
+ * <li>invert_state - for "connected" status, active state is <code>false</code></li>
+ * </ul>
+ * 
+ * @author Krzysztof Goworek
+ * @since 1.8.0
+ */
+public class ConnectionStatusBindingConfig extends SatelBindingConfig {
+
+	enum StatusType {
+		CONNECTED, CONNECTED_SINCE, CONNECTION_ERRORS
+	}
+
+	private StatusType statusType;
+	private Calendar connectedSince;
+	private int connectionFailures;
+
+	private ConnectionStatusBindingConfig(StatusType statusType, Map<String, String> options) {
+		super(options);
+		this.statusType = statusType;
+		this.connectedSince = null;
+		this.connectionFailures = 0;
+	}
+
+	/**
+	 * Parses given binding configuration and creates configuration object.
+	 * 
+	 * @param bindingConfig
+	 *            config to parse
+	 * @return parsed config object or <code>null</code> if config does not
+	 *         match
+	 * @throws BindingConfigParseException
+	 *             in case of parse errors
+	 */
+	public static ConnectionStatusBindingConfig parseConfig(String bindingConfig) throws BindingConfigParseException {
+		ConfigIterator iterator = new ConfigIterator(bindingConfig);
+
+		// check if a status item
+		if (!"module".equalsIgnoreCase(iterator.next()))
+			return null;
+
+		return new ConnectionStatusBindingConfig(iterator.nextOfType(StatusType.class, "status type"),
+				parseOptions(iterator));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public State convertEventToState(Item item, SatelEvent event) {
+		if (!(event instanceof ConnectionStatusEvent)) {
+			return null;
+		}
+
+		ConnectionStatusEvent statusEvent = (ConnectionStatusEvent) event;
+		boolean invertState = hasOptionEnabled(Options.INVERT_STATE);
+
+		// update internal values
+		if (statusEvent.isConnected()) {
+			this.connectionFailures = 0;
+			if (this.connectedSince == null) {
+				this.connectedSince = Calendar.getInstance();
+			}
+		} else {
+			this.connectionFailures += 1;
+			this.connectedSince = null;
+		}
+
+		switch (this.statusType) {
+		case CONNECTED:
+			return booleanToState(item, statusEvent.isConnected() ^ invertState);
+
+		case CONNECTED_SINCE:
+			if (this.connectedSince == null) {
+				return UnDefType.NULL;
+			} else if (item.getAcceptedDataTypes().contains(DateTimeType.class)) {
+				return new DateTimeType(this.connectedSince);
+			}
+			break;
+
+		case CONNECTION_ERRORS:
+			if (item.getAcceptedDataTypes().contains(DecimalType.class)) {
+				return new DecimalType(this.connectionFailures);
+			}
+			break;
+		}
+
+		return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public SatelMessage convertCommandToMessage(Command command, IntegraType integraType, String userCode) {
+		// this configuration does not accept commands
+		return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public SatelMessage buildRefreshMessage(IntegraType integraType) {
+		// this is configuration for internal state - does not need refresh
+		// command
+		return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String toString() {
+		return String.format("%s: status = %s, options = %s", this.getClass().getName(), this.statusType,
+				this.optionsAsString());
+	}
+}

--- a/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/config/IntegraStateBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/config/IntegraStateBindingConfig.java
@@ -44,6 +44,7 @@ import org.openhab.model.item.binding.BindingConfigParseException;
  * <ul>
  * <li>commands_only - binding does not update state of the item, but accepts commands</li>
  * <li>force_arm - forces arming for items that accept arming commands</li>
+ * <li>invert_state - uses 0 as active state</li>
  * </ul>
  * 
  * @author Krzysztof Goworek

--- a/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelGenericBindingProvider.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import org.openhab.binding.satel.SatelBindingConfig;
 import org.openhab.binding.satel.SatelBindingProvider;
+import org.openhab.binding.satel.config.ConnectionStatusBindingConfig;
 import org.openhab.binding.satel.config.IntegraStateBindingConfig;
 import org.openhab.binding.satel.config.IntegraStatusBindingConfig;
 import org.openhab.core.items.Item;
@@ -94,8 +95,14 @@ public class SatelGenericBindingProvider extends AbstractGenericBindingProvider 
 				return bc;
 			}
 
-			// try IntegraStatusBindingConfig
+			// next try IntegraStatusBindingConfig
 			bc = IntegraStatusBindingConfig.parseConfig(bindingConfig);
+			if (bc != null) {
+				return bc;
+			}
+
+			// next try ConnectionStatusBindingConfig
+			bc = ConnectionStatusBindingConfig.parseConfig(bindingConfig);
 			if (bc != null) {
 				return bc;
 			}

--- a/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/ConnectionStatusEvent.java
+++ b/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/event/ConnectionStatusEvent.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.satel.internal.event;
+
+/**
+ * Event class describing connection status to Satel module.
+ * 
+ * @author Krzysztof Goworek
+ * @since 1.7.0
+ */
+public class ConnectionStatusEvent implements SatelEvent {
+
+	private boolean connected;
+
+	/**
+	 * Constructs event class with given connection status.
+	 * 
+	 * @param connected value describing connection status
+	 */
+	public ConnectionStatusEvent(boolean connected) {
+		this.connected = connected;
+	}
+
+	/**
+	 * Returns status of connection.
+	 * 
+	 * @return a boolean value describing connection status
+	 */
+	public boolean isConnected() {
+		return this.connected;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String toString() {
+		return String.format("%s: connected = %b", this.getClass().getName(), this.connected);
+	}
+}


### PR DESCRIPTION
This PR allows to define items for connection status to the module. Currently there are 3 new binding configurations added:
* module:connected - simple binary flag active when there is connection established,
* module:connected_since - a timestamp describing when connection has been established,
* module:connection_errors - a number describing number of connection errors in a row; it is cleared after connection has been established.
