### PR TITLE
Fix state properties Plex binding latest PMS

### DIFF
--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexBinding.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexBinding.java
@@ -244,7 +244,10 @@ public class PlexBinding extends AbstractActiveBinding<PlexBindingProvider> impl
 		for (PlexBindingProvider provider : providers) {
 			for (String itemName : provider.getItemNames()) {
 				PlexBindingConfig config = provider.getConfig(itemName);
-				if (session.getMachineIdentifier().equals(config.getMachineIdentifier()))
+				// In newer PMS versions, the machine identifier in the session also contains the type 
+				// of media that is playing (<id>_Video for example). We'll keep it backwards compatible
+				// by only matching the first part of the machine identifier.
+				if (session.getMachineIdentifier().startsWith(config.getMachineIdentifier()))
 					updateConfigFromSession(config, session);
 			}
 		}


### PR DESCRIPTION
The latest release of the Plex Media Server (PMS, version 0.9.12.4) slightly changed the format of the machine ID in the session information. Because of this properties like state, title, etc. were no longer working in the binding. This PR fixes this. 

Could this be included in 1.7.1? Bug is also referenced here: https://groups.google.com/d/msg/openhab/-xkZGLY_zOs/Ekd-t11c4TYJ
