### PR TITLE
Strip off the double quotes from the mapping command in case they exist.

### DIFF
--- a/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/resources/SitemapResource.java
+++ b/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/resources/SitemapResource.java
@@ -330,18 +330,7 @@ public class SitemapResource {
     		Switch switchWidget = (Switch) widget;
     		for(Mapping mapping : switchWidget.getMappings()) {
     			MappingBean mappingBean = new MappingBean();
-				// Remove quotes - if they exist
-				if(mapping.getCmd() != null) {
-					if(mapping.getCmd().startsWith("\"") && mapping.getCmd().endsWith("\"")) {
-						mappingBean.command = mapping.getCmd().substring(1, mapping.getCmd().length()-1);
-					}
-					else {
-						mappingBean.command = mapping.getCmd();
-					}
-				}
-				else {
-					mappingBean.command = mapping.getCmd();
-				}
+				mappingBean.command = mapping.getCmd();
 				mappingBean.label = mapping.getLabel();
 				bean.mappings.add(mappingBean);
 			}
@@ -350,18 +339,7 @@ public class SitemapResource {
 			Selection selectionWidget = (Selection) widget;
 			for (Mapping mapping : selectionWidget.getMappings()) {
 				MappingBean mappingBean = new MappingBean();
-				// Remove quotes - if they exist
-				if(mapping.getCmd() != null) {
-					if(mapping.getCmd().startsWith("\"") && mapping.getCmd().endsWith("\"")) {
-						mappingBean.command = mapping.getCmd().substring(1, mapping.getCmd().length()-1);
-					}
-					else {
-						mappingBean.command = mapping.getCmd();
-					}				
-				}
-				else {
-					mappingBean.command = mapping.getCmd();
-				}
+				mappingBean.command = mapping.getCmd();
     			mappingBean.label = mapping.getLabel();
     			bean.mappings.add(mappingBean);
     		}

--- a/bundles/model/org.openhab.model.sitemap/src/org/openhab/model/valueconverter/SitemapConverters.java
+++ b/bundles/model/org.openhab.model.sitemap/src/org/openhab/model/valueconverter/SitemapConverters.java
@@ -11,17 +11,44 @@ package org.openhab.model.valueconverter;
 import org.eclipse.xtext.common.services.DefaultTerminalConverters;
 import org.eclipse.xtext.conversion.IValueConverter;
 import org.eclipse.xtext.conversion.ValueConverter;
+import org.eclipse.xtext.conversion.impl.AbstractNullSafeConverter;
 import org.eclipse.xtext.conversion.impl.STRINGValueConverter;
+import org.eclipse.xtext.nodemodel.INode;
 
 import com.google.inject.Inject;
+import java.util.regex.Pattern;
 
 public class SitemapConverters extends DefaultTerminalConverters {
+
+	private static final Pattern ID_PATTERN = Pattern.compile("\\p{Alpha}\\w*");
 
 	@Inject
 	private STRINGValueConverter stringValueConverter;
 
-	 @ValueConverter(rule = "Icon")
-	 public IValueConverter<String> BIG_DECIMAL() {
-	   return stringValueConverter;
-	 }
+	@ValueConverter(rule = "Icon")
+	public IValueConverter<String> BIG_DECIMAL() {
+		return stringValueConverter;
+	}
+
+	@ValueConverter(rule = "Command")
+	public IValueConverter<String> Command() {
+		return new AbstractNullSafeConverter<String>() {
+			@Override
+			protected String internalToValue(String string, INode node) {
+				if((string.startsWith("'") && string.endsWith("'"))||(string.startsWith("\"") && string.endsWith("\""))) {
+					return STRING().toValue(string, node);
+				}
+				return ID().toValue(string, node);
+			}
+
+			@Override
+			protected String internalToString(String value) {
+				if(ID_PATTERN.matcher(value).matches()) {
+					return ID().toString(value);
+				} else {
+					return STRING().toString(value);
+				}
+			}
+		};
+	}
 }


### PR DESCRIPTION
This fixes the root cause of the Classic UI not supporting double quotes in Mapping commands.

When enclosing the command in double quotes, the double quotes become part of command. This causes two problems:
* HTML gets formatted as ""the command"" instead of "the command"
* "the command" != the command so there can never be a match and as a result the switch and selection item do not work properly when the command is wrapped in double quotes

Reported problems/issues:
* This fixes the problem reported [here](https://groups.google.com/forum/#!category-topic/openhab/sitemaps/wFbXRT1LWxg) with the Harmony Hub Binding.
* #1414
* Probably #1837 as well.

Discussion topic can be found [here](https://groups.google.com/forum/#!category-topic/openhab/sitemaps/D-PpPY-ixns).
