### PR TITLE
z-wave binding zw096 - added additional international Type ID codes for US, EU, AU, CN

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/aeon/zw096.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/aeon/zw096.xml
@@ -189,8 +189,9 @@
         <Parameter>
             <Index>83</Index>
             <Type>byte</Type>
-            <Default>DDA0DD</Default>
+            <Default>14524637</Default>
             <Minimum>0</Minimum>
+            <Maximum>16777215</Maximum>
             <Size>3</Size>
             <Label lang="en">RGB value when it is in Night light mode</Label>
             <Help lang="en">Configure the RGB value when it is in Night light mode. 
@@ -202,8 +203,9 @@
         <Parameter>
             <Index>84</Index>
             <Type>byte</Type>
-            <Default>505050</Default>
-            <Minimum>010101</Minimum>
+            <Default>3289650</Default>
+            <Minimum>0</Minimum>
+            <Maximum>6513507</Maximum>
             <Size>3</Size>
             <Label lang="en">LED brightness in Energy Mode</Label>
             <Help lang="en">Configure the brightness level of RGB LED (0%‐100%) when 

--- a/bundles/binding/org.openhab.binding.zwave/database/aeon/zw096.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/aeon/zw096.xml
@@ -191,7 +191,6 @@
             <Type>byte</Type>
             <Default>DDA0DD</Default>
             <Minimum>0</Minimum>
-            <Maximum>FFFFFF</Maximum>
             <Size>3</Size>
             <Label lang="en">RGB value when it is in Night light mode</Label>
             <Help lang="en">Configure the RGB value when it is in Night light mode. 
@@ -205,7 +204,6 @@
             <Type>byte</Type>
             <Default>505050</Default>
             <Minimum>010101</Minimum>
-            <Maximum>999999</Maximum>
             <Size>3</Size>
             <Label lang="en">LED brightness in Energy Mode</Label>
             <Help lang="en">Configure the brightness level of RGB LED (0%‐100%) when 

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -673,6 +673,18 @@
 				<Type>0003</Type>
 				<Id>0060</Id>
 			</Reference>
+			<Reference>
+                <Type>0103</Type>
+                <Id>0060</Id>
+            </Reference>
+            <Reference>
+                <Type>0203</Type>
+                <Id>0060</Id>
+            </Reference>
+            <Reference>
+                <Type>1D03</Type>
+                <Id>0060</Id>
+            </Reference>
 			<Model>ZW096</Model>
 			<Label lang="en">Smart Switch 6</Label>
 			<ConfigFile>aeon/zw096.xml</ConfigFile>

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ConfigurationParameter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ConfigurationParameter.java
@@ -34,7 +34,7 @@ public class ConfigurationParameter {
 	 */
 	public ConfigurationParameter(Integer index, Integer value, Integer size) throws IllegalArgumentException {
 		
-		if (size != 1 && size != 2 && size != 4) {
+		if (size < 1 || size > 4) {
 			throw new IllegalArgumentException("illegal parameter size");
 		}
 		


### PR DESCRIPTION
removed maximum settings where they did not make sense
added additional international Type ID codes for US, EU, AU, CN
