### PR TITLE
fix common handling for double broadcasts within rest (websocket)

### DIFF
--- a/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/filter/DuplicateBroadcastProtectionFilter.java
+++ b/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/filter/DuplicateBroadcastProtectionFilter.java
@@ -64,6 +64,13 @@ public class DuplicateBroadcastProtectionFilter implements PerRequestBroadcastFi
 	private boolean isDoubleBroadcast(HttpServletRequest request,
 			Object responseEntity) throws JsonGenerationException,
 			JsonMappingException, IOException {
+		
+		if (request.getPathInfo().endsWith("state")) {
+			// extra handling for state requests.
+			// if an item and another item is switched to the same state
+			// the message must be broadcasted as well
+			return false;
+		}
 	
 		String clientId = request.getHeader(HeaderConfig.X_ATMOSPHERE_TRACKING_ID);
 

--- a/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/filter/DuplicateBroadcastProtectionFilter.java
+++ b/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/filter/DuplicateBroadcastProtectionFilter.java
@@ -64,14 +64,6 @@ public class DuplicateBroadcastProtectionFilter implements PerRequestBroadcastFi
 	private boolean isDoubleBroadcast(HttpServletRequest request,
 			Object responseEntity) throws JsonGenerationException,
 			JsonMappingException, IOException {
-		
-		if (request.getPathInfo().endsWith("state")) {
-			// extra handling for state requests.
-			// if an item and another item is switched to the same state
-			// the message must be broadcasted as well
-			return false;
-		}
-	
 		String clientId = request.getHeader(HeaderConfig.X_ATMOSPHERE_TRACKING_ID);
 
 		// return false if the X-Atmosphere-tracking-id is not set

--- a/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/listeners/ItemsStateChangeListener.java
+++ b/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/listeners/ItemsStateChangeListener.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.io.rest.internal.listeners;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.openhab.core.items.Item;
+import org.openhab.io.rest.RESTApplication;
+import org.openhab.ui.items.ItemUIRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is the {@link ResourceStateChangeListener} implementation for item REST requests
+ * 
+ * @author Robert Delbrück
+ * @since 1.8.0
+ */
+public class ItemsStateChangeListener extends ResourceStateChangeListener {
+
+	static final Logger logger = LoggerFactory.getLogger(ItemsStateChangeListener.class);
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Object getResponseObject(HttpServletRequest request) {	
+		return getItemAndState(this.lastChange);
+	}
+	
+	public static String getItemAndState(final Item item) {
+		if (item != null) {
+			return item.getName() + ":" + item.getState().toString();
+		}
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected Object getSingleResponseObject(Item item, HttpServletRequest request) {
+		return getResponseObject(request);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected Set<String> getRelevantItemNames(String pathInfo) {       
+		ItemUIRegistry registry = RESTApplication.getItemUIRegistry();
+        final Set<String> result = new HashSet<String>();
+        for (Item item : registry.getItems()) {
+        	result.add(item.getName());
+        }
+		return result;
+	}
+
+}

--- a/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/listeners/ResourceStateChangeListener.java
+++ b/bundles/io/org.openhab.io.rest/src/main/java/org/openhab/io/rest/internal/listeners/ResourceStateChangeListener.java
@@ -51,6 +51,7 @@ abstract public class ResourceStateChangeListener {
 	final static long CACHE_TIME = 300 * 1000; // 5 mins
 	
 	final static ConcurrentMap<String, CacheEntry> cachedEntries = new ConcurrentHashMap<String, CacheEntry>();
+	protected Item lastChange;
 	
 	static ScheduledFuture<?> executorFuture;
 	
@@ -149,6 +150,7 @@ abstract public class ResourceStateChangeListener {
 			}
 			
 			public void stateChanged(final Item item, State oldState, State newState) {
+				lastChange = item;
 				broadcaster.broadcast(item);
 //				Collection<AtmosphereResource> resources = broadcaster.getAtmosphereResources();
 //				if(!resources.isEmpty()) {
@@ -212,6 +214,10 @@ abstract public class ResourceStateChangeListener {
 			GenericItem genericItem = (GenericItem) item;
 			genericItem.removeStateChangeListener(stateChangeListener);
 		}
+	}
+	
+	public Item getLastChange() {
+		return this.lastChange;
 	}
 
 	/**


### PR DESCRIPTION
Not sending double broadcasts is good, but if registering for state changes on multiple items just the first change to e. g. ON is sended, all other following ON commands on other items will not be broadcasted.
This pull excludes double broadcast handling for */state registrations.