### PR TITLE
Netatmo: Added additional types, fix for #1820, #3242, and other improvements

### DIFF
--- a/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/NetatmoBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/NetatmoBindingProvider.java
@@ -10,6 +10,7 @@ package org.openhab.binding.netatmo;
 
 import org.openhab.core.binding.BindingProvider;
 import org.openhab.binding.netatmo.internal.NetatmoMeasureType;
+import org.openhab.binding.netatmo.internal.NetatmoScale;
 
 /**
  * This interface is implemented by classes that can provide mapping information
@@ -19,6 +20,7 @@ import org.openhab.binding.netatmo.internal.NetatmoMeasureType;
  * taken into account.
  * 
  * @author Andreas Brenk
+ * @author Rob Nielsen
  * @since 1.4.0
  */
 public interface NetatmoBindingProvider extends BindingProvider {
@@ -62,4 +64,13 @@ public interface NetatmoBindingProvider extends BindingProvider {
 	 */
 	String getModuleId(String itemName);
 
+	/**
+	 * Returns the scale to use when querying the Netatmo measure of the given
+	 * {@code itemName}.
+	 *
+	 * @param itemName
+	 * @return the Netatmo scale of the Item identified by {@code itemName} if
+	 *         it has a Netatmo binding, <code>null</code> otherwise
+	 */
+	NetatmoScale getNetatmoScale(String itemName);
 }

--- a/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoMeasureType.java
+++ b/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoMeasureType.java
@@ -12,22 +12,40 @@ import org.apache.commons.lang.StringUtils;
 
 /**
  * @author Gaël L'hopital
+ * @author Rob Nielsen
  * @since 1.6.0
  *
  *        This enum holds all the different measures and states available to be
  *        retrieved by the Netatmo binding
  */
 public enum NetatmoMeasureType {
-	CO2("CO2"), TEMPERATURE("Temperature"), HUMIDITY("Humidity"), NOISE("Noise"), PRESSURE(
-			"Pressure"), RAIN("Rain"), WIFISTATUS("WifiStatus"), ALTITUDE(
-			"Altitude"), LATITUDE("Latitude"), LONGITUDE("Longitude"), RFSTATUS(
-			"RfStatus"), BATTERYVP("BatteryVp"), TIMESTAMP("TimeStamp"), MODULENAME(
-			"ModuleName"), STATIONNAME("StationName"), COORDINATE("Coordinate");
+	CO2("CO2", NetatmoScale.MAX), TEMPERATURE("Temperature", NetatmoScale.MAX),
+	HUMIDITY("Humidity", NetatmoScale.MAX), NOISE("Noise", NetatmoScale.MAX),
+	PRESSURE("Pressure", NetatmoScale.MAX), RAIN("Rain", NetatmoScale.MAX),
+	WIFISTATUS("WifiStatus", NetatmoScale.MAX), ALTITUDE("Altitude",NetatmoScale.MAX),
+	LATITUDE("Latitude", NetatmoScale.MAX), LONGITUDE("Longitude", NetatmoScale.MAX),
+	RFSTATUS("RfStatus", NetatmoScale.MAX), BATTERYVP("BatteryVp", NetatmoScale.MAX),
+	TIMESTAMP("TimeStamp", NetatmoScale.MAX), MODULENAME("ModuleName",NetatmoScale.MAX),
+	STATIONNAME("StationName", NetatmoScale.MAX), COORDINATE("Coordinate", NetatmoScale.MAX),
+	MIN_TEMP("min_temp", NetatmoScale.ONE_DAY), MAX_TEMP("max_temp", NetatmoScale.ONE_DAY),
+	MIN_HUM("min_hum", NetatmoScale.ONE_DAY), MAX_HUM("max_hum", NetatmoScale.ONE_DAY),
+	MIN_PRESSURE("min_pressure", NetatmoScale.ONE_DAY), MAX_PRESSURE("max_pressure", NetatmoScale.ONE_DAY),
+	MIN_NOISE("min_noise", NetatmoScale.ONE_DAY), MAX_NOISE("max_noise", NetatmoScale.ONE_DAY),
+	MIN_CO2("min_co2", NetatmoScale.ONE_DAY), MAX_CO2("max_co2", NetatmoScale.ONE_DAY),
+	SUM_RAIN("sum_rain", NetatmoScale.ONE_DAY), DATE_MIN_TEMP("date_min_temp", NetatmoScale.ONE_DAY),
+	DATE_MAX_TEMP("date_max_temp", NetatmoScale.ONE_DAY), DATE_MIN_HUM("date_min_hum", NetatmoScale.ONE_DAY),
+	DATE_MAX_HUM("date_max_hum", NetatmoScale.ONE_DAY), DATE_MIN_PRESSURE("date_min_pressure", NetatmoScale.ONE_DAY),
+	DATE_MAX_PRESSURE("date_max_pressure", NetatmoScale.ONE_DAY), DATE_MIN_NOISE("date_min_noise", NetatmoScale.ONE_DAY),
+	DATE_MAX_NOISE("date_max_noise", NetatmoScale.ONE_DAY), DATE_MIN_CO2("date_min_co2", NetatmoScale.ONE_DAY),
+	DATE_MAX_CO2("date_max_co2", NetatmoScale.ONE_DAY);
 
-	String measure;
+	final String measure;
 
-	private NetatmoMeasureType(String measure) {
+	final NetatmoScale defaultScale;
+
+	private NetatmoMeasureType(String measure, NetatmoScale defaultScale) {
 		this.measure = measure;
+		this.defaultScale = defaultScale;
 	}
 
 	public String getMeasure() {
@@ -43,5 +61,26 @@ public enum NetatmoMeasureType {
 			}
 		}
 		throw new IllegalArgumentException("Invalid measure: " + measure);
+	}
+
+	public NetatmoScale getDefaultScale() {
+		return defaultScale;
+	}
+
+	public static boolean isPressure(NetatmoMeasureType measureType) {
+		return measureType == NetatmoMeasureType.PRESSURE
+				|| measureType == NetatmoMeasureType.MIN_PRESSURE
+				|| measureType == NetatmoMeasureType.MAX_PRESSURE;
+	}
+
+	public static boolean isRain(NetatmoMeasureType measureType) {
+		return measureType == NetatmoMeasureType.RAIN
+				|| measureType == NetatmoMeasureType.SUM_RAIN;
+	}
+
+	public static boolean isTemperature(NetatmoMeasureType measureType) {
+		return measureType == NetatmoMeasureType.TEMPERATURE
+				|| measureType == NetatmoMeasureType.MIN_TEMP
+				|| measureType == NetatmoMeasureType.MAX_TEMP;
 	}
 }

--- a/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoPressureUnit.java
+++ b/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoPressureUnit.java
@@ -23,9 +23,10 @@ public enum NetatmoPressureUnit {
 	MBAR("mbar"), INHG("inHg"), MMHG("mmHg");
 
 	public static final NetatmoPressureUnit DEFAULT_PRESSURE_UNIT = NetatmoPressureUnit.MBAR;
-	private static final BigDecimal MBAR_TO_INHG = new BigDecimal(0.02952998751);
 
-	private static final BigDecimal MBAR_TO_MMHG = new BigDecimal(0.750061683);
+	private static final BigDecimal MBAR_TO_INHG = new BigDecimal("0.0295");
+
+	private static final BigDecimal MBAR_TO_MMHG = new BigDecimal("0.7500");
 
 	String pressureUnit;
 
@@ -50,6 +51,16 @@ public enum NetatmoPressureUnit {
 				+ pressureUnit);
 	}
 	
+	/**
+	 * Convert to appropriate measurement.
+	 *
+	 * The Barometer is accurate to +-1 mbar or +- 0.03 inHg
+	 *
+	 * @param value
+	 *            pressure in mbars
+	 *
+	 * @return value in proper measurement
+	 */
 	public BigDecimal convertPressure(BigDecimal value) {
 		if (this == DEFAULT_PRESSURE_UNIT) {
 			return value;

--- a/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoScale.java
+++ b/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoScale.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.netatmo.internal;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * @author Rob Nielsen
+ * @since 1.8.0
+ *
+ *        This enum holds all the different scales for the Netatmo binding
+ *        when using the Netatmo getMeasure api
+ */
+public enum NetatmoScale {
+	MAX("max"), THIRTY_MIN("30min"), ONE_HOUR("1hour"), THREE_HOURS("3hours"),
+	ONE_DAY("1day"), ONE_WEEK("1week"), ONE_MONTH("1month");
+
+	String scale;
+
+	private NetatmoScale(String scale) {
+		this.scale = scale;
+	}
+
+	public String getScale() {
+		return scale;
+	}
+
+	public static NetatmoScale fromString(String scale) {
+		if (!StringUtils.isEmpty(scale)) {
+			for (NetatmoScale unitSystemType : NetatmoScale.values()) {
+				if (unitSystemType.getScale().equalsIgnoreCase(scale)) {
+					return unitSystemType;
+				}
+			}
+		}
+		throw new IllegalArgumentException("Invalid scale: " + scale);
+	}
+}

--- a/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoUnitSystem.java
+++ b/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/NetatmoUnitSystem.java
@@ -26,11 +26,11 @@ public enum NetatmoUnitSystem {
 
 	private static final double METERS_TO_FEET = 3.2808399;
 
-	private static final BigDecimal MM_TO_INCHES = new BigDecimal(0.0393700787);
+	private static final BigDecimal MM_TO_INCHES = new BigDecimal("0.0394");
 
-	private static final BigDecimal ONE_POINT_EIGHT = new BigDecimal(1.8);
+	private static final BigDecimal ONE_POINT_EIGHT = new BigDecimal("1.8");
 
-	private static final BigDecimal THIRTY_TWO = new BigDecimal(32);
+	private static final BigDecimal THIRTY_TWO = new BigDecimal("32");
 
 	String unitSystem;
 
@@ -53,6 +53,14 @@ public enum NetatmoUnitSystem {
 		throw new IllegalArgumentException("Invalid unitSystem: " + unitSystem);
 	}
 	
+	/**
+	 * Convert to appropriate measurement.
+	 *
+	 * @param value
+	 *            altitude in Meters
+	 *
+	 * @return value in the proper measurement
+	 */
 	public double convertAltitude(double value) {
 		if (this == DEFAULT_UNIT_SYSTEM) {
 			return value;
@@ -61,6 +69,17 @@ public enum NetatmoUnitSystem {
 		return value * METERS_TO_FEET;
 	}
 	
+	/**
+	 * Convert to appropriate measurement.
+	 *
+	 * The Rain gauge is accurate to 1 mm/h or 0.04 in/h, and the range starts
+	 * at 0.2 mm/h or 0.01 in/h.
+	 *
+	 * @param value
+	 *            rain in Millimeters
+	 *
+	 * @return value in the proper measurement
+	 */
 	public BigDecimal convertRain(BigDecimal value) {
 		if (this == DEFAULT_UNIT_SYSTEM) {
 			return value;
@@ -68,7 +87,17 @@ public enum NetatmoUnitSystem {
 		
 		return value.multiply(MM_TO_INCHES);
 	}
-	
+
+	/**
+	 * Convert to appropriate measurement.
+	 *
+	 * The Thermometer is accurate to +- 0.3°C or +- 0.54°F
+	 *
+	 * @param value
+	 *            temperature in Celsius
+	 *
+	 * @return value the in proper measurement
+	 */
 	public BigDecimal convertTemp(BigDecimal value) {
 		if (this == DEFAULT_UNIT_SYSTEM) {
 			return value;

--- a/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/messages/DeviceListRequest.java
+++ b/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/messages/DeviceListRequest.java
@@ -14,6 +14,8 @@ import static org.openhab.io.net.http.HttpUtil.executeUrl;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.openhab.binding.netatmo.internal.NetatmoException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A devicelist request returns the list of devices owned by the user, and their
@@ -27,6 +29,8 @@ import org.openhab.binding.netatmo.internal.NetatmoException;
 public class DeviceListRequest extends AbstractRequest {
 
 	private static final String RESOURCE_URL = API_BASE_URL + "devicelist";
+
+	private static final Logger logger = LoggerFactory.getLogger(DeviceListRequest.class);
 
 	private final String accessToken;
 
@@ -46,6 +50,9 @@ public class DeviceListRequest extends AbstractRequest {
 	@Override
 	public DeviceListResponse execute() {
 		final String url = prepare();
+
+		logger.debug(url);
+
 		String json = null;
 
 		try {

--- a/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/messages/NetatmoError.java
+++ b/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/messages/NetatmoError.java
@@ -56,6 +56,10 @@ public class NetatmoError extends AbstractMessagePart {
 		return this.message;
 	}
 
+	public boolean isTokenNotVaid() {
+		return this.code == 2;
+	}
+
 	public boolean isAccessTokenExpired() {
 		return this.code == 3;
 	}

--- a/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/messages/RefreshTokenRequest.java
+++ b/bundles/binding/org.openhab.binding.netatmo/src/main/java/org/openhab/binding/netatmo/internal/messages/RefreshTokenRequest.java
@@ -54,6 +54,9 @@ public class RefreshTokenRequest extends AbstractRequest {
 					this.clientId, this.clientSecret);
 
 			json = executeQuery(content);
+			if (json == null) {
+				return null;
+			}
 
 			final RefreshTokenResponse response = JSON.readValue(json,
 					RefreshTokenResponse.class);


### PR DESCRIPTION
Added support to Netamato binding for *min_*, *max_*, sum_rain for the intervals 30 minutes, 1 hour, 3 hours, 1 day, 1 week and 1 month. The interval is configurable and defaults to 1 day.

The pull request https://github.com/openhab/openhab/pull/2820 that I created didn't have any scaling of converted values, this was giving the false impression of higher precision than is actually available (many digits of precision). The values are treated as intermediate vales scaled according to the Significant Figures and Significant Arithmetic rules which is widely used with scientific data.

Fix for issue https://github.com/openhab/openhab/issues/1820, if the token was expired, the token was refreshed and a recursive call was made to re-execute the binding, this would cause null pointer exceptions in the original execute call to the binding.

Fix for issue https://github.com/openhab/openhab/issues/3242, if the Netatmo api returns a null altituded, the binding was throwing a null pointer exception.

Added support to also refresh the token if the call to netamoto indicated the token was invalid.

Added better error message if the StartCom CA certificate is not installed