### PR TITLE
DSC Alarm Binding - Feature Additions

### DIFF
--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmItemType.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmItemType.java
@@ -24,6 +24,17 @@ public enum DSCAlarmItemType{
 	PANEL_COMMAND("panel_command"),
 	PANEL_SYSTEM_ERROR("panel_system_error"),
 
+	PANEL_TROUBLE_MESSAGE("panel_trouble_message"),
+	PANEL_TROUBLE_LED("panel_trouble_led"),
+	PANEL_SERVICE_REQUIRED("panel_service_required"),
+	PANEL_AC_TROUBLE("panel_ac_trouble"),
+	PANEL_TELEPHONE_TROUBLE("panel_telephone_trouble"),
+	PANEL_FTC_TROUBLE("panel_ftc_trouble"),
+	PANEL_ZONE_FAULT("panel_zone_fault"),
+	PANEL_ZONE_TAMPER("panel_zone_tamper"),
+	PANEL_ZONE_LOW_BATTERY("panel_zone_low_battery"),
+	PANEL_TIME_LOSS("panel_time_loss"),
+
 	PANEL_TIME("panel_time"),
 	PANEL_TIME_STAMP("panel_time_stamp"),
 	PANEL_TIME_BROADCAST("panel_time_broadcast"),
@@ -40,6 +51,7 @@ public enum DSCAlarmItemType{
 	PARTITION_ENTRY_DELAY("partition_entry_delay"),
 	PARTITION_EXIT_DELAY("partition_exit_delay"),
 	PARTITION_IN_ALARM("partition_in_alarm"),
+	PARTITION_OPENING_CLOSING_MODE("partition_opening_closing_mode"),
 	
 	ZONE_GENERAL_STATUS("zone_general_status"),
 	ZONE_ALARM_STATUS("zone_alarm_status"),
@@ -51,6 +63,7 @@ public enum DSCAlarmItemType{
 	ZONE_TAMPER("zone_tamper"),
 	ZONE_FAULT("zone_fault"),
 	ZONE_TRIPPED("zone_tripped"),
+	ZONE_STATE("zone_state"),
 	
 	KEYPAD_READY_LED("keypad_ready_led"),
 	KEYPAD_ARMED_LED("keypad_armed_led"),

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/connector/SerialConnector.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/connector/SerialConnector.java
@@ -74,6 +74,7 @@ public class SerialConnector implements DSCAlarmConnector, SerialPortEventListen
         try {
         	serialOutput.write(writeString);
             serialOutput.flush();
+    		logger.debug("write(): Message Sent: {}",writeString);
         }catch (IOException ioException) {
         	logger.error("write(): {}",ioException);
 			connected = false;
@@ -91,6 +92,7 @@ public class SerialConnector implements DSCAlarmConnector, SerialPortEventListen
 
         try {
         	message = readLine();
+    		logger.debug("read(): Message Received: {}",message);
         }
         catch (IOException ioException) {
 			logger.error("read(): IO Exception: ", ioException);

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/connector/TCPConnector.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/connector/TCPConnector.java
@@ -70,6 +70,7 @@ public class TCPConnector implements DSCAlarmConnector {
         try {
         	tcpOutput.write(writeString);
             tcpOutput.flush();
+    		logger.debug("write(): Message Sent: {}",writeString);
         }catch (IOException ioException) {
         	logger.error("write(): {}",ioException);
 			connected = false;
@@ -87,6 +88,7 @@ public class TCPConnector implements DSCAlarmConnector {
 
         try {
         	message = tcpInput.readLine();
+    		logger.debug("read(): Message Received: {}",message);
         }
         catch (IOException ioException) {
 			logger.error("read(): IO Exception: ", ioException);

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/DSCAlarmDeviceProperties.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/DSCAlarmDeviceProperties.java
@@ -50,7 +50,16 @@ public class DSCAlarmDeviceProperties {
 	private String tamperStateDescription = "";
 	private int faultState = 0;
 	private String faultStateDescription = "";
-
+	private int openingClosingState = 0; /* 0=None, 1=User Closing, 2=Special Closing, 3=Partial Closing, 4=User Opening, 5=Special Opening */
+	private String openingClosingStateDescription = "";
+	/* Bitwise representation of a zones state:
+	   bit0=General State (0-Closed, 1-Open),
+	   bit1=Arm State (0-Armed, 1-Bypassed)
+	   bit2=Alarm State (0-No Alarm, 1-Alarm)
+	   bit3=Tamper State (0-No Tamper, 1-Tamper)
+	   bit4=Fault State (0-No Fault, 1-Fault) */
+	private int zoneBitState = 0;
+	
 	private String ledStates[] = {"Off","On","Flashing"};
 	private int readyLEDState = 0; /* 0=Off, 1=On, 2=Flashing*/
 	private String readyLEDStateDescription = "Off";
@@ -71,6 +80,17 @@ public class DSCAlarmDeviceProperties {
 	private int acLEDState = 0; /* 0=Off, 1=On, 2=Flashing*/
 	private String acLEDStateDescription = "Off";
 
+	private String troubleMessage = "";
+	private boolean troubleLED = false;
+	private boolean serviceRequired = false;
+	private boolean acTrouble = false;
+	private boolean telephoneLineTrouble = false;
+	private boolean failureToCommunicate = false;
+	private boolean zoneFault = false;
+	private boolean zoneTamper = false;
+	private boolean zoneLowBattery = false;
+	private boolean lossOfTime = false;
+		
 	private boolean fireKeyAlarm = false;
 	private boolean panicKeyAlarm = false;
 	private boolean auxKeyAlarm = false;
@@ -91,7 +111,8 @@ public class DSCAlarmDeviceProperties {
 		ARM_STATE,
 		ALARM_STATE,
 		TAMPER_STATE,
-		FAULT_STATE;
+		FAULT_STATE,
+		OPENING_CLOSING_STATE;
 	}
 	
 	enum LEDStateType{
@@ -106,6 +127,17 @@ public class DSCAlarmDeviceProperties {
 		AC_LED_STATE;
 	}
 
+	enum TroubleType{
+		SERVICE_REQUIRED,
+		AC_TROUBLE,
+		TELEPHONE_LINE_TROUBLE,
+		FAILURE_TO_COMMUNICATE,
+		ZONE_FAULT,
+		ZONE_TAMPER,
+		ZONE_LOW_BATTERY,
+		LOSS_OF_TIME;
+	}
+	
 	enum TriggerType{
 		FIRE_KEY_ALARM,
 		PANIC_KEY_ALARM,
@@ -202,6 +234,9 @@ public class DSCAlarmDeviceProperties {
 			case FAULT_STATE:
 				state = faultState;
 				break;
+			case OPENING_CLOSING_STATE:
+				state = openingClosingState;
+				break;
 			default:
 				break;
 		}
@@ -231,13 +266,59 @@ public class DSCAlarmDeviceProperties {
 			case FAULT_STATE:
 				stateDescription = faultStateDescription;
 				break;
+			case OPENING_CLOSING_STATE:
+				stateDescription = openingClosingStateDescription;
+				break;
 			default:
 				break;
 		}
 		
 		return stateDescription;
 	}
-
+	
+	public int getZoneBitState() {
+		return zoneBitState;
+	}
+	
+	public boolean getZoneBitState(int bit) {
+		int bitState;
+		boolean state = false;
+		
+		if(bit >= 0 && bit <= 7) {
+			bitState = (this.zoneBitState >> bit) & 1;
+			if(bitState == 1)
+				state = true;
+		}
+		
+		return state;
+	}
+	
+	public boolean getZoneBitState(StateType stateType) {
+		int bit = -1;
+		
+		switch(stateType) {
+			case GENERAL_STATE:
+				bit = 0;
+				break;
+			case ARM_STATE:
+				bit = 1;
+				break;
+			case ALARM_STATE:
+				bit = 2;
+				break;
+			case TAMPER_STATE:
+				bit = 3;
+				break;
+			case FAULT_STATE:
+				bit = 4;
+				break;
+			default:
+				break;
+		}
+		
+		return getZoneBitState(bit);
+	}
+	
 	public int getLEDState(LEDStateType stateType) {
 		int state = 0;
 		
@@ -314,6 +395,50 @@ public class DSCAlarmDeviceProperties {
 	
 		return stateDescription;
 
+	}
+	
+	public String getTroubleMessage() {
+		return troubleMessage;
+	}
+
+	public boolean getTroubleLED() {
+		return troubleLED;
+	}
+
+	public boolean getTrouble(TroubleType troubleType) {
+		boolean trouble = false;
+		
+		switch(troubleType) {
+			case SERVICE_REQUIRED:
+				trouble = serviceRequired;
+				break;
+			case AC_TROUBLE:
+				trouble = acTrouble;
+				break;
+			case TELEPHONE_LINE_TROUBLE:
+				trouble = telephoneLineTrouble;
+				break;
+			case FAILURE_TO_COMMUNICATE:
+				trouble = failureToCommunicate;
+				break;
+			case ZONE_FAULT:
+				trouble = zoneFault;
+				break;
+			case ZONE_TAMPER:
+				trouble = zoneTamper;
+				break;
+			case ZONE_LOW_BATTERY:
+				trouble = zoneLowBattery;
+				break;
+			case LOSS_OF_TIME:
+				trouble = lossOfTime;
+				break;
+			default:
+				break;
+		}
+		
+		return trouble;
+		
 	}
 	
 	public boolean getTrigger(TriggerType triggerType) {
@@ -454,6 +579,10 @@ public class DSCAlarmDeviceProperties {
 				faultState = state;
 				faultStateDescription = stateDescription;
 				break;
+			case OPENING_CLOSING_STATE:
+				openingClosingState = state;
+				openingClosingStateDescription = stateDescription;
+				break;
 			default:
 				break;
 		}
@@ -480,11 +609,57 @@ public class DSCAlarmDeviceProperties {
 			case FAULT_STATE:
 				faultStateDescription = stateDescription;
 				break;
+			case OPENING_CLOSING_STATE:
+				openingClosingStateDescription = stateDescription;
+				break;
 			default:
 				break;
 		}
 	}
+
+	public void clearZoneBitState() {
+		zoneBitState = 0;
+	}
 	
+	public void setZoneBitState(int bit, boolean set) {
+		
+		if(bit >= 0 && bit <= 7) {
+			if(set) {
+				zoneBitState |= 1 << bit;
+			}
+			else {
+				zoneBitState &= ~(1 << bit);
+				
+			}
+		}
+	}
+
+	public void setZoneBitState(StateType stateType, boolean set) {
+		int bit = -1;
+		
+		switch(stateType) {
+			case GENERAL_STATE:
+				bit = 0;
+				break;
+			case ARM_STATE:
+				bit = 1;
+				break;
+			case ALARM_STATE:
+				bit = 2;
+				break;
+			case TAMPER_STATE:
+				bit = 3;
+				break;
+			case FAULT_STATE:
+				bit = 4;
+				break;
+			default:
+				break;
+		}
+		
+		setZoneBitState(bit, set);
+	}
+
 	public void setLEDState(LEDStateType stateType, int state) {
 		
 		switch(stateType) {
@@ -528,6 +703,47 @@ public class DSCAlarmDeviceProperties {
 				break;
 		}	
 	}
+
+	public void setTroubleMessage(String troubleCondition) {
+		this.troubleMessage = troubleCondition;
+	}
+
+	public void setTroubleLED(boolean troubleLED) {
+		this.troubleLED = troubleLED;
+	}
+
+	public void setTrouble(TroubleType troubleType, boolean trouble) {
+		
+		switch(troubleType) {
+			case SERVICE_REQUIRED:
+				serviceRequired = trouble;
+				break;
+			case AC_TROUBLE:
+				acTrouble = trouble;
+				break;
+			case TELEPHONE_LINE_TROUBLE:
+				telephoneLineTrouble = trouble;
+				break;
+			case FAILURE_TO_COMMUNICATE:
+				failureToCommunicate = trouble;
+				break;
+			case ZONE_FAULT:
+				zoneFault = trouble;
+				break;
+			case ZONE_TAMPER:
+				zoneTamper = trouble;
+				break;
+			case ZONE_LOW_BATTERY:
+				zoneLowBattery = trouble;
+				break;
+			case LOSS_OF_TIME:
+				lossOfTime = trouble;
+				break;
+			default:
+				break;
+		}		
+	}
+	
 	public void setTrigger(TriggerType triggerType, boolean trigger) {
 		
 		switch(triggerType) {
@@ -573,5 +789,66 @@ public class DSCAlarmDeviceProperties {
 			default:
 				break;
 		}
+	}
+	
+	public static void main (String[] arg) {
+		DSCAlarmDeviceProperties prop = new DSCAlarmDeviceProperties();
+		int bitState = prop.getZoneBitState();
+		boolean state = false;
+		System.out.println(bitState + " " + state);
+		
+		prop.setZoneBitState(StateType.GENERAL_STATE, true);
+		bitState = prop.getZoneBitState();
+		state = prop.getZoneBitState(StateType.GENERAL_STATE);
+		System.out.println("General State: " + bitState + " " + state);
+		prop.setZoneBitState(StateType.GENERAL_STATE, false);
+		bitState = prop.getZoneBitState();
+		state = prop.getZoneBitState(StateType.GENERAL_STATE);
+		System.out.println("General State: " + bitState + " " + state);
+		
+		prop.setZoneBitState(StateType.ARM_STATE, true);
+		bitState = prop.getZoneBitState();
+		state = prop.getZoneBitState(StateType.ARM_STATE);
+		System.out.println("Arm State: " + bitState + " " + state);
+		prop.setZoneBitState(StateType.ARM_STATE, false);
+		bitState = prop.getZoneBitState();
+		state = prop.getZoneBitState(StateType.ARM_STATE);
+		System.out.println("Arm State: " + bitState + " " + state);
+
+		prop.setZoneBitState(StateType.ALARM_STATE, true);
+		bitState = prop.getZoneBitState();
+		state = prop.getZoneBitState(StateType.ALARM_STATE);
+		System.out.println("Alarm State: " + bitState + " " + state);
+		prop.setZoneBitState(StateType.ALARM_STATE, false);
+		bitState = prop.getZoneBitState();
+		state = prop.getZoneBitState(StateType.ALARM_STATE);
+		System.out.println("Alarm State: " + bitState + " " + state);
+
+		prop.setZoneBitState(StateType.TAMPER_STATE, true);
+		bitState = prop.getZoneBitState();
+		state = prop.getZoneBitState(StateType.TAMPER_STATE);
+		System.out.println("Tamper State: " + bitState + " " + state);
+		prop.setZoneBitState(StateType.TAMPER_STATE, false);
+		bitState = prop.getZoneBitState();
+		state = prop.getZoneBitState(StateType.ALARM_STATE);
+		System.out.println("Tamper State: " + bitState + " " + state);
+
+		prop.setZoneBitState(StateType.FAULT_STATE, true);
+		bitState = prop.getZoneBitState();
+		state = prop.getZoneBitState(StateType.FAULT_STATE);
+		System.out.println("Fault State: " + bitState + " " + state);
+		prop.setZoneBitState(StateType.FAULT_STATE, false);
+		bitState = prop.getZoneBitState();
+		state = prop.getZoneBitState(StateType.FAULT_STATE);
+		System.out.println("Fault State: " + bitState + " " + state);
+		
+		prop.setZoneBitState(7, true);
+		bitState = prop.getZoneBitState();
+		state = prop.getZoneBitState(7);
+		System.out.println("Seventh Bit: " + bitState + " " + state);
+		prop.setZoneBitState(7, false);
+		bitState = prop.getZoneBitState();
+		state = prop.getZoneBitState(7);
+		System.out.println("Seventh Bit: " + bitState + " " + state);
 	}
 }

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Panel.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Panel.java
@@ -11,6 +11,7 @@ package org.openhab.binding.dscalarm.internal.model;
 import org.openhab.binding.dscalarm.DSCAlarmBindingConfig;
 import org.openhab.binding.dscalarm.internal.model.DSCAlarmDeviceProperties.StateType;
 import org.openhab.binding.dscalarm.internal.model.DSCAlarmDeviceProperties.TriggerType;
+import org.openhab.binding.dscalarm.internal.model.DSCAlarmDeviceProperties.TroubleType;
 import org.openhab.binding.dscalarm.internal.protocol.APIMessage;
 import org.openhab.binding.dscalarm.internal.DSCAlarmEvent;
 import org.openhab.core.events.EventPublisher;
@@ -52,6 +53,7 @@ public class Panel extends DSCAlarmDevice{
 		int state;
 		String str = "";
 		boolean trigger;
+		boolean trouble;
 		boolean boolState;
 		OnOffType onOffType;
 
@@ -88,6 +90,55 @@ public class Panel extends DSCAlarmDevice{
 						state = panelProperties.getSystemCommand();
 						publisher.postUpdate(item.getName(), new DecimalType(state));
 						break;
+					case PANEL_TROUBLE_MESSAGE:
+						str = panelProperties.getTroubleMessage();
+						publisher.postUpdate(item.getName(), new StringType(str));
+						break;
+					case PANEL_TROUBLE_LED:
+						boolState = panelProperties.getTroubleLED();
+						onOffType = boolState ? OnOffType.ON : OnOffType.OFF;
+						publisher.postUpdate(item.getName(), onOffType);
+						break;						
+					case PANEL_SERVICE_REQUIRED:
+						trouble = panelProperties.getTrouble(TroubleType.SERVICE_REQUIRED);
+						onOffType = trouble ? OnOffType.ON : OnOffType.OFF;
+						publisher.postUpdate(item.getName(), onOffType);
+						break;						
+					case PANEL_AC_TROUBLE:
+						trouble = panelProperties.getTrouble(TroubleType.AC_TROUBLE);
+						onOffType = trouble ? OnOffType.ON : OnOffType.OFF;
+						publisher.postUpdate(item.getName(), onOffType);
+						break;						
+					case PANEL_TELEPHONE_TROUBLE:
+						trouble = panelProperties.getTrouble(TroubleType.TELEPHONE_LINE_TROUBLE);
+						onOffType = trouble ? OnOffType.ON : OnOffType.OFF;
+						publisher.postUpdate(item.getName(), onOffType);
+						break;						
+					case PANEL_FTC_TROUBLE:
+						trouble = panelProperties.getTrouble(TroubleType.FAILURE_TO_COMMUNICATE);
+						onOffType = trouble ? OnOffType.ON : OnOffType.OFF;
+						publisher.postUpdate(item.getName(), onOffType);
+						break;						
+					case PANEL_ZONE_FAULT:
+						trouble = panelProperties.getTrouble(TroubleType.ZONE_FAULT);
+						onOffType = trouble ? OnOffType.ON : OnOffType.OFF;
+						publisher.postUpdate(item.getName(), onOffType);
+						break;						
+					case PANEL_ZONE_TAMPER:
+						trouble = panelProperties.getTrouble(TroubleType.ZONE_TAMPER);
+						onOffType = trouble ? OnOffType.ON : OnOffType.OFF;
+						publisher.postUpdate(item.getName(), onOffType);
+						break;						
+					case PANEL_ZONE_LOW_BATTERY:
+						trouble = panelProperties.getTrouble(TroubleType.ZONE_LOW_BATTERY);
+						onOffType = trouble ? OnOffType.ON : OnOffType.OFF;
+						publisher.postUpdate(item.getName(), onOffType);
+						break;						
+					case PANEL_TIME_LOSS:
+						trouble = panelProperties.getTrouble(TroubleType.LOSS_OF_TIME);
+						onOffType = trouble ? OnOffType.ON : OnOffType.OFF;
+						publisher.postUpdate(item.getName(), onOffType);
+						break;						
 					case PANEL_FIRE_KEY_ALARM:
 						trigger = panelProperties.getTrigger(TriggerType.FIRE_KEY_ALARM);
 						onOffType = trigger ? OnOffType.ON : OnOffType.OFF;
@@ -122,10 +173,14 @@ public class Panel extends DSCAlarmDevice{
 	@Override
 	public void handleEvent(Item item, DSCAlarmBindingConfig config, EventPublisher publisher, DSCAlarmEvent event) {
 		APIMessage apiMessage = null;
+		int apiCode = -1;
+		boolean boolState;
 		int state;
+		OnOffType onOffType;
 
 		if(event != null) {
 			apiMessage = event.getAPIMessage();
+			apiCode = Integer.parseInt(apiMessage.getAPICode());
 			String str = "";
 			logger.debug("handleEvent(): Panel Item Name: {}", item.getName());
 	
@@ -157,6 +212,22 @@ public class Panel extends DSCAlarmDevice{
 								publisher.postUpdate(item.getName(), new StringType(str));
 							}
 							break;
+						case PANEL_TROUBLE_MESSAGE:
+							if(apiMessage != null) {
+								str = apiMessage.getAPIDescription();
+								panelProperties.setTroubleMessage(str);
+							}
+							publisher.postUpdate(item.getName(), new StringType(str));
+							break;
+						case PANEL_TROUBLE_LED:
+							if(apiMessage != null) {
+								boolState = (apiCode == 840) ? true:false;
+								panelProperties.setTroubleLED(boolState);
+								
+								onOffType = boolState ? OnOffType.ON : OnOffType.OFF;
+								publisher.postUpdate(item.getName(), onOffType);
+							}
+							break;
 						case PANEL_TIME:
 							if(apiMessage != null) {
 								panelProperties.setSystemTime(apiMessage.getAPIData());
@@ -180,6 +251,7 @@ public class Panel extends DSCAlarmDevice{
 		logger.debug("updateProperties(): Panel Item Name: {}", item.getName());
 		
 		boolean trigger = state != 0 ? true : false;
+		boolean trouble = state != 0 ? true : false;		
 		boolean boolState = state != 0 ? true : false;
 
 		if(config != null) {
@@ -194,6 +266,36 @@ public class Panel extends DSCAlarmDevice{
 					case PANEL_COMMAND:
 						panelProperties.setSystemCommand(state);
 						break;
+					case PANEL_TROUBLE_MESSAGE:
+						panelProperties.setTroubleMessage(description);
+						break;
+					case PANEL_TROUBLE_LED:
+						panelProperties.setTroubleLED(boolState);
+						break;						
+					case PANEL_SERVICE_REQUIRED:
+						panelProperties.setTrouble(TroubleType.SERVICE_REQUIRED, trouble);
+						break;						
+					case PANEL_AC_TROUBLE:
+						panelProperties.setTrouble(TroubleType.AC_TROUBLE, trouble);
+						break;						
+					case PANEL_TELEPHONE_TROUBLE:
+						panelProperties.setTrouble(TroubleType.TELEPHONE_LINE_TROUBLE, trouble);
+						break;						
+					case PANEL_FTC_TROUBLE:
+						panelProperties.setTrouble(TroubleType.FAILURE_TO_COMMUNICATE, trouble);
+						break;						
+					case PANEL_ZONE_FAULT:
+						panelProperties.setTrouble(TroubleType.ZONE_FAULT, trouble);
+						break;						
+					case PANEL_ZONE_TAMPER:
+						panelProperties.setTrouble(TroubleType.ZONE_TAMPER, trouble);
+						break;						
+					case PANEL_ZONE_LOW_BATTERY:
+						panelProperties.setTrouble(TroubleType.ZONE_LOW_BATTERY, trouble);
+						break;						
+					case PANEL_TIME_LOSS:
+						panelProperties.setTrouble(TroubleType.LOSS_OF_TIME, trouble);
+						break;						
 					case PANEL_FIRE_KEY_ALARM:
 						panelProperties.setTrigger(TriggerType.FIRE_KEY_ALARM, trigger);
 						break;

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Partition.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Partition.java
@@ -91,6 +91,16 @@ public class Partition extends DSCAlarmDevice{
 						onOffType = trigger ? OnOffType.ON : OnOffType.OFF;
 						publisher.postUpdate(item.getName(), onOffType);
 						break;
+					case PARTITION_OPENING_CLOSING_MODE:
+						state = partitionProperties.getState(StateType.OPENING_CLOSING_STATE);
+						strStatus = partitionProperties.getStateDescription(StateType.OPENING_CLOSING_STATE);
+						if(item instanceof NumberItem) {
+							publisher.postUpdate(item.getName(), new DecimalType(state));
+						}
+						if(item instanceof StringItem) {
+							publisher.postUpdate(item.getName(), new StringType(strStatus));
+						}
+						break;
 					default:
 						logger.debug("refreshItem(): Partition item not updated.");
 						break;
@@ -151,6 +161,37 @@ public class Partition extends DSCAlarmDevice{
 								publisher.postUpdate(item.getName(), new StringType(strStatus));
 							}
 							break;
+						case PARTITION_OPENING_CLOSING_MODE:
+							switch(apiCode) {
+								case 700:
+									state=1;
+									break;
+								case 701:
+									state=2;
+									break;
+								case 702:
+									state=3;
+									break;
+								case 750:
+									state=4;
+									break;
+								case 751:
+									state=5;
+									break;
+								default:
+									state=0;
+									strStatus = "";
+									break;
+							}							
+							partitionProperties.setState(StateType.OPENING_CLOSING_STATE, state, strStatus);
+							strStatus = partitionProperties.getStateDescription(StateType.OPENING_CLOSING_STATE);
+							if(item instanceof NumberItem) {
+								publisher.postUpdate(item.getName(), new DecimalType(state));
+							}
+							if(item instanceof StringItem) {
+								publisher.postUpdate(item.getName(), new StringType(strStatus));
+							}
+							break;
 						default:
 							logger.debug("handleEvent(): Partition item not updated.");
 							break;
@@ -188,6 +229,9 @@ public class Partition extends DSCAlarmDevice{
 						break;
 					case PARTITION_IN_ALARM:
 						partitionProperties.setTrigger(TriggerType.ALARMED, trigger);
+						break;
+					case PARTITION_OPENING_CLOSING_MODE:
+						partitionProperties.setState(StateType.OPENING_CLOSING_STATE, state, description);
 						break;
 					default: 
 						logger.debug("updateProperties(): Partition property not updated.");

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/APIMessage.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/APIMessage.java
@@ -451,6 +451,7 @@ public class APIMessage {
 						apiDescription = apiCodeReceived + ": A partition has been armed by a user.";
 						partition = Integer.parseInt(apiMessage.substring(3, 4));
 						user = apiMessage.substring(4);
+						apiName = apiName.concat(": " + user);
 						apiMessageType = APIMessageType.PARTITION_EVENT;
 						break;
 					case SpecialClosing: /*701*/
@@ -470,6 +471,7 @@ public class APIMessage {
 						apiDescription = apiCodeReceived + ": A partition has been disarmed by a user.";
 						partition = Integer.parseInt(apiMessage.substring(3, 4));
 						user = apiMessage.substring(4);
+						apiName = apiName.concat(": " + user);
 						apiMessageType = APIMessageType.PARTITION_EVENT;
 						break;
 					case SpecialOpening: /*751*/
@@ -485,7 +487,7 @@ public class APIMessage {
 						break;
 					case PanelBatteryTroubleRestore: /*801*/
 						apiName = "Panel Battery Trouble Restore";
-						apiDescription = apiCodeReceived + ": The panel�s low battery has been restored.";
+						apiDescription = apiCodeReceived + ": The panels low battery has been restored.";
 						break;
 					case PanelACTrouble: /*802*/
 						apiName = "Panel AC Trouble";
@@ -567,11 +569,11 @@ public class APIMessage {
 						break;
 					case HomeAutomationTrouble: /*831*/
 						apiName = "Home Automation Trouble";
-						apiDescription = apiCodeReceived + ": A Escort 5580 module trouble.";
+						apiDescription = apiCodeReceived + ": Escort 5580 module trouble.";
 						break;
 					case HomeAutomationTroubleRestore: /*832*/
 						apiName = "Home Automation Trouble Restore";
-						apiDescription = apiCodeReceived + ": A Escort 5580 module trouble has been restored.";
+						apiDescription = apiCodeReceived + ": Escort 5580 module trouble has been restored.";
 						break;
 					case TroubleLEDOn: /*840*/
 						apiName = "Trouble LED ON";


### PR DESCRIPTION
Here are some feature additions made to the DSC Alarm binding:

1. The following new items were added to display panel trouble conditions which was not possible previously.
  * **panel_trouble_led**
  * **panel_service_required**
  * **panel_ac_trouble**
  * **panel_telephone_trouble**
  * **panel_ftc_trouble**
  * **panel_zone_fault**
  * **panel_zone_tamper**
  * **panel_zone_low_battery**
  * **panel_time_loss**
  * **panel_trouble_message**

2. The item **partition_opening_closing_mode** was added to show which opening/closing method was used, and to separate those messages from the **partition_status** item.  This was by request from openHAB Google Group as seen here: https://groups.google.com/d/msg/openhab/71Ku6VOf16o/GpI0t25wWXcJ.

3. A new configuration option was added to suppress the display of acknowledgment messages coming from the panel such as the message; '500 : A command has been received successfully.'.