### PR TITLE
remove -Dorg.eclipse.swt.browser.DefaultType=mozilla startup parameter again

### DIFF
--- a/products/org.openhab.designer.product/org.openhab.designer.product.product
+++ b/products/org.openhab.designer.product/org.openhab.designer.product.product
@@ -15,8 +15,10 @@ http://p.yusukekamiyamane.com, http://www.icons-land.com
    </configIni>
 
    <launcherArgs>
-      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts -Djava.awt.headless=true</vmArgsMac>
-      <vmArgs>-Dorg.eclipse.equinox.p2.reconciler.dropins.directory=../../addons -DnoRules=true -Xmx256m -XX:PermSize=128M -Dorg.eclipse.swt.browser.DefaultType=mozilla</vmArgs>
+      <vmArgs>-Dorg.eclipse.equinox.p2.reconciler.dropins.directory=../../addons -DnoRules=true -Xmx256m -XX:PermSize=128M
+      </vmArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts -Djava.awt.headless=true
+      </vmArgsMac>
    </launcherArgs>
 
    <windowImages i16="/org.openhab.designer.core/icons/openhab_logo_16.png" i32="/org.openhab.designer.core/icons/openhab_logo_32.png" i128="/org.openhab.designer.core/icons/openhab_logo_128.png"/>


### PR DESCRIPTION
See discussion at https://groups.google.com/forum/#!topic/openhab/WpbdsFUGCug. This parameter seem to have a longer history through the Eclipse versions since it has been valid as a workaround got invalid and valid meanwhile (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=404776 for more details of the underlying bug).

Signed-off-by: Thomas Eichstädt-Engelen <thomas@openhab.org>