### PR TITLE
Fix pollution of / URL space

### DIFF
--- a/bundles/ui/org.openhab.ui.webapp/snippets/button.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/button.html
@@ -1,1 +1,1 @@
-<a href="javascript:void(0)" onclick="OH.changeState('../CMD?%item%=%cmd%')" class="iButton iB%type%" style="%labelstyle%">%label%</a>
+<a href="javascript:void(0)" onclick="OH.changeState('/CMD?%item%=%cmd%')" class="iButton iB%type%" style="%labelstyle%">%label%</a>

--- a/bundles/ui/org.openhab.ui.webapp/snippets/colorpicker.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/colorpicker.html
@@ -1,17 +1,17 @@
 <li>
 	<img src="/images/%icon%.png" width="29" height="29" class="iFull" />
 	<span class="options">
-		<img src="images/_down.png" 
-			ontouchstart="OH.repeatedRequest('../CMD?%item%=DECREASE', %frequency%, 1, event)" 
-			ontouchend="OH.stopRepeatedRequest('../CMD?%item%=OFF', event)" 
-			onmousedown="OH.repeatedRequest('../CMD?%item%=DECREASE', %frequency%, 1)" 
-			onmouseup="OH.stopRepeatedRequest('../CMD?%item%=OFF')" />
+		<img src="/images/_down.png" 
+			ontouchstart="OH.repeatedRequest('/CMD?%item%=DECREASE', %frequency%, 1, event)" 
+			ontouchend="OH.stopRepeatedRequest('/CMD?%item%=OFF', event)" 
+			onmousedown="OH.repeatedRequest('/CMD?%item%=DECREASE', %frequency%, 1)" 
+			onmouseup="OH.stopRepeatedRequest('/CMD?%item%=OFF')" />
 		<img src="/images/colorwheel.png" width="29" height="29" border="0" 
 			onclick="OH.colorpicker.setup('%item%', '%purelabel%', '%state%')" />
-		<img src="images/_up.png" 
-			ontouchstart="OH.repeatedRequest('../CMD?%item%=INCREASE', %frequency%, 1, event)" 
-			ontouchend="OH.stopRepeatedRequest('../CMD?%item%=ON', event)" 
-			onmousedown="OH.repeatedRequest('../CMD?%item%=INCREASE', %frequency%, 1)" 
-			onmouseup="OH.stopRepeatedRequest('../CMD?%item%=ON')" />
+		<img src="/images/_up.png" 
+			ontouchstart="OH.repeatedRequest('/CMD?%item%=INCREASE', %frequency%, 1, event)" 
+			ontouchend="OH.stopRepeatedRequest('/CMD?%item%=ON', event)" 
+			onmousedown="OH.repeatedRequest('/CMD?%item%=INCREASE', %frequency%, 1)" 
+			onmouseup="OH.stopRepeatedRequest('/CMD?%item%=ON')" />
 	</span>%label%
 </li>

--- a/bundles/ui/org.openhab.ui.webapp/snippets/group.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/group.html
@@ -1,1 +1,1 @@
-<li><a href="#_%id%" onclick="OH.asyncLoad('%id%')"><img src="images/%icon%.png" width="29" height="29" style="%labelstyle%"/>%label%</a></li>
+<li><a href="#_%id%" onclick="OH.asyncLoad('%id%')"><img src="/images/%icon%.png" width="29" height="29" style="%labelstyle%"/>%label%</a></li>

--- a/bundles/ui/org.openhab.ui.webapp/snippets/main.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/main.html
@@ -6,26 +6,26 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="black" />
-		
+
 		<link rel="shortcut icon" href="images/favicon.ico" />
-		
+
 		<link rel="apple-touch-icon" href="images/app-icon.png" />
 		<link rel="apple-touch-startup-image" href="images/splash-ipad-h.png" media="screen and (min-device-width: 481px) and (max-device-width: 1024px) and (orientation:landscape)" />
 		<link rel="apple-touch-startup-image" href="images/splash-ipad-v.png" media="screen and (min-device-width: 481px) and (max-device-width: 1024px) and (orientation:portrait)" />
-		<link rel="apple-touch-startup-image" href="images/splash-iphone.png" media="screen and (max-device-width: 320px)" />		
+		<link rel="apple-touch-startup-image" href="images/splash-iphone.png" media="screen and (max-device-width: 320px)" />
 
-		<link rel="stylesheet" type="text/css" href="WebApp/Design/Render.css" />
-		<link rel="stylesheet" type="text/css" href="WebApp/Design/RenderRTL.css" />
-		<link rel="stylesheet" type="text/css" href="WebApp/Design/Firefox.css" />
-		<link rel="stylesheet" type="text/css" href="WebApp/Design/openHAB.css" />
-		<link rel="stylesheet" type="text/css" href="jquery.miniColors.css" />
+		<link rel="stylesheet" type="text/css" href="classicui/WebApp/Design/Render.css" />
+		<link rel="stylesheet" type="text/css" href="classicui/WebApp/Design/RenderRTL.css" />
+		<link rel="stylesheet" type="text/css" href="classicui/WebApp/Design/Firefox.css" />
+		<link rel="stylesheet" type="text/css" href="classicui/WebApp/Design/openHAB.css" />
+		<link rel="stylesheet" type="text/css" href="classicui/jquery.miniColors.css" />
 
-		<script type="text/javascript" src="WebApp/Action/Logic.min.js"></script>
-		<script src="jquery.min.js"></script>
-		<script src="jquery.miniColors.js"></script>
+		<script src="classicui/WebApp/Action/Logic.min.js"></script>
+		<script src="classicui/jquery.min.js"></script>
+		<script src="classicui/jquery.miniColors.js"></script>
 
 		<script>
-		
+
       WA.AddEventListener("endasync", function (evt) {
         var hash = document.location.hash.substring(2);
         if (hash === 'Colorpicker') return; // Skip refresh on colorpicker view
@@ -51,34 +51,34 @@
         search = search + "sitemap=%sitemap%&w=" + hash.substring(2) + "&poll=true";
         url = path + search;
         OH.pollURL = url;
-        OH.pollingRequest = WA.Request(url, null, -1, true, null); 
+        OH.pollingRequest = WA.Request(url, null, -1, true, null);
         OH.images.refresh = OH.images.countOnPage;
         OH.images.countOnPage = 0;
       });
 
       WA.AddEventListener("load", function () {
-    	var url = '../%servletname%?sitemap=%sitemap%&poll=true';
+    	var url = '?sitemap=%sitemap%&poll=true';
     	OH.pollURL = url;
-    	
+
     	setTimeout(function() {
-          OH.pollingRequest = WA.Request(url, null, -1, true, null);	
+          OH.pollingRequest = WA.Request(url, null, -1, true, null);
         }, 1500);
       });
 
       // Global scope for openHAB
       document.OH = OH = {};
-      
+
       $(document).ready(function() {
-    	  
+
     	  var resetAllTimers = function() {
     		OH.dimmer.resetTimer();
-      	  	OH.rollershutter.resetTimer();  
+      	  	OH.rollershutter.resetTimer();
     	  }
-    	  
-    	  var stopEventDefault = function(event) { 
+
+    	  var stopEventDefault = function(event) {
     		  event.preventDefault();
           }
-    	  
+
     	  var resetVideos = function() {
     		$("video").each(function(){
     		  var videoEl = $(this).get(0);
@@ -86,15 +86,15 @@
     		  videoEl.currentTime = 0;
   			});
     	  }
-    	  
+
      	  // Stop all intervals to prevent left repeated XHRs on page change (multitouch)
           WA.AddEventListener("endslide", resetAllTimers);
           WA.AddEventListener("endslide", resetVideos);
-          
+
           WA.AddEventListener("sliderchange", function(ev) {
             var data = ev.context;
-            var request = '../CMD?' + data.item + '=' + data.value;
-            
+            var request = '/CMD?' + data.item + '=' + data.value;
+
             switch(data.type) {
             case "start":
             	WA.CancelRequest(OH.pollingRequest);
@@ -103,17 +103,17 @@
             	OH.pollingRequest = WA.Request(OH.pollURL, null, -1, true, null);
             	break;
             }
-            
+
             WA.Request(request, null, null, true, null);
           });
-                    
+
           // Disable dragging to prevent accidential infinite loop
           $('body')
           	.on('dragstart', 'img', stopEventDefault) 	// dragstart on an img tag
     	  	.on('mouseup', resetAllTimers); 			// mouseup everywhere
-    	  	
+
       });
-      
+
       OH.stopEvent = function (event) {
       	if (event && event.stopPropagation) {
         		event.stopPropagation();
@@ -175,7 +175,7 @@
       OH.rollershutter = {
         pressed: false,
         longPress: false,
-        
+
         resetTimer: function () {
           if (OH.rollershutter.longPressTimeout) clearTimeout(OH.rollershutter.longPressTimeout);
           OH.rollershutter.longPressTimeout = null;
@@ -205,14 +205,14 @@
       };
 
       OH.asyncLoad = function AsyncLoad(widgetId) {
-        WA.Request("../%servletname%?sitemap=%sitemap%&w=" + widgetId, null, -1, true, null);
+        WA.Request("?sitemap=%sitemap%&w=" + widgetId, null, -1, true, null);
       };
 
       // script code for the color picker widget
       OH.colorpicker = {
         colorItem: null,
         debounce: new Debounce(300), // do request max every 300ms
-        
+
         onChange: function() {
         	if (!OH.colorpicker.colorItem) {
         		throw new Error('No color item selected!');
@@ -222,7 +222,7 @@
 				WA.Request("/CMD?" + OH.colorpicker.colorItem + "=" + cmd, null, -1, true);
 			});
         },
-        
+
       	setup: function(item, label, state) {
       		OH.colorpicker.colorItem=item;
 			$('#waColorpicker').attr('title', label);
@@ -231,11 +231,11 @@
 			document.location.href='#_Colorpicker';
       	}
       };
-      
+
       function Debounce(time) {
     	  this.timeToWait = time;
       }
-      
+
       Debounce.prototype.exec = function(cb, scope) {
     	  var now = new Date().getTime();
     	  if (!this.lastCallTime || this.lastCallTime + this.timeToWait < now) {
@@ -243,8 +243,8 @@
     		  this.lastCallTime = now;
     	  }
       }
-      
-      
+
+
 
     </script>
 
@@ -270,8 +270,8 @@
 					<ul class="iArrow">
 						<p>
 							<center>
-								<img style="padding:10px;width:1%" src="images/none.png" />
-								<input id="colorPickerInput" onchange="OH.colorpicker.onChange()" type="minicolors" value="#ffffff" 
+								<img style="padding:10px;width:1%" src="/images/none.png" />
+								<input id="colorPickerInput" onchange="OH.colorpicker.onChange()" type="minicolors" value="#ffffff"
 									data-control="inline" data-slider="wheel" data-style="margin: 10px;" />
 							</center>
 						</p>

--- a/bundles/ui/org.openhab.ui.webapp/snippets/rollerblind.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/rollerblind.html
@@ -1,17 +1,17 @@
 <li style="%labelstyle%">
 	<img src="/images/%icon%.png" width="29" height="29" class="iFull" />
 	<span class="options">
-		<img src="images/_down.png" 
-			ontouchstart="OH.buttonPressed('../CMD?%item%=DOWN', event)" 
-			ontouchend="OH.buttonReleased('../CMD?%item%=DOWN', '../CMD?%item%=STOP', event)" 
-			onMouseDown="OH.buttonPressed('../CMD?%item%=DOWN')" 
-			onMouseUp="OH.buttonReleased('../CMD?%item%=DOWN', '../CMD?%item%=STOP')" />
-		<img src="images/_stop.png" onclick="OH.changeState('../CMD?%item%=STOP')" />
-		<img src="images/_up.png" 
-		ontouchstart="OH.buttonPressed('../CMD?%item%=UP', event)" 
-		ontouchend="OH.buttonReleased('../CMD?%item%=UP', '../CMD?%item%=STOP', event)" 
-		onMouseDown="OH.buttonPressed('../CMD?%item%=UP')" 
-		onMouseUp="OH.buttonReleased('../CMD?%item%=UP', '../CMD?%item%=STOP')" />
+		<img src="/images/_down.png" 
+			ontouchstart="OH.buttonPressed('/CMD?%item%=DOWN', event)" 
+			ontouchend="OH.buttonReleased('/CMD?%item%=DOWN', '/CMD?%item%=STOP', event)" 
+			onMouseDown="OH.buttonPressed('/CMD?%item%=DOWN')" 
+			onMouseUp="OH.buttonReleased('/CMD?%item%=DOWN', '/CMD?%item%=STOP')" />
+		<img src="/images/_stop.png" onclick="OH.changeState('/CMD?%item%=STOP')" />
+		<img src="/images/_up.png" 
+		ontouchstart="OH.buttonPressed('/CMD?%item%=UP', event)" 
+		ontouchend="OH.buttonReleased('/CMD?%item%=UP', '/CMD?%item%=STOP', event)" 
+		onMouseDown="OH.buttonPressed('/CMD?%item%=UP')" 
+		onMouseUp="OH.buttonReleased('/CMD?%item%=UP', '/CMD?%item%=STOP')" />
 	</span style="%valuestyle%">%label%
 </li>
 

--- a/bundles/ui/org.openhab.ui.webapp/snippets/selection_row.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/selection_row.html
@@ -1,1 +1,1 @@
-<label><input type="radio" name="%item%" value="%cmd%" %checked% onClick="OH.changeState('../CMD?%item%=%cmd%')" />%label%</label>
+<label><input type="radio" name="%item%" value="%cmd%" %checked% onClick="OH.changeState('/CMD?%item%=%cmd%')" />%label%</label>

--- a/bundles/ui/org.openhab.ui.webapp/snippets/setpoint.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/setpoint.html
@@ -1,2 +1,11 @@
-<li style="%labelstyle%"><img src="/images/%icon%.png" width="29" height="29" class="iFull" /><span class="options"><img src="images/_down.png" ontouchstart="OH.changeState('../CMD?%item%=%newlowerstate%');event.stopPropagation();event.preventDefault();" onmousedown="OH.changeState('../CMD?%item%=%newlowerstate%')" /><img src="images/_up.png" ontouchstart="OH.changeState('../CMD?%item%=%newhigherstate%');event.stopPropagation();event.preventDefault();" onmousedown="OH.changeState('../CMD?%item%=%newhigherstate%')" /></span>%label%</li>
+<li style="%labelstyle%">
+<img src="/images/%icon%.png" width="29" height="29" class="iFull" />
+<span class="options">
+<img src="/images/_down.png" 
+	ontouchstart="OH.changeState('/CMD?%item%=%newlowerstate%');event.stopPropagation();event.preventDefault();" 
+	onmousedown="OH.changeState('/CMD?%item%=%newlowerstate%')" />
+<img src="/images/_up.png" 
+	ontouchstart="OH.changeState('/CMD?%item%=%newhigherstate%');event.stopPropagation();event.preventDefault();" 
+	onmousedown="OH.changeState('/CMD?%item%=%newhigherstate%')" />
+</span>%label%</li>
 

--- a/bundles/ui/org.openhab.ui.webapp/snippets/switch.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/switch.html
@@ -1,1 +1,1 @@
-<li><input type="checkbox" id="%item%" class="iToggle" title="I|O" %checked% onclick="OH.changeState('../CMD?%item%=TOGGLE')"/><img src="/images/%icon%.png" width="29" height="29" class="iFull" /><label style="%labelstyle%">%label%</label></li>
+<li><input type="checkbox" id="%item%" class="iToggle" title="I|O" %checked% onclick="OH.changeState('/CMD?%item%=TOGGLE')"/><img src="/images/%icon%.png" width="29" height="29" class="iFull" /><label style="%labelstyle%">%label%</label></li>

--- a/bundles/ui/org.openhab.ui.webapp/snippets/text_link.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/text_link.html
@@ -1,1 +1,1 @@
-<li style="%labelstyle%"><a href="#_%id%" onclick="OH.asyncLoad('%id%')"><img src="images/%icon%.png" width="29" height="29" />%label%</a></li>
+<li style="%labelstyle%"><a href="#_%id%" onclick="OH.asyncLoad('%id%')"><img src="/images/%icon%.png" width="29" height="29" />%label%</a></li>

--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/ColorpickerRenderer.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/ColorpickerRenderer.java
@@ -16,6 +16,7 @@ import org.openhab.core.library.types.HSBType;
 import org.openhab.core.types.State;
 import org.openhab.model.sitemap.Colorpicker;
 import org.openhab.model.sitemap.Widget;
+import org.openhab.ui.webapp.internal.servlet.BaseServlet;
 import org.openhab.ui.webapp.internal.servlet.WebAppServlet;
 import org.openhab.ui.webapp.render.RenderException;
 import org.openhab.ui.webapp.render.WidgetRenderer;
@@ -74,7 +75,7 @@ public class ColorpickerRenderer extends AbstractWidgetRenderer {
 		snippet = StringUtils.replace(snippet, "%purelabel%", purelabel);
 		snippet = StringUtils.replace(snippet, "%state%", hexValue);
 		snippet = StringUtils.replace(snippet, "%frequency%", frequency);
-		snippet = StringUtils.replace(snippet, "%servletname%", WebAppServlet.SERVLET_NAME);
+		snippet = StringUtils.replace(snippet, "%servletname%", WebAppServlet.SERVLET_PATH);
 
 		String style = "";
 		String color = itemUIRegistry.getLabelColor(w);

--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/PageRenderer.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/PageRenderer.java
@@ -74,7 +74,7 @@ public class PageRenderer extends AbstractWidgetRenderer {
 			label = label.replace("[", "").replace("]", "");
 		}
 		snippet = StringUtils.replace(snippet, "%label%", label);
-		snippet = StringUtils.replace(snippet, "%servletname%", WebAppServlet.SERVLET_NAME);
+		snippet = StringUtils.replace(snippet, "%servletname%", WebAppServlet.SERVLET_PATH);
 		snippet = StringUtils.replace(snippet, "%sitemap%", sitemap);
 
 		String[] parts = snippet.split("%children%");

--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/SetpointRenderer.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/SetpointRenderer.java
@@ -88,7 +88,7 @@ public class SetpointRenderer extends AbstractWidgetRenderer {
 		snippet = StringUtils.replace(snippet, "%newlowerstate%", newLowerState);
 		snippet = StringUtils.replace(snippet, "%newhigherstate%", newHigherState);
 		snippet = StringUtils.replace(snippet, "%label%", getLabel(w));
-		snippet = StringUtils.replace(snippet, "%servletname%", WebAppServlet.SERVLET_NAME);
+		snippet = StringUtils.replace(snippet, "%servletname%", WebAppServlet.SERVLET_PATH);
 		snippet = StringUtils.replace(snippet, "%minValue%", minValue.toString());
 		snippet = StringUtils.replace(snippet, "%maxValue%", maxValue.toString());
 		snippet = StringUtils.replace(snippet, "%step%", step.toString());

--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/SliderRenderer.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/SliderRenderer.java
@@ -56,7 +56,7 @@ public class SliderRenderer extends AbstractWidgetRenderer {
 		snippet = StringUtils.replace(snippet, "%state%", itemUIRegistry.getState(s).toString());
 		snippet = StringUtils.replace(snippet, "%frequency%", frequency);
 		snippet = StringUtils.replace(snippet, "%switch%", s.isSwitchEnabled() ? "1" : "0");
-		snippet = StringUtils.replace(snippet, "%servletname%", WebAppServlet.SERVLET_NAME);
+		snippet = StringUtils.replace(snippet, "%servletname%", WebAppServlet.SERVLET_PATH);
 
 		// Process the color tags
 		snippet = processColor(w, snippet);

--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/SwitchRenderer.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/SwitchRenderer.java
@@ -77,7 +77,7 @@ public class SwitchRenderer extends AbstractWidgetRenderer {
 		snippet = StringUtils.replace(snippet, "%icon%", escapeURLPath(itemUIRegistry.getIcon(w)));
 		snippet = StringUtils.replace(snippet, "%item%", w.getItem());
 		snippet = StringUtils.replace(snippet, "%label%", getLabel(w));
-		snippet = StringUtils.replace(snippet, "%servletname%", WebAppServlet.SERVLET_NAME);
+		snippet = StringUtils.replace(snippet, "%servletname%", WebAppServlet.SERVLET_PATH);
 		
 		State state = itemUIRegistry.getState(w);
 		

--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/servlet/BaseServlet.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/servlet/BaseServlet.java
@@ -26,7 +26,7 @@ import org.osgi.service.http.HttpService;
 public abstract class BaseServlet implements Servlet {
 	
 	/** the root path of this web application */
-	public static final String WEBAPP_ALIAS = "/";
+	public static final String WEBAPP_ALIAS = "/classicui";
 		
 	protected HttpService httpService;
 	protected ItemRegistry itemRegistry;

--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/servlet/CmdServlet.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/servlet/CmdServlet.java
@@ -38,8 +38,8 @@ public class CmdServlet extends BaseServlet {
 
 	private static final Logger logger = LoggerFactory.getLogger(CmdServlet.class);
 
-	public static final String SERVLET_NAME = "CMD";
-
+	public static final String SERVLET_NAME = "/CMD";
+	
 	private EventPublisher eventPublisher;	
 
 	
@@ -54,10 +54,10 @@ public class CmdServlet extends BaseServlet {
 
 	protected void activate() {
 		try {
-			logger.debug("Starting up CMD servlet at " + WEBAPP_ALIAS + SERVLET_NAME);
+			logger.debug("Starting up CMD servlet at " + SERVLET_NAME);
 
 			Hashtable<String, String> props = new Hashtable<String, String>();
-			httpService.registerServlet(WEBAPP_ALIAS + SERVLET_NAME, this, props, createHttpContext());
+			httpService.registerServlet(SERVLET_NAME, this, props, createHttpContext());
 			
 		} catch (NamespaceException e) {
 			logger.error("Error during servlet startup", e);
@@ -67,7 +67,7 @@ public class CmdServlet extends BaseServlet {
 	}
 
 	protected void deactivate() {
-		httpService.unregister(WEBAPP_ALIAS + SERVLET_NAME);
+		httpService.unregister(SERVLET_NAME);
 	}
 	
 	/**

--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/servlet/WebAppServlet.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/servlet/WebAppServlet.java
@@ -52,7 +52,9 @@ public class WebAppServlet extends BaseServlet {
 	private static final long TIMEOUT_IN_MS = 10000L;
 
 	/** the name of the servlet to be used in the URL */
-	public static final String SERVLET_NAME = "openhab.app";
+	public static final String SERVLET_NAME = "/openhab.app";
+	
+	public static final String SERVLET_PATH = WEBAPP_ALIAS + SERVLET_NAME;
 		
 	private PageRenderer renderer;
 	protected SitemapProvider sitemapProvider;
@@ -70,13 +72,12 @@ public class WebAppServlet extends BaseServlet {
 		this.renderer = renderer;
 	}
 	
-	
 	protected void activate() {
 		try {			
 			Hashtable<String, String> props = new Hashtable<String, String>();
-			httpService.registerServlet(WEBAPP_ALIAS + SERVLET_NAME, this, props, createHttpContext());
+			httpService.registerServlet(SERVLET_NAME, this, props, createHttpContext());
 			httpService.registerResources(WEBAPP_ALIAS, "web", null);
-			logger.info("Started Classic UI at " + WEBAPP_ALIAS + SERVLET_NAME);
+			logger.info("Started Classic UI at " + SERVLET_PATH);
 		} catch (NamespaceException e) {
 			logger.error("Error during servlet startup", e);
 		} catch (ServletException e) {
@@ -85,7 +86,7 @@ public class WebAppServlet extends BaseServlet {
 	}
 	
 	protected void deactivate() {
-		httpService.unregister(WEBAPP_ALIAS + SERVLET_NAME);
+		httpService.unregister(SERVLET_PATH);
 		httpService.unregister(WEBAPP_ALIAS);
 		logger.info("Stopped Classic UI");
 	}


### PR DESCRIPTION
This fixes #2742.

* All assets are moved from URL Path `/` to `/classicui`
* Moved all classicui related assets below `/classicui` (BaseServlet.java)
* Moved CMD Servlet to `/classicui/CMD`
* Fixed all Widgets to use relative URLs
* HTML-Variable `%servletname&` is now replaced by full servlet URL.
* Fixed all image URLs to always use `/images/...`
* Fixed refresh handling to use relative URL

Testen on Chrom, IE 11 and Firefox.

Signed-off-by: Sebastian Janzen <sebastian@janzen.it>