### PR TITLE
Fix for #2552. Allow the use of double quotes around state/commands in rules

### DIFF
--- a/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/RulesRuntimeModule.java
+++ b/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/RulesRuntimeModule.java
@@ -11,6 +11,7 @@
  */
 package org.openhab.model.rule;
 
+import org.eclipse.xtext.conversion.IValueConverterService;
 import org.eclipse.xtext.scoping.IScopeProvider;
 import org.eclipse.xtext.xbase.featurecalls.IdentifiableSimpleNameProvider;
 import org.eclipse.xtext.xbase.scoping.featurecalls.StaticImplicitMethodsFeatureForTypeProvider.ExtensionClassNameProvider;
@@ -21,6 +22,7 @@ import org.openhab.model.script.scoping.ActionClassLoader;
 import org.openhab.model.script.scoping.ActionClasspathBasedTypeScopeProvider;
 import org.openhab.model.script.scoping.ActionClasspathTypeProviderFactory;
 import org.openhab.model.script.scoping.StateAndCommandProvider;
+import org.openhab.model.rule.valueconverter.RuleConverters;
 
 
 /**
@@ -44,6 +46,11 @@ public class RulesRuntimeModule extends org.openhab.model.rule.AbstractRulesRunt
 	@Override
 	public Class<? extends IScopeProvider> bindIScopeProvider() {
 		return RulesScopeProvider.class;
+	}
+
+	@Override
+	public Class<? extends IValueConverterService> bindIValueConverterService() {
+		return RuleConverters.class;
 	}
 	
 	/* we need this so that our pluggable actions can be resolved at design time */

--- a/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/valueconverter/RuleConverters.java
+++ b/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/valueconverter/RuleConverters.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.model.rule.valueconverter;
+
+import org.eclipse.xtext.conversion.IValueConverter;
+import org.eclipse.xtext.conversion.ValueConverter;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.xbase.conversion.XbaseValueConverterService;
+import org.eclipse.xtext.conversion.impl.AbstractNullSafeConverter;
+
+import java.util.regex.Pattern;
+
+@SuppressWarnings("restriction")
+public class RuleConverters extends XbaseValueConverterService {
+
+	private static final Pattern ID_PATTERN = Pattern.compile("\\p{Alpha}\\w*");
+
+	@ValueConverter(rule = "ValidCommand")
+	public IValueConverter<String> ValidCommand() {
+		return new AbstractNullSafeConverter<String>() {
+			@Override
+			protected String internalToValue(String string, INode node) {
+				if((string.startsWith("'") && string.endsWith("'"))||(string.startsWith("\"") && string.endsWith("\""))) {
+					return STRING().toValue(string, node);
+				}
+				return ID().toValue(string, node);
+			}
+
+			@Override
+			protected String internalToString(String value) {
+				if(ID_PATTERN.matcher(value).matches()) {
+					return ID().toString(value);
+				} else {
+					return STRING().toString(value);
+				}
+			}
+		};
+	}
+
+	@ValueConverter(rule = "ValidState")
+	public IValueConverter<String> ValidState() {
+		return new AbstractNullSafeConverter<String>() {
+			@Override
+			protected String internalToValue(String string, INode node) {
+				if((string.startsWith("'") && string.endsWith("'"))||(string.startsWith("\"") && string.endsWith("\""))) {
+					return STRING().toValue(string, node);
+				}
+				return ID().toValue(string, node);
+			}
+
+			@Override
+			protected String internalToString(String value) {
+				if(ID_PATTERN.matcher(value).matches()) {
+					return ID().toString(value);
+				} else {
+					return STRING().toString(value);
+				}
+			}
+		};
+	}
+}


### PR DESCRIPTION
In rules, double quotes should not be part of the state/command string. This fix removes them.

    Item <item> received command "Armed Away"
    Item <item> received update "Armed-Away"
    Item <item> changed from Disarmed to "Armed-Away"

Without removing the double quotes, the rule will never trigger because Armed-Away != "Armed-Away".

Fixes issue #2552 Rule trigger 'changed from to' does not work for string items
Replaces PR #2578 quick-fix for issue #2552, as suggest as option 2

I tested this using a String item which I changed to "Armed Away", "Armed-Away", "Disarmed" and Disarmed using both sendCommand() and postUpdate(). It would be good if the reporter of issue #2552 could verify the fix.