### PR TITLE
Add Panasonic TV to default configuration file

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1964,3 +1964,9 @@ tcp:refreshinterval=250
 # the application scope used when authorizing the binding
 # choices are smartWrite,smartRead, or ems, or multiple (comma-separated, no spaces)
 # ecobee:scope=smartWrite
+
+################################ Panasonic TV Binding #######################################
+#
+# IP address of a Panasonic TV instance
+# panasonictv:<id>=
+


### PR DESCRIPTION
Panasonic TV was missing in default config file.