### PR TITLE
DSC Alarm: Adds User Number to User Opening/Closing Messages

### DIFF
--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/APIMessage.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/APIMessage.java
@@ -448,10 +448,10 @@ public class APIMessage {
 						
 					case UserClosing: /*700*/
 						apiName = "User Closing";
-						apiDescription = apiCodeReceived + ": A partition has been armed by a user.";
 						partition = Integer.parseInt(apiMessage.substring(3, 4));
 						user = apiMessage.substring(4);
 						apiName = apiName.concat(": " + user);
+						apiDescription = apiCodeReceived + ": Partition " + String.valueOf(partition) + " has been armed by user " + user + ".";
 						apiMessageType = APIMessageType.PARTITION_EVENT;
 						break;
 					case SpecialClosing: /*701*/
@@ -468,10 +468,10 @@ public class APIMessage {
 						break;
 					case UserOpening: /*750*/
 						apiName = "User Opening";
-						apiDescription = apiCodeReceived + ": A partition has been disarmed by a user.";
 						partition = Integer.parseInt(apiMessage.substring(3, 4));
 						user = apiMessage.substring(4);
 						apiName = apiName.concat(": " + user);
+						apiDescription = apiCodeReceived + ": Partition " + String.valueOf(partition) + " has been disarmed by user " + user + ".";
 						apiMessageType = APIMessageType.PARTITION_EVENT;
 						break;
 					case SpecialOpening: /*751*/


### PR DESCRIPTION
The user number has been added to the message shown in the PANEL_MESSAGE item when the alarm system is armed (closed) or disarmed (opened) by the User Opening/Closing Methods.  This is per request from issue #2951.  Also, the partition number has been added to the message.  The event log will show the following entries for item PANEL_MESSAGE when it is updated:

2015-07-26 11:04:26 - PANEL_MESSAGE state updated to 700: Partition 1 has been armed by user 0040.

2015-07-26 11:04:43 - PANEL_MESSAGE state updated to 750: Partition 1 has been disarmed by user 0040.

Thanks,
Russell
