### PR TITLE
Update Eco Link Database

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/eco/tiltzwave2.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/eco/tiltzwave2.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+	<Model>TILTZWAVE2</Model>
+	<Label lang="en">Z-Wave Garage Door Sensor</Label>
+	<Associations>
+		<Group>
+			<Index>1</Index>
+			<Maximum>5</Maximum>
+			<Label lang="en">Group 1</Label>
+			<SetToController>true</SetToController>
+			<Help lang="en"><![CDATA[All nodes associated with Group 1 will receive unsolicited alarm report 
+			frames, and basic report frames of ON and OFF.]]></Help>
+		</Group>
+		<Group>
+			<Index>2</Index>
+			<Maximum>5</Maximum>
+			<Label lang="en">Group 2</Label>
+			<Help lang="en"><![CDATA[This group is intended for any device that is controllable with a Basic 
+			Set of ON such as lights, sirens, or chimes.]]></Help>
+		</Group>
+	</Associations>
+</Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -1577,9 +1577,9 @@
 				<Type>0001</Type>
 				<Id>0003</Id>
 			</Reference>
-			<Model>TILTZWAVE1</Model>
+			<Model>TILTZWAVE2</Model>
 			<Label lang="en">Z-Wave Garage Door Sensor</Label>
-			<ConfigFile>eco/tiltzwave1.xml</ConfigFile>
+			<ConfigFile>eco/tiltzwave2.xml</ConfigFile>
 		</Product>
 	</Manufacturer>
 	<Manufacturer>


### PR DESCRIPTION
Added tiltzwave2 to database and updated product file per Issue #1411. I
recognize this was probably unnecessary but I had the xml created with help
in CDATA consistent with OH2 parameters before I realized the
products.xml had been updated to incorporate the existing XML. Decided
to push as the issue is still open.