### PR TITLE
Improve thread safety around contextMap

### DIFF
--- a/bundles/binding/org.openhab.binding.autelis/src/main/java/org/openhab/binding/autelis/internal/AutelisGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.autelis/src/main/java/org/openhab/binding/autelis/internal/AutelisGenericBindingProvider.java
@@ -8,7 +8,6 @@
  */
 package org.openhab.binding.autelis.internal;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import org.openhab.binding.autelis.AutelisBindingProvider;
@@ -68,9 +67,6 @@ public class AutelisGenericBindingProvider extends AbstractGenericBindingProvide
 	 */
 	@Override
 	public void processBindingConfiguration(String context, Item item, String bindingConfig) throws BindingConfigParseException {
-		super.processBindingConfiguration(context, item, bindingConfig);
-		
-		
 		//read values must contain a '.' like equipment.circuit1 or be lightcmd
 		if(bindingConfig.indexOf('.') < 0 && !bindingConfig.equalsIgnoreCase("lightscmd")){
 			logger.warn("Item {}'s configuration ({}) is not valid, please use the pattern 'parentType.childType' or lightscmd ", item.getName(), bindingConfig);
@@ -80,13 +76,8 @@ public class AutelisGenericBindingProvider extends AbstractGenericBindingProvide
 		AutelisBindingConfig config = new AutelisBindingConfig(bindingConfig);
 		
 		addBindingConfig(item, config);	
-		
-		Set<Item> items = contextMap.get(context);
-		if (items == null) {
-			items = new HashSet<Item>();
-			contextMap.put(context, items);
-		}
-		items.add(item);
+
+		super.processBindingConfiguration(context, item, bindingConfig);
 	}
 
 	/**

--- a/bundles/binding/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/DigitalSTROMBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/DigitalSTROMBindingProvider.java
@@ -9,11 +9,9 @@
 package org.openhab.binding.digitalstrom;
 
 import java.util.List;
-import java.util.Set;
 
 import org.openhab.binding.digitalstrom.internal.config.DigitalSTROMBindingConfig;
 import org.openhab.core.binding.BindingProvider;
-import org.openhab.core.items.Item;
 
 /**
  * @author Alexander Betker
@@ -32,8 +30,6 @@ public interface DigitalSTROMBindingProvider extends BindingProvider {
 	
 	public List<String> getItemNamesByDsid(String dsid);
 	
-	public Set<Item> getItemNamesByContext(String context);
-
 	public List<DigitalSTROMBindingConfig> getAllCircuitConsumptionItems();
 	
 	public List<DigitalSTROMBindingConfig> getAllDeviceConsumptionItems();	

--- a/bundles/binding/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/DigitalSTROMGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.digitalstrom/src/main/java/org/openhab/binding/digitalstrom/internal/DigitalSTROMGenericBindingProvider.java
@@ -9,9 +9,7 @@
 package org.openhab.binding.digitalstrom.internal;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
 
 import org.openhab.binding.digitalstrom.DigitalSTROMBindingProvider;
 import org.openhab.binding.digitalstrom.internal.config.DigitalSTROMBindingConfig;
@@ -120,10 +118,5 @@ public class DigitalSTROMGenericBindingProvider extends AbstractGenericBindingPr
 			}
 		}
 		return deviceConsumptionItems;
-	}
-
-	@Override
-	public Set<Item> getItemNamesByContext(String context) {
-		return new HashMap<String, Set<Item>>(super.contextMap).get(context);
 	}
 }

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmGenericBindingProvider.java
@@ -59,7 +59,6 @@ public class DSCAlarmGenericBindingProvider extends AbstractGenericBindingProvid
 	 * {@inheritDoc}
 	 */
 	public void processBindingConfiguration(String context, Item item, String bindingConfig) throws BindingConfigParseException {
-		super.processBindingConfiguration(context, item, bindingConfig);
 
 		String[] sections = bindingConfig.split(":");
 		
@@ -107,13 +106,8 @@ public class DSCAlarmGenericBindingProvider extends AbstractGenericBindingProvid
 		
 		DSCAlarmBindingConfig config = new DSCAlarmBindingConfig(dscAlarmDeviceType, partitionId, zoneId, dscAlarmItemType);
 		addBindingConfig(item, config);
-		Set<Item> items = contextMap.get(context);
-		if (items == null) {
-			items = new HashSet<Item>();
-			contextMap.put(context, items);
-		}
-		items.add(item);
 		
+		super.processBindingConfiguration(context, item, bindingConfig);
 		logger.debug("processBindingConfiguration(): Item added: {} - {}",item.getName(),bindingConfig);
 	}
 	

--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
@@ -585,8 +585,11 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 		// different thermostats or properties than before.
 		if (provider instanceof EcobeeBindingProvider) {
 			String userid = ((EcobeeBindingProvider) provider).getUserid(itemName);
-			getOAuthCredentials(userid).getLastRevisionMap().clear();
+			if (userid != null) {
+				getOAuthCredentials(userid).getLastRevisionMap().clear();
+			}
 		}
+		super.bindingChanged(provider, itemName);
 	}
 
 	/**
@@ -601,6 +604,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 				getOAuthCredentials(userid).getLastRevisionMap().clear();
 			}
 		}
+		super.allBindingsChanged(provider);
 	}
 
 	/**

--- a/bundles/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/config/EnoceanGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.enocean/src/main/java/org/openhab/binding/enocean/internal/config/EnoceanGenericBindingProvider.java
@@ -77,17 +77,6 @@ public class EnoceanGenericBindingProvider extends AbstractGenericBindingProvide
     }
 
     @Override
-    public void removeConfigurations(String context) {
-        Set<Item> configuredItems = contextMap.get(context);
-        if (configuredItems != null) {
-            for (Item item : configuredItems) {
-                items.remove(item.getName());
-            }
-        }
-        super.removeConfigurations(context);
-    }
-
-    @Override
     public EnoceanParameterAddress getParameterAddress(String itemName) {
         EnoceanBindingConfig config = (EnoceanBindingConfig) bindingConfigs.get(itemName);
         return config != null ? new EnoceanParameterAddress(EnoceanId.fromString(config.id), config.channel, config.parameter) : null;

--- a/bundles/binding/org.openhab.binding.freeswitch/src/main/java/org/openhab/binding/freeswitch/internal/FreeswitchGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.freeswitch/src/main/java/org/openhab/binding/freeswitch/internal/FreeswitchGenericBindingProvider.java
@@ -55,7 +55,6 @@ public class FreeswitchGenericBindingProvider extends AbstractGenericBindingProv
 	 */
 	@Override
 	public void processBindingConfiguration(String context, Item item, String bindingConfig) throws BindingConfigParseException {
-		super.processBindingConfiguration(context, item, bindingConfig);
 		
 		String[] configParts = bindingConfig.trim().split(":", 2);
 		
@@ -74,13 +73,7 @@ public class FreeswitchGenericBindingProvider extends AbstractGenericBindingProv
 		FreeswitchBindingConfig config = new FreeswitchBindingConfig(item.getName(),item.getClass(), type, argument);
 		
 		addBindingConfig(item, config);
-		
-		Set<Item> items = contextMap.get(context);
-		if (items == null) {
-			items = new HashSet<Item>();
-			contextMap.put(context, items);
-		}
-		items.add(item);
+		super.processBindingConfiguration(context, item, bindingConfig);
 	}
 
 	@Override

--- a/bundles/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/HarmonyHubBinding.java
+++ b/bundles/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/HarmonyHubBinding.java
@@ -76,7 +76,7 @@ public class HarmonyHubBinding extends AbstractBinding<HarmonyHubBindingProvider
 		if(provider instanceof HarmonyHubBindingProvider) {
 			HarmonyHubBindingProvider harmonyProvider = (HarmonyHubBindingProvider)provider;
 			final HarmonyHubBindingConfig config = harmonyProvider.getHarmonyHubBindingConfig(itemName);
-			if(harmonyHubGateway != null && config.getBindingType() == HarmonyHubBindingType.CurrentActivity) {
+			if(harmonyHubGateway != null && config != null && config.getBindingType() == HarmonyHubBindingType.CurrentActivity) {
 				if(!harmonyListeners.containsKey(config.getQualifier())) {
 					logger.debug("adding new listener for {}", config.getQualifier());
 					HarmonyHubListener listener = new HarmonyHubListener() {

--- a/bundles/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/HarmonyHubGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.harmonyhub/src/main/java/org/openhab/binding/harmonyhub/internal/HarmonyHubGenericBindingProvider.java
@@ -62,7 +62,6 @@ public class HarmonyHubGenericBindingProvider extends AbstractGenericBindingProv
 	 */
 	@Override
 	public void processBindingConfiguration(String context, Item item, String bindingConfig) throws BindingConfigParseException {
-		super.processBindingConfiguration(context, item, bindingConfig);
 
 		Matcher m = bindingPattern.matcher(bindingConfig);
 
@@ -105,12 +104,7 @@ public class HarmonyHubGenericBindingProvider extends AbstractGenericBindingProv
 			HarmonyHubBindingConfig config = new HarmonyHubBindingConfig(type,qualifier,type.getLabel(),param1,param2, item.getClass());
 
 			addBindingConfig(item, config);		
-			Set<Item> items = contextMap.get(context);
-			if (items == null) {
-				items = new HashSet<Item>();
-				contextMap.put(context, items);
-			}
-			items.add(item);
+			super.processBindingConfiguration(context, item, bindingConfig);
 		} else {
 			throw new BindingConfigParseException("Config string did not match pattern { harmonyhub=\"<binding>[ (qualifier:)<binding> ...]\" }");
 		}

--- a/bundles/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/OmniLinkGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.omnilink/src/main/java/org/openhab/binding/omnilink/internal/OmniLinkGenericBindingProvider.java
@@ -75,12 +75,7 @@ public class OmniLinkGenericBindingProvider extends
 				new Object[] { config.getObjectType(), config.getNumber() });
 		addBindingConfig(item, config);
 
-		Set<Item> items = contextMap.get(context);
-		if (items == null) {
-			items = new HashSet<Item>();
-			contextMap.put(context, items);
-		}
-		items.add(item);
+		super.processBindingConfiguration(context, item, bindingConfig);
 	}
 
 	@Override

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OneWireGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OneWireGenericBindingProvider.java
@@ -61,12 +61,11 @@ public class OneWireGenericBindingProvider extends AbstractGenericBindingProvide
 	 */
 	@Override
 	public void processBindingConfiguration(String pvContext, Item pvItem, String pvBindingConfig) throws BindingConfigParseException {
-		super.processBindingConfiguration(pvContext, pvItem, pvBindingConfig);
-
 		OneWireBindingConfig pvDevicePropertyBindingConfig = OneWireBindingConfigFactory.createOneWireDeviceProperty(pvItem, pvBindingConfig);
 
 		addBindingConfig(pvItem, pvDevicePropertyBindingConfig);
 
+		super.processBindingConfiguration(pvContext, pvItem, pvBindingConfig);
 	}
 
 	/* (non-Javadoc)

--- a/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelGenericBindingProvider.java
@@ -53,11 +53,11 @@ public class SatelGenericBindingProvider extends AbstractGenericBindingProvider 
 	public void processBindingConfiguration(String context, Item item, String bindingConfig)
 			throws BindingConfigParseException {
 		logger.trace("Processing binding configuration for item {}", item.getName());
-		super.processBindingConfiguration(context, item, bindingConfig);
 
 		SatelBindingConfig bc = this.createBindingConfig(bindingConfig);
 		logger.trace("Adding binding configuration for item {}: {}", item.getName(), bc);
 		addBindingConfig(item, bc);
+		super.processBindingConfiguration(context, item, bindingConfig);
 	}
 
 	/**

--- a/bundles/binding/org.openhab.binding.xpl/src/main/java/org/openhab/binding/xpl/internal/XplGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.xpl/src/main/java/org/openhab/binding/xpl/internal/XplGenericBindingProvider.java
@@ -120,7 +120,6 @@ public class XplGenericBindingProvider extends AbstractGenericBindingProvider im
 	 */
 	@Override
 	public void processBindingConfiguration(String context, Item item, String bindingConfig) throws BindingConfigParseException {
-		super.processBindingConfiguration(context, item, bindingConfig);
 		
 		String[] configParts = bindingConfig.trim().split(",");
 		if (configParts.length < 5) {
@@ -159,6 +158,7 @@ public class XplGenericBindingProvider extends AbstractGenericBindingProvider im
 	    } 
 		
 		addBindingConfig(item, config);
+		super.processBindingConfiguration(context, item, bindingConfig);
 	}
 		
 }

--- a/bundles/model/org.openhab.model.item/src/org/openhab/model/item/binding/AbstractGenericBindingProvider.java
+++ b/bundles/model/org.openhab.model.item/src/org/openhab/model/item/binding/AbstractGenericBindingProvider.java
@@ -13,7 +13,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -42,7 +41,7 @@ public abstract class AbstractGenericBindingProvider implements BindingConfigRea
 	private Set<BindingChangeListener> listeners = new CopyOnWriteArraySet<BindingChangeListener>();
 
 	/** caches binding configurations. maps itemNames to {@link BindingConfig}s */
-	protected Map<String, BindingConfig> bindingConfigs = new ConcurrentHashMap<String, BindingConfig>(new WeakHashMap<String, BindingConfig>());
+	protected Map<String, BindingConfig> bindingConfigs = new ConcurrentHashMap<String, BindingConfig>();
 
 	/** 
 	 * stores information about the context of items. The map has this content
@@ -77,27 +76,34 @@ public abstract class AbstractGenericBindingProvider implements BindingConfigRea
 			throw new BindingConfigParseException("context is not permitted to be null for item "+item);
 		}
 
-		Set<Item> items = contextMap.get(context);
-		if (items==null) {
-			items = new HashSet<Item>();
-			contextMap.put(context, items);
+		synchronized (contextMap) {
+			Set<Item> items = contextMap.get(context);
+			if (items == null) {
+				items = new HashSet<Item>();
+				contextMap.put(context, items);
+			}
+
+			items.add(item);
 		}
-			
-		items.add(item);
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	public void removeConfigurations(String context) {
-		Set<Item> items = contextMap.get(context);
-		if(items!=null) {
-			for(Item item : items) {
+		Set<Item> items = null;
+		synchronized (contextMap) {
+			items = contextMap.get(context);
+			if (items != null) {
+				contextMap.remove(context);
+			}
+		}
+		if (items != null) {
+			for (Item item : items) {
 				// we remove all binding configurations for all items
 				bindingConfigs.remove(item.getName());
 				notifyListeners(item);
 			}
-			contextMap.remove(context);
 		}
 	}
 	


### PR DESCRIPTION
Trying to find the proper fix for #2842 and #1419.  Found lack of thread safety around protected `contextMap` member of `AbstractGenericBindingProvider`.  Also found bindings performing unnecessary and bug-inducing changes in their overrides of `processBindingConfiguration` calls.

Please review this code carefully (as I'm sure you would anyway).  I've added line comments in the changes to explain my thinking.  These changes are not tested, but here to spur others' thinking about the origins of #2842 and #1419.