### PR TITLE
Corrected the Modbus parameters in openhab_default.cfg

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -782,29 +782,26 @@ ntp:hostname=ptbtime1.ptb.de
 # Value in milliseconds (optional, defaults to 200)
 #modbus:poll=
 
-# host (mandatory)
-#modbus:slave1.host=
+# host:port (mandatory)
+#modbus:tcp.slave1.connection=
 
 # The data type, can be "coil" "discrete" "holding" "input"
-#modbus:slave1.type=
-
-# the TCP port (optional, defaults to '502')
-#modbus:slave1.port=
+#modbus:tcp.slave1.type=
 
 # The slave id (optional, defaults to '1')
-#modbus:slave1.id=
+#modbus:tcp.slave1.id=
 
 # The slave start address (optional, defaults to '0')
-#modbus:slave1.start=
+#modbus:tcp.slave1.start=
 
 # The number of data item to read
 # (optional, defaults to '0' - but set it to something meaningful)
-#modbus:slave1.length=
+#modbus:tcp.slave1.length=
 
 # Value type, required for combined registers (details: http://www.simplymodbus.ca/FAQ.htm#Types)
 # Can be "bit", "int8", "uint8", "int16", "uint16", "int32", "uint32", "float32"
 # (optional, defaults to 'uint16')
-#modbus:slave1.valuetype=
+#modbus:tcp.slave1.valuetype=
 
 ############################### PLC Bus Binding #######################################
 #


### PR DESCRIPTION
openhab_default.cfg is not consistent with
https://github.com/openhab/openhab/wiki/Modbus-Tcp-Binding

"modbus:slave1.host" seems not to work, while
"modbus:tcp.slave1.connection" in fact does.