### PR TITLE
Removing PersistentStateRestorer work to make MySQL bundle OH2 compatible

### DIFF
--- a/bundles/persistence/org.openhab.persistence.mysql/OSGI-INF/mysql.xml
+++ b/bundles/persistence/org.openhab.persistence.mysql/OSGI-INF/mysql.xml
@@ -17,5 +17,4 @@
    </service>
    <reference bind="setItemRegistry" cardinality="0..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry"/>
    <property name="service.pid" type="String" value="org.openhab.mysql"/>
-   <reference bind="setPersistentStateRestorer" cardinality="0..1" interface="org.openhab.core.persistence.PersistentStateRestorer" name="PersistentStateRestorer" policy="dynamic" unbind="unsetPersistentStateRestorer"/>
 </scr:component>

--- a/bundles/persistence/org.openhab.persistence.mysql/java/org/openhab/persistence/mysql/internal/MysqlPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.mysql/java/org/openhab/persistence/mysql/internal/MysqlPersistenceService.java
@@ -50,7 +50,6 @@ import org.openhab.core.persistence.FilterCriteria;
 import org.openhab.core.persistence.FilterCriteria.Ordering;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.PersistenceService;
-import org.openhab.core.persistence.PersistentStateRestorer;
 import org.openhab.core.persistence.QueryablePersistenceService;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
@@ -99,7 +98,6 @@ public class MysqlPersistenceService implements QueryablePersistenceService, Man
 
 	private boolean initialized = false;
 	protected ItemRegistry itemRegistry;
-	private PersistentStateRestorer persistentStateRestorer;
 
 	// Error counter - used to reconnect to database on error
 	private int errCnt;
@@ -142,14 +140,6 @@ public class MysqlPersistenceService implements QueryablePersistenceService, Man
 		this.itemRegistry = null;
 	}
 	
-	public void setPersistentStateRestorer(PersistentStateRestorer persistentStateRestorer) {
-		this.persistentStateRestorer = persistentStateRestorer;
-	}
-	
-	public void unsetPersistentStateRestorer(PersistentStateRestorer persistentStateRestorer) {
-		this.persistentStateRestorer = null;
-	}
-
 	/**
 	 * @{inheritDoc
 	 */


### PR DESCRIPTION
I've done minor testing of this change and it is working on my OH2 instance. I'm not really sure how is this line still working:
persistentStateRestorer.initializeItems(getName()); #MysqlPersistenceService.java#L552

but it definitely is.  If you guys want me to do more testing, let me know, otherwise it is all yours.

 https://github.com/openhab/openhab/issues/2661

