### PR TITLE
Fix incorrect endpoint when MULTI_CMD command class used

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiCommandCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiCommandCommandClass.java
@@ -111,7 +111,7 @@ public class ZWaveMultiCommandCommandClass extends ZWaveCommandClass {
 				}
 				else {
 					logger.debug("NODE {}: Calling handleApplicationCommandRequest.", this.getNode().getNodeId());
-					zwaveCommandClass.handleApplicationCommandRequest(serialMessage, offset + 2, 1);
+					zwaveCommandClass.handleApplicationCommandRequest(serialMessage, offset + 2, 0);
 				}
 			}
 


### PR DESCRIPTION
Signed-off-by: Chris Jackson <chris@cd-jackson.com>