### PR TITLE
z-wave: add Enerwave as a vendor (011a) and add device zw20r

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/enerwave/zw20r.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/enerwave/zw20r.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+    <Model>ZW20R</Model>
+    <Label lang="en">20A Duplex Receptacle</Label>
+    <Configuration>
+        <Parameter>
+            <Index>1</Index>
+            <Type>list</Type>
+            <Default>0</Default>
+            <Size>1</Size>
+            <Label lang="en">Toggle LED mode</Label>
+            <Help lang="en">Set to 1 for LED to be in sync with switch.</Help>
+            <Item>
+                <Value>0</Value>
+                <Label lang="en">0: LED is on when switch is off</Label>
+            </Item>
+            <Item>
+                <Value>1</Value>
+                <Label lang="en">1: LED is on when switch is on</Label>
+            </Item>
+        </Parameter>
+    </Configuration>
+</Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -2046,6 +2046,19 @@
 		</Product>
 	</Manufacturer>
 	<Manufacturer>
+        <Id>011a</Id>
+        <Name>Enerwave</Name>
+        <Product>
+            <Reference>
+                <Type>101</Type>
+                <Id>0603</Id>
+            </Reference>
+            <Model>ZW20R</Model>
+            <Label lang="en">20A Tamper Resistant Duplex Receptacle</Label>
+            <ConfigFile>enerwave/zw20r.xml</ConfigFile>
+        </Product>
+    </Manufacturer>
+	<Manufacturer>
 		<Id>0001</Id>
 		<Name>ACT</Name>
 		<Product>


### PR DESCRIPTION
This pull request is to add the Enerwave zw20r duplex receptacle to the zwave binding