### PR TITLE
MQTT Action bundle

### DIFF
--- a/bundles/action/org.openhab.action.mqtt/.classpath
+++ b/bundles/action/org.openhab.action.mqtt/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/action/org.openhab.action.mqtt/.project
+++ b/bundles/action/org.openhab.action.mqtt/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.action.mqtt</name>
+	<comment>This is the ${binding-name} binding of the open Home Automation Bus (openHAB)</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/action/org.openhab.action.mqtt/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.mqtt/META-INF/MANIFEST.MF
@@ -1,0 +1,28 @@
+Manifest-Version: 1.0
+Private-Package: org.openhab.action.mqtt.internal
+Ignore-Package: org.openhab.action.mqtt.internal
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-Name: openHAB Mqtt Action
+Bundle-SymbolicName: org.openhab.action.mqtt
+Bundle-Vendor: openHAB.org
+Bundle-Version: 1.8.0.qualifier
+Bundle-Activator: org.openhab.action.mqtt.internal.MqttActivator
+Bundle-ManifestVersion: 2
+Bundle-Description: This is the Mqtt action of the open Home Aut
+ omation Bus (openHAB)
+Import-Package: org.apache.commons.lang,
+ org.openhab.core.items,
+ org.openhab.core.library.items,
+ org.openhab.core.library.types,
+ org.openhab.core.scriptengine.action,
+ org.openhab.core.types,
+ org.openhab.io.transport.mqtt,
+ org.osgi.framework,
+ org.osgi.service.cm,
+ org.osgi.service.component,
+ org.slf4j
+Bundle-DocURL: http://www.openhab.org
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Service-Component: OSGI-INF/action.xml
+Bundle-ClassPath: .
+Bundle-ActivationPolicy: lazy

--- a/bundles/action/org.openhab.action.mqtt/OSGI-INF/action.xml
+++ b/bundles/action/org.openhab.action.mqtt/OSGI-INF/action.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2015, openHAB.org and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" immediate="true" name="org.openhab.action.mqtt.action">
+	<implementation class="org.openhab.action.mqtt.internal.MqttActionService" />
+
+	<service>
+		<provide interface="org.openhab.core.scriptengine.action.ActionService" />
+		<provide interface="org.osgi.service.cm.ManagedService" />
+	</service>
+
+	<property name="service.pid" type="String" value="org.openhab.mqtt" />
+ <reference bind="setMqttTransportService" cardinality="1..1" interface="org.openhab.io.transport.mqtt.MqttService" name="MqttService" policy="static" unbind="unsetMqttTransportService"/>
+	
+</scr:component>

--- a/bundles/action/org.openhab.action.mqtt/build.properties
+++ b/bundles/action/org.openhab.action.mqtt/build.properties
@@ -1,0 +1,6 @@
+source.. = src/main/java/,\
+           src/main/resources/
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/
+output.. = target/classes/

--- a/bundles/action/org.openhab.action.mqtt/pom.xml
+++ b/bundles/action/org.openhab.action.mqtt/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<parent>
+		<groupId>org.openhab.bundles</groupId>
+		<artifactId>action</artifactId>
+		<version>1.8.0-SNAPSHOT</version>
+	</parent>
+
+	<properties>
+		<bundle.symbolicName>org.openhab.action.mqtt</bundle.symbolicName>
+		<bundle.namespace>org.openhab.action.mqtt</bundle.namespace>
+		<deb.name>openhab-addon-action-mqtt</deb.name>
+		<deb.description>${project.name}</deb.description>
+	</properties>
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.openhab.action</groupId>
+	<artifactId>org.openhab.action.mqtt</artifactId>
+
+	<name>openHAB MQTT Action</name>
+
+	<packaging>eclipse-plugin</packaging>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.vafer</groupId>
+				<artifactId>jdeb</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/bundles/action/org.openhab.action.mqtt/src/main/java/org/openhab/action/mqtt/internal/Mqtt.java
+++ b/bundles/action/org.openhab.action.mqtt/src/main/java/org/openhab/action/mqtt/internal/Mqtt.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.action.mqtt.internal;
+
+import org.openhab.action.mqtt.internal.MqttMessagePublisher;
+import org.openhab.core.scriptengine.action.ActionDoc;
+import org.openhab.core.scriptengine.action.ParamDoc;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.openhab.io.transport.mqtt.MqttService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This class contains the methods that are made available in scripts and rules for MQTT Action.
+ * 
+ * @author Klaudiusz Staniek
+ * @since 1.8.0
+ */
+public class Mqtt {
+
+	private static final Logger logger = LoggerFactory.getLogger(Mqtt.class);
+	public static MqttService mqttTransportService;
+	private static ConcurrentHashMap<String, MqttMessagePublisher> messagePublishers = new ConcurrentHashMap<String, MqttMessagePublisher>();
+	
+
+	@ActionDoc(text = "Publishes the message to topic using specified MQTT broker")
+	public static boolean publish(
+			@ParamDoc(name = "brokerName", text = "The name of the MQTT broker defined in configuration") String brokerName,
+			@ParamDoc(name = "topic", text = "The MQTT topic") String topic,
+			@ParamDoc(name = "message", text = "The message to be published") String message) {
+		
+		if (!MqttActionService.isProperlyConfigured) {
+			logger.debug("Mqtt action is not yet configured - execution aborted!");
+			return false;
+		}
+		logger.debug("Message to broker: {}, topic: {}", brokerName, topic);
+		
+		MqttMessagePublisher publisher = messagePublishers.get(brokerName);
+		if (publisher == null) {
+			publisher = new MqttMessagePublisher();
+			messagePublishers.put(brokerName, publisher);
+			mqttTransportService.registerMessageProducer(brokerName, publisher);
+		}
+		
+		publisher.publish(topic, message);
+
+		return true;
+	}
+
+}

--- a/bundles/action/org.openhab.action.mqtt/src/main/java/org/openhab/action/mqtt/internal/MqttActionService.java
+++ b/bundles/action/org.openhab.action.mqtt/src/main/java/org/openhab/action/mqtt/internal/MqttActionService.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.action.mqtt.internal;
+
+import java.util.Dictionary;
+
+import org.openhab.core.scriptengine.action.ActionService;
+import org.openhab.io.transport.mqtt.MqttService;
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.cm.ManagedService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+	
+
+/**
+ * This class registers an OSGi service for the MQTT Action.
+ * 
+ * @author Klaudiusz Staniek
+ * @since 1.8.0
+ */
+public class MqttActionService implements ActionService, ManagedService {
+
+	private static final Logger logger = LoggerFactory.getLogger(MqttActionService.class);
+
+	/**
+	 * Indicates whether this action is properly configured which means all
+	 * necessary configurations are set. This flag can be checked by the
+	 * action methods before executing code.
+	 */
+	/* default */ static boolean isProperlyConfigured = true;
+	
+	public MqttActionService() {
+	}
+	
+	public void activate() {
+	}
+	
+	public void deactivate() {
+		// deallocate Resources here that are no longer needed and 
+		// should be reset when activating this binding again
+	}
+
+	@Override
+	public String getActionClassName() {
+		return Mqtt.class.getCanonicalName();
+	}
+
+	@Override
+	public Class<?> getActionClass() {
+		return Mqtt.class;
+	}
+
+	/**
+	 * @{inheritDoc}
+	 */
+	@Override
+	public void updated(Dictionary<String, ?> config) throws ConfigurationException {		
+		isProperlyConfigured = true;
+	}
+	
+	public void setMqttTransportService(MqttService mQTTService) {
+		Mqtt.mqttTransportService = mQTTService;
+	}
+	
+	public void unsetMqttTransportService(MqttService mQTTService) {
+		Mqtt.mqttTransportService = null;
+	}
+	
+}

--- a/bundles/action/org.openhab.action.mqtt/src/main/java/org/openhab/action/mqtt/internal/MqttActivator.java
+++ b/bundles/action/org.openhab.action.mqtt/src/main/java/org/openhab/action/mqtt/internal/MqttActivator.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.action.mqtt.internal;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Extension of the default OSGi bundle activator
+ * 
+ * @author Klaudiusz Staniek
+ * @since 1.8.0
+ */
+public final class MqttActivator implements BundleActivator {
+
+	private static Logger logger = LoggerFactory.getLogger(MqttActivator.class); 
+	
+	private static BundleContext context;
+	
+	/**
+	 * Called whenever the OSGi framework starts our bundle
+	 */
+	public void start(BundleContext bc) throws Exception {
+		context = bc;
+		logger.debug("Mqtt action has been started.");
+	}
+
+	/**
+	 * Called whenever the OSGi framework stops our bundle
+	 */
+	public void stop(BundleContext bc) throws Exception {
+		context = null;
+		logger.debug("Mqtt action has been stopped.");
+	}
+	
+	/**
+	 * Returns the bundle context of this bundle
+	 * @return the bundle context
+	 */
+	public static BundleContext getContext() {
+		return context;
+	}
+	
+}

--- a/bundles/action/org.openhab.action.mqtt/src/main/java/org/openhab/action/mqtt/internal/MqttMessagePublisher.java
+++ b/bundles/action/org.openhab.action.mqtt/src/main/java/org/openhab/action/mqtt/internal/MqttMessagePublisher.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.action.mqtt.internal;
+
+import org.openhab.io.transport.mqtt.MqttMessageProducer;
+import org.openhab.io.transport.mqtt.MqttSenderChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class implementing Message Producer from MQTT IO service.
+ * 
+ * @author Klaudiusz Staniek
+ * @since 1.8.0
+ */
+public class MqttMessagePublisher implements MqttMessageProducer {
+
+	private static final Logger logger = LoggerFactory.getLogger(MqttMessagePublisher.class);
+
+	private MqttSenderChannel senderChannel;
+	
+	public void publish(String topic, String message) {
+		if (senderChannel == null) {
+			return;
+		}
+		try {
+			senderChannel.publish(topic, message.getBytes());
+		} catch (Exception e) {
+			logger.error("Error publishing message: {}", e.getMessage());
+		}
+	}
+	
+	@Override
+	public void setSenderChannel(MqttSenderChannel channel) {
+		senderChannel = channel;
+	}
+}

--- a/bundles/action/org.openhab.action.mqtt/src/main/resources/readme.txt
+++ b/bundles/action/org.openhab.action.mqtt/src/main/resources/readme.txt
@@ -1,0 +1,1 @@
+Bundle resources go in here!

--- a/bundles/action/pom.xml
+++ b/bundles/action/pom.xml
@@ -32,6 +32,8 @@
     <module>org.openhab.action.astro</module>
     <module>org.openhab.action.tinkerforge</module>
     <module>org.openhab.action.harmonyhub</module>
+    <module>org.openhab.action.mqtt</module>
+
   </modules>
 
 </project>

--- a/features/org.openhab.designer.feature/feature.xml
+++ b/features/org.openhab.designer.feature/feature.xml
@@ -405,6 +405,13 @@
          unpack="false"/>
 
    <plugin
+         id="org.openhab.action.mqtt"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>   
+
+   <plugin
          id="org.openhab.binding.astro"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
This is a small enhancement adding MQTT Action to OH. It can be used in rules to simply publish the MQTT message to topic using configured broker. I can see it useful to work with the project like mqttwarn simplifying MQTT message routing.