### PR TITLE
Rewritten rule engine, allows using regexp matching and also 'item in'…

### DIFF
--- a/bundles/model/org.openhab.model.core/src/main/java/org/openhab/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/model/org.openhab.model.core/src/main/java/org/openhab/model/core/internal/ModelRepositoryImpl.java
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.Resource.Diagnostic;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.xtext.resource.SynchronizedXtextResourceSet;
 import org.eclipse.xtext.resource.XtextResource;
@@ -52,11 +53,17 @@ public class ModelRepositoryImpl implements ModelRepository {
 		synchronized (resourceSet) {
 	 		Resource resource = getResource(name);
 			if(resource!=null) {
+				if (!resource.getErrors().isEmpty()) {
+					logger.error("Configuration model '{}' is has following errors and was disabled:", name);
+					for (Diagnostic d: resource.getErrors()) {
+						logger.error("Errors reported for '{}': {}", name, d);
+					}
+					resourceSet.getResources().remove(resource);
+					return null;
+				}
 				if(resource.getContents().size()>0) {
 					return resource.getContents().get(0);
 				} else {
-					logger.warn("Configuration model '{}' is either empty or cannot be parsed correctly!", name);
-					logger.debug("Errors reported for '{}': {}", name, resource.getErrors());
 					resourceSet.getResources().remove(resource);
 					return null;
 				}

--- a/bundles/model/org.openhab.model.persistence/xtend-gen/org/openhab/model/persistence/generator/PersistenceGenerator.java
+++ b/bundles/model/org.openhab.model.persistence/xtend-gen/org/openhab/model/persistence/generator/PersistenceGenerator.java
@@ -1,11 +1,3 @@
-/**
- * Copyright (c) 2010-2015, openHAB.org and others.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- */
 package org.openhab.model.persistence.generator;
 
 import org.eclipse.emf.ecore.resource.Resource;

--- a/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/Rules.xtext
+++ b/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/Rules.xtext
@@ -24,23 +24,29 @@ Rule:
 ;
 
 EventTrigger:
-	UpdateEventTrigger |
-	CommandEventTrigger |
-	ChangedEventTrigger |
+	ItemEventTrigger |
 	TimerTrigger |
 	SystemTrigger
 ;
 
+ItemEventTrigger:
+	'Item' (in?='in')? item=ItemName trigger=(UpdateEventTrigger|CommandEventTrigger|ChangedEventTrigger)
+;
+
+
 CommandEventTrigger:
-	'Item' item=ItemName 'received command' (command=ValidCommand)?
+	{CommandEventTrigger}
+	'received command' (command=ValidCommand)?
 ;
 
 UpdateEventTrigger:
-	'Item' item=ItemName 'received update' (state=ValidState)?
+	{UpdateEventTrigger}
+	'received update' (state=ValidState)?
 ;
 
 ChangedEventTrigger:
-	'Item' item=ItemName 'changed' ('from' oldState=ValidState)? ('to' newState=ValidState)?
+	{ChangedEventTrigger}
+	'changed' ('from' oldState=ValidState)? ('to' newState=ValidState)?
 ;		
 
 TimerTrigger:
@@ -67,7 +73,7 @@ QualifiedNameWithWildCard :
 	QualifiedName  ('.' '*')?;
 	
 ItemName :
-	ID
+	ID | STRING
 ;
 
 ValidState:

--- a/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/internal/engine/RuleContextHelper.java
+++ b/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/internal/engine/RuleContextHelper.java
@@ -37,6 +37,9 @@ public class RuleContextHelper {
 
 	private static final Logger logger = LoggerFactory.getLogger(RuleContextHelper.class);
 
+	/** Variable name for the triggering item */
+	public static final String VAR_ITEM = "item";
+
 	/** Variable name for the previous state of an item in a "changed state triggered" rule */
 	public static final String VAR_PREVIOUS_STATE = "previousState";
 

--- a/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/scoping/RulesScopeProvider.java
+++ b/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/scoping/RulesScopeProvider.java
@@ -29,16 +29,20 @@ import org.eclipse.xtext.xbase.XVariableDeclaration;
 import org.eclipse.xtext.xbase.XbaseFactory;
 import org.eclipse.xtext.xbase.scoping.LocalVariableScopeContext;
 import org.eclipse.xtext.xbase.scoping.featurecalls.LocalVarDescription;
+import org.openhab.core.items.Item;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.openhab.model.rule.internal.engine.RuleContextHelper;
 import org.openhab.model.rule.rules.ChangedEventTrigger;
 import org.openhab.model.rule.rules.CommandEventTrigger;
 import org.openhab.model.rule.rules.EventTrigger;
+import org.openhab.model.rule.rules.ItemEventTrigger;
 import org.openhab.model.rule.rules.Rule;
 import org.openhab.model.rule.rules.RuleModel;
 import org.openhab.model.script.scoping.ScriptScopeProvider;
 
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 
 
@@ -108,6 +112,16 @@ public class RulesScopeProvider extends ScriptScopeProvider {
 			varResource.getContents().add(varDecl);
 			descriptions.add(new LocalVarDescription(QualifiedName.create(varDecl.getName()), varDecl));
 		}
+		if(containsItemTrigger(rule)) {
+			JvmTypeReference itemTypeRef = typeReferences.getTypeForName(Item.class, rule);
+			XVariableDeclaration varDecl = XbaseFactory.eINSTANCE.createXVariableDeclaration();
+			varDecl.setName(RuleContextHelper.VAR_ITEM);
+			varDecl.setType(itemTypeRef);
+			varDecl.setWriteable(false);
+			varResource.getContents().add(varDecl);
+			descriptions.add(new LocalVarDescription(QualifiedName.create(varDecl.getName()), varDecl));
+		}
+		
 		return descriptions;
 	}
 
@@ -128,4 +142,9 @@ public class RulesScopeProvider extends ScriptScopeProvider {
 		}
 		return false;
 	}
+	
+	private boolean containsItemTrigger(Rule rule) {
+		return Iterables.any(rule.getEventtrigger(), Predicates.instanceOf(ItemEventTrigger.class));
+	}
+	
 }

--- a/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/valueconverter/RuleConverters.java
+++ b/bundles/model/org.openhab.model.rule/src/org/openhab/model/rule/valueconverter/RuleConverters.java
@@ -64,4 +64,27 @@ public class RuleConverters extends XbaseValueConverterService {
 			}
 		};
 	}
+	
+	@ValueConverter(rule = "ItemName")
+	public IValueConverter<String> ItemName() {
+		return new AbstractNullSafeConverter<String>() {
+			@Override
+			protected String internalToValue(String string, INode node) {
+				if((string.startsWith("'") && string.endsWith("'"))||(string.startsWith("\"") && string.endsWith("\""))) {
+					return STRING().toValue(string, node);
+				}
+				return ID().toValue(string, node);
+			}
+
+			@Override
+			protected String internalToString(String value) {
+				if(ID_PATTERN.matcher(value).matches()) {
+					return ID().toString(value);
+				} else {
+					return STRING().toString(value);
+				}
+			}
+		};
+	}
+	
 }

--- a/bundles/model/org.openhab.model.rule/xtend-gen/org/openhab/model/rule/jvmmodel/RulesJvmModelInferrer.java
+++ b/bundles/model/org.openhab.model.rule/xtend-gen/org/openhab/model/rule/jvmmodel/RulesJvmModelInferrer.java
@@ -1,11 +1,3 @@
-/**
- * Copyright (c) 2010-2015, openHAB.org and others.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- */
 package org.openhab.model.rule.jvmmodel;
 
 import com.google.inject.Inject;

--- a/bundles/model/org.openhab.model.script/xtend-gen/org/openhab/model/script/jvmmodel/ScriptIdentifiableSimpleNameProvider.java
+++ b/bundles/model/org.openhab.model.script/xtend-gen/org/openhab/model/script/jvmmodel/ScriptIdentifiableSimpleNameProvider.java
@@ -1,11 +1,3 @@
-/**
- * Copyright (c) 2010-2015, openHAB.org and others.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- */
 package org.openhab.model.script.jvmmodel;
 
 import java.util.Arrays;

--- a/bundles/model/org.openhab.model.script/xtend-gen/org/openhab/model/script/jvmmodel/ScriptJvmModelInferrer.java
+++ b/bundles/model/org.openhab.model.script/xtend-gen/org/openhab/model/script/jvmmodel/ScriptJvmModelInferrer.java
@@ -1,11 +1,3 @@
-/**
- * Copyright (c) 2010-2015, openHAB.org and others.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- */
 package org.openhab.model.script.jvmmodel;
 
 import com.google.inject.Inject;

--- a/distribution/openhabhome/configurations/items/demo.items
+++ b/distribution/openhabhome/configurations/items/demo.items
@@ -93,6 +93,9 @@ Contact Window_FF_Bed 			"Bedroom [MAP(en.map):%s]"			(FF_Bed, Windows)
 Contact Window_FF_Office_Window "Office Window [MAP(en.map):%s]"	(FF_Office, Windows)
 Contact Window_FF_Office_Door 	"Balcony Door [MAP(en.map):%s]"		(FF_Office, Windows)
 
+String LastOpenedWindow "Window last opened: [%s]"
+String LastClosedWindow "Window last closed: [%s]"
+
 Contact Garage_Door 			"Garage Door [MAP(en.map):%s]"		(Outdoor, Windows)
 
 Group Weather_Chart													(Weather)

--- a/distribution/openhabhome/configurations/persistence/logging.persist
+++ b/distribution/openhabhome/configurations/persistence/logging.persist
@@ -11,5 +11,5 @@ Strategies {
  */
 Items {
 	// log all temperatures on every change
-	Temperature* -> "temperatures"
+	Temperature* -> "temperatures";
 }

--- a/distribution/openhabhome/configurations/rules/demo.rules
+++ b/distribution/openhabhome/configurations/rules/demo.rules
@@ -125,6 +125,8 @@ then
 	}
 end
 
+
+
 /** 
  * shows how to check recent switch states - very helpful to avoid executing something too often, just
  * because somebody presses a button too often (e.g. sending a notification, if the doorbell button is pressed)
@@ -182,3 +184,19 @@ then
 	var Number humidex = T + (new Double(5) / new Double(9)) * (e - 10)
 	postUpdate(Weather_Humidex, humidex)
 end
+
+rule "Window opened"
+when 
+	Item in Windows changed from "CLOSED" to "OPEN"
+then
+	sendCommand("LastOpenedWindow", item.name)
+end
+
+rule "Catch all"
+when 
+	Item "Window_.*" changed from "OPEN" to "CLOSED"
+then
+	
+	sendCommand("LastClosedWindow", item.name)
+end
+

--- a/distribution/openhabhome/configurations/sitemaps/demo.sitemap
+++ b/distribution/openhabhome/configurations/sitemaps/demo.sitemap
@@ -67,5 +67,7 @@ sitemap demo label="Demo House"
 				Webview url="http://heise-online.mobi/" height=8
 			}
 		}
+		Text item=LastOpenedWindow
+		Text item=LastClosedWindow
 	}
 }


### PR DESCRIPTION
https://community.openhab.org/t/allowing-regular-expression-matching-in-rules/2072/7

These changes do:

- extended rule syntax to catch a change/update/command of an item in a group: 
the <code>item in \<groupItem\>...</code>' (etc) monitors events to any item in the group, executes the script and provides the changed item is local variable <code>item</code>

- extended rule syntax to have regular expression strings for item names: the <code>item "\<regexp\>"...</code> and <code>item in "\<regexp\>"...</code> matches item names by regexp resp. their groups by regexp, hence the item name in item triggers is generally handled as regexp if quoted.

- expose item variable in rule script to access the item that triggered the rule: an item-based rule script has a local variable <code>item</code> pointing to the triggering item

- (minor bug fixes)

Syntax changes for rules:

```
EventTrigger:
	ItemEventTrigger |
	TimerTrigger |
	SystemTrigger
;

ItemEventTrigger:
	'Item' (in?='in')? item=ItemName trigger=(UpdateEventTrigger|CommandEventTrigger|ChangedEventTrigger)
;


CommandEventTrigger:
	{CommandEventTrigger}
	'received command' (command=ValidCommand)?
;

UpdateEventTrigger:
	{UpdateEventTrigger}
	'received update' (state=ValidState)?
;

ChangedEventTrigger:
	{ChangedEventTrigger}
	'changed' ('from' oldState=ValidState)? ('to' newState=ValidState)?
;		
```