### PR TITLE
SupportSwitchAllCommandClass

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
@@ -357,7 +357,7 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 
 				ZWaveSwitchAllCommandClass switchAllCommandClass = (ZWaveSwitchAllCommandClass)node.getCommandClass(ZWaveCommandClass.CommandClass.SWITCH_ALL);
 	            if (switchAllCommandClass != null) {
-	            	record = new OpenHABConfigurationRecord(domain, "Switch All", "Switch All", false);
+	            	record = new OpenHABConfigurationRecord(domain, "SwitchAll", "Switch All", false);
 	            	record.type = OpenHABConfigurationRecord.TYPE.LIST;
 					record.addValue("0", "Exclude from All On and All Off groups");
 					record.addValue("1", "Include in All On group");
@@ -1112,7 +1112,7 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 				return;
 			}
 
-			// TODO: Should we check that the node is finished initializing
+			// TODO: Should we check that the node is finished initialising
 
 			ZWaveProductDatabase database = new ZWaveProductDatabase();
 			if (database.FindProduct(node.getManufacturer(), node.getDeviceType(), node.getDeviceId(), node.getApplicationVersion()) == false) {
@@ -1128,7 +1128,7 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 					node.setLocation(value);
 				}
 				
-				if (splitDomain[2].equals("Switch All")) {
+				if (splitDomain[2].equals("SwitchAll")) {
 					ZWaveSwitchAllCommandClass switchAllCommandClass = (ZWaveSwitchAllCommandClass) node
 							.getCommandClass(CommandClass.SWITCH_ALL);
 

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
@@ -363,6 +363,7 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 					record.addValue("1", "Include in All On group");
 					record.addValue("2", "Include in All Off group");
 					record.addValue("255", "Include in All On and All Off groups");
+					record.value = String.valueOf(switchAllCommandClass.getMode());
 	            	records.add(record);
 	            }
 				

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveConfiguration.java
@@ -32,6 +32,7 @@ import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClas
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass.CommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveConfigurationCommandClass.ZWaveConfigurationParameterEvent;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveConfigurationCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSwitchAllCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveVersionCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveWakeUpCommandClass;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
@@ -353,6 +354,17 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 				record.value = node.getLocation();
 				records.add(record);
 
+				ZWaveSwitchAllCommandClass switchAllCommandClass = (ZWaveSwitchAllCommandClass)node.getCommandClass(ZWaveCommandClass.CommandClass.SWITCH_ALL);
+	            if (switchAllCommandClass != null) {
+	            	record = new OpenHABConfigurationRecord(domain, "Switch All", "Switch All", false);
+	            	record.type = OpenHABConfigurationRecord.TYPE.LIST;
+					record.addValue("0x00", "Exclude from All On and All Off groups");
+					record.addValue("0x01", "Include in All On group");
+					record.addValue("0x02", "Include in All Off group");
+					record.addValue("0xFF", "Include in All On and All Off groups");
+	            	records.add(record);
+	            }
+				
 				if(node.getManufacturer() != Integer.MAX_VALUE) {
 					if (database.FindProduct(node.getManufacturer(), node.getDeviceType(), node.getDeviceId(), node.getApplicationVersion()) == true) {
 						// Add links to configuration if the node supports the various command classes
@@ -391,6 +403,18 @@ public class ZWaveConfiguration implements OpenHABConfigurationService, ZWaveEve
 
 				record = new OpenHABConfigurationRecord(domain + "info/", "Information");
 				records.add(record);
+			} else if (arg.equals("switch_all/")) { 
+				/*ZWaveSwitchAllCommandClass switchAllCommandClass = (ZWaveSwitchAllCommandClass)node.getCommandClass(ZWaveCommandClass.CommandClass.SWITCH_ALL);
+	            if (switchAllCommandClass != null) {
+	                logger.debug("NODE {}: Supports Switch All Command Class Adding Switch All Configuration ", (Object)nodeId);
+	                record = new OpenHABConfigurationRecord(domain, "Mode", "Mode", true);
+	                record.type = OpenHABConfigurationRecord.TYPE.LIST;
+					record.addValue("0x00", "Exclude from All On and All Off groups");
+					record.addValue("0x01", "Include in All On group");
+					record.addValue("0x02", "Include in All Off group");
+					record.addValue("0xFF", "Include in All On and All Off groups");
+					records.add(record);
+	            }*/
 			} else if (arg.equals("info/")) {
 				record = new OpenHABConfigurationRecord(domain, "NodeID", "Node ID", true);
 				record.value = Integer.toString(node.getNodeId());

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterHandler.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterHandler.java
@@ -287,6 +287,10 @@ public class ZWaveConverterHandler {
 			if (commandClassName.equalsIgnoreCase("info")) {
 				return infoConverter.getRefreshInterval();
 			}
+			
+			if(node.getNodeId() == this.controller.getOwnNodeId() && commandClassName.equalsIgnoreCase("switch_all")) {
+			    return 0;
+			}
 
 			commandClass = node.resolveCommandClass(CommandClass.getCommandClass(commandClassName),
 					bindingConfiguration.getEndpoint());
@@ -385,34 +389,34 @@ public class ZWaveConverterHandler {
 		}
 		ZWaveCommandClass commandClass;
 		String commandClassName = bindingConfiguration.getArguments().get("command");
-
-		if (commandClassName != null) {
-			commandClass = node.resolveCommandClass(CommandClass.getCommandClass(commandClassName),
-					bindingConfiguration.getEndpoint());
-			
-			if(node.getNodeId() == this.controller.getOwnNodeId() && commandClassName == "SWITCH_ALL") {
-			    commandClass = node.getCommandClass(CommandClass.getCommandClass(commandClassName));
-			}
-
-			if (commandClass == null) {
-				logger.warn(
-						"NODE {}: No command class found for item = {}. Class = {}({}), endpoint = {}. Ignoring command.",
-						node.getNodeId(), itemName, commandClassName, CommandClass.getCommandClass(commandClassName)
-								.toString(), bindingConfiguration.getEndpoint());
-				return;
-			}
-		} else {
-			commandClass = resolveConverter(provider.getItem(itemName), node, bindingConfiguration.getEndpoint());
+		
+		if(node.getNodeId() == this.controller.getOwnNodeId() && commandClassName.equalsIgnoreCase("switch_all")) {
+		    commandClass = ZWaveCommandClass.getInstance(0x27, node, this.controller);
 		}
-
+		else {
+			if (commandClassName != null) {
+				commandClass = node.resolveCommandClass(CommandClass.getCommandClass(commandClassName),
+						bindingConfiguration.getEndpoint());
+	
+				if (commandClass == null) {
+					logger.warn(
+							"NODE {}: No command class found for item = {}. Class = {}({}), endpoint = {}. Ignoring command.",
+							node.getNodeId(), itemName, commandClassName, CommandClass.getCommandClass(commandClassName)
+									.toString(), bindingConfiguration.getEndpoint());
+					return;
+				}
+			} else {
+				commandClass = resolveConverter(provider.getItem(itemName), node, bindingConfiguration.getEndpoint());
+			}
+		}
 		if (commandClass == null) {
 			logger.warn("NODE {}: No converter found for item = {}, ignoring command.", node.getNodeId(), itemName);
 			return;
 		}
 
-		ZWaveCommandClassConverter<ZWaveCommandClass> converter = (ZWaveCommandClassConverter<ZWaveCommandClass>) getConverter(commandClass
-				.getCommandClass());
-
+		ZWaveCommandClassConverter<ZWaveCommandClass> converter = 
+				(ZWaveCommandClassConverter<ZWaveCommandClass>) getConverter(commandClass.getCommandClass());
+		
 		if (converter == null) {
 			logger.warn("NODE {}: No converter found for item = {}, ignoring command.", node.getNodeId(), itemName);
 			return;

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterHandler.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterHandler.java
@@ -390,11 +390,12 @@ public class ZWaveConverterHandler {
 		ZWaveCommandClass commandClass;
 		String commandClassName = bindingConfiguration.getArguments().get("command");
 		
-		if(node.getNodeId() == this.controller.getOwnNodeId() && commandClassName.equalsIgnoreCase("switch_all")) {
-		    commandClass = ZWaveCommandClass.getInstance(0x27, node, this.controller);
-		}
-		else {
-			if (commandClassName != null) {
+		if (commandClassName != null) {
+			
+			if(node.getNodeId() == this.controller.getOwnNodeId() && commandClassName.equalsIgnoreCase("switch_all")) {
+			    commandClass = ZWaveCommandClass.getInstance(0x27, node, this.controller);
+			}
+			else {
 				commandClass = node.resolveCommandClass(CommandClass.getCommandClass(commandClassName),
 						bindingConfiguration.getEndpoint());
 	
@@ -404,11 +405,13 @@ public class ZWaveConverterHandler {
 							node.getNodeId(), itemName, commandClassName, CommandClass.getCommandClass(commandClassName)
 									.toString(), bindingConfiguration.getEndpoint());
 					return;
-				}
-			} else {
-				commandClass = resolveConverter(provider.getItem(itemName), node, bindingConfiguration.getEndpoint());
+				} 
 			}
 		}
+		else {
+			commandClass = resolveConverter(provider.getItem(itemName), node, bindingConfiguration.getEndpoint());
+		}
+		
 		if (commandClass == null) {
 			logger.warn("NODE {}: No converter found for item = {}, ignoring command.", node.getNodeId(), itemName);
 			return;

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterHandler.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterHandler.java
@@ -74,6 +74,7 @@ public class ZWaveConverterHandler {
 				eventPublisher));
 		converters.put(CommandClass.BATTERY, new ZWaveBatteryConverter(controller, eventPublisher));
 		converters.put(CommandClass.SWITCH_BINARY, new ZWaveBinarySwitchConverter(controller, eventPublisher));
+		converters.put(CommandClass.SWITCH_ALL, new ZWaveSwitchAllConverter(controller, eventPublisher));
 		converters.put(CommandClass.SWITCH_MULTILEVEL, new ZWaveMultiLevelSwitchConverter(controller, eventPublisher));
 		converters.put(CommandClass.SENSOR_BINARY, new ZWaveBinarySensorConverter(controller, eventPublisher));
 		converters.put(CommandClass.SENSOR_MULTILEVEL, new ZWaveMultiLevelSensorConverter(controller, eventPublisher));

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterHandler.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterHandler.java
@@ -142,7 +142,7 @@ public class ZWaveConverterHandler {
 			return null;
 		}
 
-		for (CommandClass commandClass : preferredCommandClasses.get(item.getClass())) {
+		for (CommandClass commandClass : preferredCommandClasses.get(item.getClass())) {	
 			ZWaveCommandClass result = node.resolveCommandClass(commandClass, endpointId);
 
 			if (result != null && converters.containsKey(commandClass)) {
@@ -389,6 +389,10 @@ public class ZWaveConverterHandler {
 		if (commandClassName != null) {
 			commandClass = node.resolveCommandClass(CommandClass.getCommandClass(commandClassName),
 					bindingConfiguration.getEndpoint());
+			
+			if(node.getNodeId() == this.controller.getOwnNodeId() && commandClassName == "SWITCH_ALL") {
+			    commandClass = node.getCommandClass(CommandClass.getCommandClass(commandClassName));
+			}
 
 			if (commandClass == null) {
 				logger.warn(

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSwitchAllConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSwitchAllConverter.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.internal.converter;
+
+import java.util.Map;
+import org.openhab.binding.zwave.internal.converter.ZWaveCommandClassConverter;
+import org.openhab.binding.zwave.internal.converter.command.BinaryOnOffCommandConverter;
+import org.openhab.binding.zwave.internal.converter.command.ZWaveCommandConverter;
+import org.openhab.binding.zwave.internal.converter.state.BinaryDecimalTypeConverter;
+import org.openhab.binding.zwave.internal.converter.state.BinaryPercentTypeConverter;
+import org.openhab.binding.zwave.internal.converter.state.IntegerOnOffTypeConverter;
+import org.openhab.binding.zwave.internal.converter.state.IntegerOpenClosedTypeConverter;
+import org.openhab.binding.zwave.internal.converter.state.IntegerUpDownTypeConverter;
+import org.openhab.binding.zwave.internal.converter.state.ZWaveStateConverter;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBatteryCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSwitchAllCommandClass;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.items.Item;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/***
+ * ZWaveSwitchAllConverter class. Converter for communication with the 
+ * {@link ZWaveSwitchAllCommandClass}. Implements All On/All Off.
+ * @author Pedro Paixao
+ * @since 1.8.0
+ */
+public class ZWaveSwitchAllConverter extends ZWaveCommandClassConverter<ZWaveSwitchAllCommandClass> {
+    private static final Logger logger = LoggerFactory.getLogger(ZWaveSwitchAllConverter.class);
+    private static final int REFRESH_INTERVAL = 0;
+
+    /**
+	 * Constructor. Creates a new instance of the {@link ZWaveSwitchAllConverter} class.
+	 * @param controller the {@link ZWaveController} to use for sending messages.
+	 * @param eventPublisher the {@link EventPublisher} to use to publish events.
+	 */
+    public ZWaveSwitchAllConverter(ZWaveController controller, EventPublisher eventPublisher) {
+        super(controller, eventPublisher);
+        this.addStateConverter(new BinaryDecimalTypeConverter());
+        this.addStateConverter(new BinaryPercentTypeConverter());
+        this.addStateConverter(new IntegerOnOffTypeConverter());
+        this.addStateConverter(new IntegerOpenClosedTypeConverter());
+        this.addStateConverter(new IntegerUpDownTypeConverter());
+        this.addCommandConverter(new BinaryOnOffCommandConverter());
+    }
+
+    /**
+	 * {@inheritDoc}
+	 */
+    @Override
+    public SerialMessage executeRefresh(ZWaveNode node, 
+    		ZWaveSwitchAllCommandClass commandClass, int endpointId, Map<String, String> arguments) {
+        logger.debug("NODE {}: Generating poll message for {}, endpoint {}", new Object[]{node.getNodeId(), commandClass.getCommandClass().getLabel(), endpointId});
+        return node.encapsulate(commandClass.getValueMessage(), commandClass, endpointId);
+    }
+
+    /**
+	 * {@inheritDoc}
+	 */
+    @Override
+    public void handleEvent(ZWaveCommandClassValueEvent event, Item item, Map<String, String> arguments) {
+    	ZWaveStateConverter<?,?> converter = this.getStateConverter(item, event.getValue());
+    	
+        if (converter == null) {
+            logger.warn("NODE {}: No converter found for item = {}, node = {} endpoint = {}, ignoring event.", new Object[]{event.getNodeId(), item.getName(), event.getEndpoint()});
+            return;
+        }
+        
+        State state = converter.convertFromValueToState(event.getValue());
+        this.getEventPublisher().postUpdate(item.getName(), state);
+    }
+
+    /**
+	 * {@inheritDoc}
+	 */
+    @Override
+    public void receiveCommand(Item item, Command command, ZWaveNode node, ZWaveSwitchAllCommandClass commandClass, int endpointId, Map<String, String> arguments) {
+    	ZWaveCommandConverter<?,?> converter = this.getCommandConverter(command.getClass());
+        
+    	if (converter == null) {
+            logger.warn("NODE {}: No converter found for item = {}, endpoint = {}, ignoring command.", new Object[]{node.getNodeId(), item.getName(), endpointId});
+            return;
+        }
+        
+    	Integer cmd = (Integer)converter.convertFromCommandToValue(item, command);
+        
+    	if (cmd == 0x00) {
+            this.getController().allOff();
+        } else {
+            this.getController().allOn();
+        }
+        
+    	if (command instanceof State) {
+            this.getEventPublisher().postUpdate(item.getName(), (State)command);
+        }
+    }
+
+    /**
+	 * {@inheritDoc}
+	 */
+    @Override
+    int getRefreshInterval() {
+        return 0;
+    }
+}
+

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSwitchAllConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSwitchAllConverter.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
  */
 public class ZWaveSwitchAllConverter extends ZWaveCommandClassConverter<ZWaveSwitchAllCommandClass> {
     private static final Logger logger = LoggerFactory.getLogger(ZWaveSwitchAllConverter.class);
-    private static final int REFRESH_INTERVAL = 0;
 
     /**
 	 * Constructor. Creates a new instance of the {@link ZWaveSwitchAllConverter} class.
@@ -57,15 +56,6 @@ public class ZWaveSwitchAllConverter extends ZWaveCommandClassConverter<ZWaveSwi
         this.addCommandConverter(new BinaryOnOffCommandConverter());
     }
 
-    /**
-	 * {@inheritDoc}
-	 */
-    @Override
-    public SerialMessage executeRefresh(ZWaveNode node, 
-    		ZWaveSwitchAllCommandClass commandClass, int endpointId, Map<String, String> arguments) {
-        logger.debug("NODE {}: Generating poll message for {}, endpoint {}", new Object[]{node.getNodeId(), commandClass.getCommandClass().getLabel(), endpointId});
-        return node.encapsulate(commandClass.getValueMessage(), commandClass, endpointId);
-    }
 
     /**
 	 * {@inheritDoc}
@@ -106,14 +96,6 @@ public class ZWaveSwitchAllConverter extends ZWaveCommandClassConverter<ZWaveSwi
     	if (command instanceof State) {
             this.getEventPublisher().postUpdate(item.getName(), (State)command);
         }
-    }
-
-    /**
-	 * {@inheritDoc}
-	 */
-    @Override
-    int getRefreshInterval() {
-        return 0;
     }
 }
 

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSwitchAllConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSwitchAllConverter.java
@@ -21,8 +21,6 @@ import org.openhab.binding.zwave.internal.converter.state.ZWaveStateConverter;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 import org.openhab.binding.zwave.internal.protocol.ZWaveController;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
-import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveBatteryCommandClass;
-import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSwitchAllCommandClass;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
 import org.openhab.core.events.EventPublisher;
@@ -56,6 +54,14 @@ public class ZWaveSwitchAllConverter extends ZWaveCommandClassConverter<ZWaveSwi
         this.addCommandConverter(new BinaryOnOffCommandConverter());
     }
 
+    /**
+	 * {@inheritDoc}
+	 */
+    @Override
+    public SerialMessage executeRefresh(ZWaveNode node, 
+    		ZWaveSwitchAllCommandClass commandClass, int endpointId, Map<String, String> arguments) {
+    	return null;
+    }
 
     /**
 	 * {@inheritDoc}
@@ -96,6 +102,14 @@ public class ZWaveSwitchAllConverter extends ZWaveCommandClassConverter<ZWaveSwi
     	if (command instanceof State) {
             this.getEventPublisher().postUpdate(item.getName(), (State)command);
         }
+    }
+    
+    /**
+	 * {@inheritDoc}
+	 */
+    @Override
+    int getRefreshInterval() {
+        return 0;
     }
 }
 

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -28,6 +28,7 @@ import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Enumeration;
 
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessagePriority;
@@ -37,6 +38,7 @@ import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClas
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClassDynamicState;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveMultiInstanceCommandClass;
 import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveWakeUpCommandClass;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveSwitchAllCommandClass;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveInclusionEvent;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveNetworkEvent;
@@ -438,6 +440,46 @@ public class ZWaveController {
 	private void addNode(int nodeId) {
 		new ZWaveInitNodeThread(this, nodeId).start();
 	}
+	
+	/**
+	 * Send All On message to all devices that support the Switch All command class
+	 */
+	public void allOn() {
+        Enumeration<Integer> nodeIds = this.zwaveNodes.keys();
+        while (nodeIds.hasMoreElements()) {
+            Integer nodeId = nodeIds.nextElement();
+            ZWaveNode node = this.getNode(nodeId);
+            ZWaveSwitchAllCommandClass switchAllCommandClass = (ZWaveSwitchAllCommandClass)node.getCommandClass(ZWaveCommandClass.CommandClass.SWITCH_ALL);
+            if (switchAllCommandClass != null) {
+                logger.debug("NODE {}: Supports Switch All Command Class Sending AllOn Message", (Object)nodeId);
+                switchAllCommandClass.setNode(node);
+                switchAllCommandClass.setController(this);
+                this.enqueue(switchAllCommandClass.allOnMessage());
+                continue;
+            }
+            logger.debug("NODE {}: Does not Support Switch All Command Class. Ignoring All On message", (Object)nodeId);
+        }
+    }
+
+	/**
+	 * Send All Off message to all devices that support the Switch All command class
+	 */
+    public void allOff() {
+        Enumeration<Integer> nodeIds = this.zwaveNodes.keys();
+        while (nodeIds.hasMoreElements()) {
+            Integer nodeId = nodeIds.nextElement();
+            ZWaveNode node = this.getNode(nodeId);
+            ZWaveSwitchAllCommandClass switchAllCommandClass = (ZWaveSwitchAllCommandClass)node.getCommandClass(ZWaveCommandClass.CommandClass.SWITCH_ALL);
+            if (switchAllCommandClass != null) {
+                logger.debug("NODE {}: Supports Switch All Command Class Sending AllOff Message", (Object)nodeId);
+                switchAllCommandClass.setNode(node);
+                switchAllCommandClass.setController(this);
+                this.enqueue(switchAllCommandClass.allOffMessage());
+                continue;
+            }
+            logger.debug("NODE {}: Does not Support Switch All Command Class. Ignoring All Off message.", (Object)nodeId);
+        }
+    }
 
 	private class ZWaveInitNodeThread extends Thread {
 		int nodeId;

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveController.java
@@ -457,7 +457,6 @@ public class ZWaveController {
                 this.enqueue(switchAllCommandClass.allOnMessage());
                 continue;
             }
-            logger.debug("NODE {}: Does not Support Switch All Command Class. Ignoring All On message", (Object)nodeId);
         }
     }
 
@@ -477,7 +476,6 @@ public class ZWaveController {
                 this.enqueue(switchAllCommandClass.allOffMessage());
                 continue;
             }
-            logger.debug("NODE {}: Does not Support Switch All Command Class. Ignoring All Off message.", (Object)nodeId);
         }
     }
 

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -367,7 +367,7 @@ public abstract class ZWaveCommandClass {
 		ZIP_SERVER(0x24,"ZIP_SERVER",null),
 		SWITCH_BINARY(0x25,"SWITCH_BINARY",ZWaveBinarySwitchCommandClass.class),
 		SWITCH_MULTILEVEL(0x26,"SWITCH_MULTILEVEL",ZWaveMultiLevelSwitchCommandClass.class),
-		SWITCH_ALL(0x27,"SWITCH_ALL",null),
+		SWITCH_ALL(0x27,"SWITCH_ALL",ZWaveSwithcAllCommandClass.class),
 		SWITCH_TOGGLE_BINARY(0x28,"SWITCH_TOGGLE_BINARY",null),
 		SWITCH_TOGGLE_MULTILEVEL(0x29,"SWITCH_TOGGLE_MULTILEVEL",null),
 		CHIMNEY_FAN(0x2A,"CHIMNEY_FAN",null),

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -367,7 +367,7 @@ public abstract class ZWaveCommandClass {
 		ZIP_SERVER(0x24,"ZIP_SERVER",null),
 		SWITCH_BINARY(0x25,"SWITCH_BINARY",ZWaveBinarySwitchCommandClass.class),
 		SWITCH_MULTILEVEL(0x26,"SWITCH_MULTILEVEL",ZWaveMultiLevelSwitchCommandClass.class),
-		SWITCH_ALL(0x27,"SWITCH_ALL",ZWaveSwithcAllCommandClass.class),
+		SWITCH_ALL(0x27,"SWITCH_ALL",ZWaveSwitchAllCommandClass.class),
 		SWITCH_TOGGLE_BINARY(0x28,"SWITCH_TOGGLE_BINARY",null),
 		SWITCH_TOGGLE_MULTILEVEL(0x29,"SWITCH_TOGGLE_MULTILEVEL",null),
 		CHIMNEY_FAN(0x2A,"CHIMNEY_FAN",null),

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.zwave.internal.protocol.commandclass;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
+import org.openhab.binding.zwave.internal.config.ZWaveDbCommandClass;
+import org.openhab.binding.zwave.internal.protocol.SerialMessage;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
+import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClass;
+import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles the Switch All command class. Sends all on or all off commands to device
+ * 
+ * @author Pedro Paixao
+ * @since 1.8.0
+ */
+@XStreamAlias(value="switchAllCommandClass")
+public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass {
+    @XStreamOmitField
+    private static final Logger logger = LoggerFactory.getLogger(ZWaveSwitchAllCommandClass.class);
+   
+    private static final int SWITCH_ALL_SET = 0x01;
+    private static final int SWITCH_ALL_GET = 0x02;
+    private static final int SWITCH_ALL_REPORT = 0x03;
+    private static final int SWITCH_ALL_ON = 0x04;
+    private static final int SWITCH_ALL_OFF = 0x05;
+    
+    private static final int SWITCH_ALL_EXCLUDED = 0x00;
+    private static final int SWITCH_ALL_INCLUDE_ON_ONLY = 0x01;
+    private static final int SWITCH_ALL_INCLUDE_OFF_ONLY = 0x02;
+    private static final int SWITCH_ALL_INCLUDE_ON_OFF = 0xFF;
+    private boolean isGetSupported = true;
+
+    /**
+	 * Creates a new instance of the ZWaveSwitchAllCommandClass class.
+	 * 
+	 * @param node the node this command class belongs to
+	 * @param controller the controller to use
+	 * @param endpoint the endpoint this Command class belongs to
+	 */
+    public ZWaveSwitchAllCommandClass(ZWaveNode node, ZWaveController controller, ZWaveEndpoint endpoint) {
+        super(node, controller, endpoint);
+    }
+
+    /**
+	 * {@inheritDoc}
+	 */
+    @Override
+    public ZWaveCommandClass.CommandClass getCommandClass() {
+        return ZWaveCommandClass.CommandClass.SWITCH_ALL;
+    }
+
+    /**
+	 * {@inheritDoc}
+	 */
+    @Override
+    public void handleApplicationCommandRequest(SerialMessage serialMessage, int offset, int endpoint) {
+        logger.trace("Handle Message Switch All Request");
+        logger.debug(String.format("Received Switch All Request for Node ID = %d", this.getNode().getNodeId()));
+        int command = serialMessage.getMessagePayloadByte(offset);
+        switch (command) {
+            case SWITCH_ALL_SET: {
+                logger.trace("Process Switch All Set");
+                logger.debug("Switch All Set sent to the controller will be processed as Switch All Report");
+                this.processSwitchAllReport(serialMessage, offset, endpoint);
+                break;
+            }
+            case SWITCH_ALL_GET: {
+                logger.warn("Command {} not implemented.", (Object)command);
+                return;
+            }
+            case SWITCH_ALL_REPORT: {
+                logger.trace("Process Switch All Report");
+                this.processSwitchAllReport(serialMessage, offset, endpoint);
+                break;
+            }
+            default: {
+                logger.warn(String.format("Unsupported Command 0x%02X for command class %s (0x%02X).", command, this.getCommandClass().getLabel(), this.getCommandClass().getKey()));
+            }
+        }
+    }
+
+    protected void processSwitchAllReport(SerialMessage serialMessage, int offset, int endpoint) {
+        int mode = serialMessage.getMessagePayloadByte(offset + 1);
+        switch (mode) {
+            case SWITCH_ALL_EXCLUDED:
+                logger.debug("NODE {}: Switch All report, device is not included in either All On or All Off groups.", (Object)this.getNode().getNodeId());
+                break;
+            case SWITCH_ALL_INCLUDE_ON_ONLY:
+                logger.debug("NODE {}: Switch All report, device included in All On group.", (Object)this.getNode().getNodeId());
+                break;
+            case SWITCH_ALL_INCLUDE_OFF_ONLY:
+                logger.debug("NODE {}: Switch All report, device included in All Off group.", (Object)this.getNode().getNodeId());
+                break;
+            case SWITCH_ALL_INCLUDE_ON_OFF:
+                logger.debug("NODE {}: Switch All report, device included in All On and All Off group.", (Object)this.getNode().getNodeId());
+                break;
+            default:
+                logger.warn(String.format("Unsupported Switch All mode 0x%02X.", mode));
+        }
+        ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(this.getNode().getNodeId(), endpoint, this.getCommandClass(), mode);
+        this.getController().notifyEventListeners(zEvent);
+    }
+
+    public SerialMessage getValueMessage() {
+        logger.debug("NODE {}: Creating new message for command SWITCH_ALL_GET", (Object)this.getNode().getNodeId());
+        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.ApplicationCommandHandler, SerialMessage.SerialMessagePriority.Get);
+        byte[] newPayload = { 
+        		(byte)this.getNode().getNodeId(), 
+        		2, 
+        		(byte) this.getCommandClass().getKey(), 
+        		(byte) SWITCH_ALL_GET };
+        result.setMessagePayload(newPayload);
+        return result;
+    }
+
+    /**
+     * Create a new SwitchAll set message
+     * @param mode as (0x00 - Exclude, 0x01 Only All On, 0x02 Only All Off, 0xFF Both All on and All off)
+     * @return SerialMessage
+     */
+    public SerialMessage setValueMessage(int mode) {
+        if (!this.isGetSupported) {
+            logger.debug("NODE {}: Node doesn't support get requests", (Object)this.getNode().getNodeId());
+            return null;
+        }
+        
+        switch (mode) {
+	        case SWITCH_ALL_EXCLUDED:
+	            logger.debug("NODE {}: Switch All report, device is not included in either All On or All Off groups.", (Object)this.getNode().getNodeId());
+	            break;
+	        case SWITCH_ALL_INCLUDE_ON_ONLY:
+	            logger.debug("NODE {}: Switch All report, device included in All On group.", (Object)this.getNode().getNodeId());
+	            break;
+	        case SWITCH_ALL_INCLUDE_OFF_ONLY:
+	            logger.debug("NODE {}: Switch All report, device included in All Off group.", (Object)this.getNode().getNodeId());
+	            break;
+	        case SWITCH_ALL_INCLUDE_ON_OFF:
+	            logger.debug("NODE {}: Switch All report, device included in All On and All Off group.", (Object)this.getNode().getNodeId());
+	            break;
+	        default:
+	            logger.warn(String.format("Unsupported Switch All mode 0x%02X.", mode));
+        }
+	        
+        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessagePriority.Set);
+        byte[] newPayload = {
+        		(byte)this.getNode().getNodeId(), 
+        		3, 
+        		(byte) this.getCommandClass().getKey(), 
+        		(byte) SWITCH_ALL_SET, 
+        		(byte) mode };
+ 
+        result.setMessagePayload(newPayload);
+        return result;
+    }
+
+    /**
+     * Create the All On message
+     * @return
+     */
+    public SerialMessage allOnMessage() {
+        logger.debug("NODE {}: Switch All - Creating All On message.", (Object)this.getNode().getNodeId());
+        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessagePriority.Set);
+        byte[] newPayload = { (byte)this.getNode().getNodeId(), 
+        		2, 
+        		(byte) this.getCommandClass().getKey(), 
+        		(byte) SWITCH_ALL_ON };
+        result.setMessagePayload(newPayload);
+        return result;
+    }
+
+    /**
+     * Create the All Off message
+     * @return
+     */
+    public SerialMessage allOffMessage() {
+        logger.debug("NODE {}: Switch All - Creating All Off message.", (Object)this.getNode().getNodeId());
+        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessagePriority.Set);
+        byte[] newPayload = { (byte)this.getNode().getNodeId(), 
+        		2, 
+        		(byte) this.getCommandClass().getKey(), 
+        		(byte) SWITCH_ALL_OFF };
+        result.setMessagePayload(newPayload);
+        return result;
+    }
+
+    @Override
+    public boolean setOptions(ZWaveDbCommandClass options) {
+        if (options.isGetSupported != null) {
+            this.isGetSupported = options.isGetSupported;
+        }
+        return true;
+    }
+}
+

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
@@ -115,6 +115,11 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass {
     }
 
     public SerialMessage getValueMessage() {
+        if (!this.isGetSupported) {
+            logger.debug("NODE {}: Node doesn't support get requests", (Object)this.getNode().getNodeId());
+            return null;
+        }
+        
         logger.debug("NODE {}: Creating new message for command SWITCH_ALL_GET", (Object)this.getNode().getNodeId());
         SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.ApplicationCommandHandler, SerialMessage.SerialMessagePriority.Get);
         byte[] newPayload = { 

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
@@ -42,6 +42,7 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass {
     private static final int SWITCH_ALL_INCLUDE_OFF_ONLY = 0x02;
     private static final int SWITCH_ALL_INCLUDE_ON_OFF = 0xFF;
     private boolean isGetSupported = true;
+    private int mode = 0;
 
     /**
 	 * Creates a new instance of the ZWaveSwitchAllCommandClass class.
@@ -93,7 +94,7 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass {
     }
 
     protected void processSwitchAllReport(SerialMessage serialMessage, int offset, int endpoint) {
-        int mode = serialMessage.getMessagePayloadByte(offset + 1);
+        mode = serialMessage.getMessagePayloadByte(offset + 1);
         switch (mode) {
             case SWITCH_ALL_EXCLUDED:
                 logger.debug("NODE {}: Switch All report, device is not included in either All On or All Off groups.", (Object)this.getNode().getNodeId());
@@ -110,7 +111,7 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass {
             default:
                 logger.warn(String.format("Unsupported Switch All mode 0x%02X.", mode));
         }
-        ZWaveCommandClassValueEvent zEvent = new ZWaveCommandClassValueEvent(this.getNode().getNodeId(), endpoint, this.getCommandClass(), mode);
+        ZWaveSwitchAllModeEvent zEvent = new ZWaveSwitchAllModeEvent(this.getNode().getNodeId(), endpoint, new Integer(mode));
         this.getController().notifyEventListeners(zEvent);
     }
 
@@ -203,5 +204,33 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass {
         }
         return true;
     }
+    
+    /**
+	 * ZWave Switch All mode received event.
+	 * Sent from the Switch All Command Class to the binding
+	 * when the switch all mode is received.
+	 * 
+	 * @author Pedro Paixao
+	 * @since 1.8.0
+	 */
+	public class ZWaveSwitchAllModeEvent extends ZWaveCommandClassValueEvent {
+
+		/**
+		 * Constructor. Creates a new instance of the ZWaveSwitchAllModeEvent
+		 * class.
+		 * @param nodeId the nodeId of the event
+		 */
+		public ZWaveSwitchAllModeEvent(int nodeId, int endpoint, Integer mode) {
+			super(nodeId, endpoint, CommandClass.SWITCH_ALL, mode);
+		}
+
+		/**
+		 * Returns the switch all mode that was received as event. 
+		 * @return the mode.
+		 */
+		public Integer getParameter() {
+			return (Integer) this.getValue();
+		}
+	}
 }
 

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
@@ -8,6 +8,9 @@
  */
 package org.openhab.binding.zwave.internal.protocol.commandclass;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import org.openhab.binding.zwave.internal.config.ZWaveDbCommandClass;
@@ -21,202 +24,266 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handles the Switch All command class. Sends all on or all off commands to device
+ * Handles the Switch All command class. Sends all on or all off commands to
+ * device
  * 
  * @author Pedro Paixao
  * @since 1.8.0
  */
-@XStreamAlias(value="switchAllCommandClass")
-public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass {
-    @XStreamOmitField
-    private static final Logger logger = LoggerFactory.getLogger(ZWaveSwitchAllCommandClass.class);
-   
-    private static final int SWITCH_ALL_SET = 0x01;
-    private static final int SWITCH_ALL_GET = 0x02;
-    private static final int SWITCH_ALL_REPORT = 0x03;
-    private static final int SWITCH_ALL_ON = 0x04;
-    private static final int SWITCH_ALL_OFF = 0x05;
-    
-    private static final int SWITCH_ALL_EXCLUDED = 0x00;
-    private static final int SWITCH_ALL_INCLUDE_ON_ONLY = 0x01;
-    private static final int SWITCH_ALL_INCLUDE_OFF_ONLY = 0x02;
-    private static final int SWITCH_ALL_INCLUDE_ON_OFF = 0xFF;
-    private boolean isGetSupported = true;
-    private int mode = 0;
+@XStreamAlias(value = "switchAllCommandClass")
+public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements
+		ZWaveCommandClassInitialization {
 
-    /**
+	@XStreamOmitField
+	private static final Logger logger = LoggerFactory
+			.getLogger(ZWaveSwitchAllCommandClass.class);
+
+	private static final int SWITCH_ALL_SET = 0x01;
+	private static final int SWITCH_ALL_GET = 0x02;
+	private static final int SWITCH_ALL_REPORT = 0x03;
+	private static final int SWITCH_ALL_ON = 0x04;
+	private static final int SWITCH_ALL_OFF = 0x05;
+
+	public enum SwitchAllMode {
+		SWITCH_ALL_EXCLUDED(0x00,
+				"not included in either All On or All Off groups"), SWITCH_ALL_INCLUDE_ON_ONLY(
+				0x01, "device included in All On group"), SWITCH_ALL_INCLUDE_OFF_ONLY(
+				0x02, "device included in All Off group"), SWITCH_ALL_INCLUDE_ON_OFF(
+				0xFF, "device included in All On and All Off group");
+
+		int mode;
+		String description;
+
+		SwitchAllMode(int mode) {
+			this.mode = mode;
+			this.description = "";
+		}
+
+		SwitchAllMode(int mode, String description) {
+			this.mode = mode;
+			this.description = description;
+		}
+
+		public int getMode() {
+			return mode;
+		}
+
+		public String getDescription() {
+			return description;
+		}
+
+		public static SwitchAllMode fromInteger(int m) {
+			switch (m) {
+			case 0x00:
+				return SWITCH_ALL_EXCLUDED;
+			case 0x01:
+				return SWITCH_ALL_INCLUDE_ON_ONLY;
+			case 0x02:
+				return SWITCH_ALL_INCLUDE_OFF_ONLY;
+			case 0xFF:
+				return SWITCH_ALL_INCLUDE_ON_OFF;
+			}
+
+			return null;
+		}
+	}
+
+	@XStreamOmitField
+	private boolean initialiseDone = false;
+
+	private boolean isGetSupported = true;
+	private SwitchAllMode mode;
+
+	/**
 	 * Creates a new instance of the ZWaveSwitchAllCommandClass class.
 	 * 
-	 * @param node the node this command class belongs to
-	 * @param controller the controller to use
-	 * @param endpoint the endpoint this Command class belongs to
+	 * @param node
+	 *            the node this command class belongs to
+	 * @param controller
+	 *            the controller to use
+	 * @param endpoint
+	 *            the endpoint this Command class belongs to
 	 */
-    public ZWaveSwitchAllCommandClass(ZWaveNode node, ZWaveController controller, ZWaveEndpoint endpoint) {
-        super(node, controller, endpoint);
-    }
+	public ZWaveSwitchAllCommandClass(ZWaveNode node,
+			ZWaveController controller, ZWaveEndpoint endpoint) {
+		super(node, controller, endpoint);
+	}
 
-    /**
+	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public ZWaveCommandClass.CommandClass getCommandClass() {
-        return ZWaveCommandClass.CommandClass.SWITCH_ALL;
-    }
+	@Override
+	public ZWaveCommandClass.CommandClass getCommandClass() {
+		return ZWaveCommandClass.CommandClass.SWITCH_ALL;
+	}
 
-    /**
+	/**
 	 * {@inheritDoc}
 	 */
-    @Override
-    public void handleApplicationCommandRequest(SerialMessage serialMessage, int offset, int endpoint) {
-        logger.trace("Handle Message Switch All Request");
-        logger.debug(String.format("Received Switch All Request for Node ID = %d", this.getNode().getNodeId()));
-        int command = serialMessage.getMessagePayloadByte(offset);
-        switch (command) {
-            case SWITCH_ALL_SET: {
-                logger.trace("Process Switch All Set");
-                logger.debug("Switch All Set sent to the controller will be processed as Switch All Report");
-                this.processSwitchAllReport(serialMessage, offset, endpoint);
-                break;
-            }
-            case SWITCH_ALL_GET: {
-                logger.warn("Command {} not implemented.", (Object)command);
-                return;
-            }
-            case SWITCH_ALL_REPORT: {
-                logger.trace("Process Switch All Report");
-                this.processSwitchAllReport(serialMessage, offset, endpoint);
-                break;
-            }
-            default: {
-                logger.warn(String.format("Unsupported Command 0x%02X for command class %s (0x%02X).", command, this.getCommandClass().getLabel(), this.getCommandClass().getKey()));
-            }
-        }
-    }
+	@Override
+	public void handleApplicationCommandRequest(SerialMessage serialMessage,
+			int offset, int endpoint) {
+		logger.trace("Handle Message Switch All Request");
+		logger.debug(String.format(
+				"Received Switch All Request for Node ID = %d", this.getNode()
+						.getNodeId()));
+		int command = serialMessage.getMessagePayloadByte(offset);
+		switch (command) {
+		case SWITCH_ALL_SET: {
+			logger.trace("Process Switch All Set");
+			logger.debug("Switch All Set sent to the controller will be processed as Switch All Report");
+			this.processSwitchAllReport(serialMessage, offset, endpoint);
+			break;
+		}
+		case SWITCH_ALL_GET: {
+			logger.warn("Command {} not implemented.", (Object) command);
+			return;
+		}
+		case SWITCH_ALL_REPORT: {
+			logger.trace("Process Switch All Report");
+			this.processSwitchAllReport(serialMessage, offset, endpoint);
+			break;
+		}
+		default: {
+			logger.warn(String
+					.format("Unsupported Command 0x%02X for command class %s (0x%02X).",
+							command, this.getCommandClass().getLabel(), this
+									.getCommandClass().getKey()));
+		}
+		}
+	}
 
-    protected void processSwitchAllReport(SerialMessage serialMessage, int offset, int endpoint) {
-        mode = serialMessage.getMessagePayloadByte(offset + 1);
-        switch (mode) {
-            case SWITCH_ALL_EXCLUDED:
-                logger.debug("NODE {}: Switch All report, device is not included in either All On or All Off groups.", (Object)this.getNode().getNodeId());
-                break;
-            case SWITCH_ALL_INCLUDE_ON_ONLY:
-                logger.debug("NODE {}: Switch All report, device included in All On group.", (Object)this.getNode().getNodeId());
-                break;
-            case SWITCH_ALL_INCLUDE_OFF_ONLY:
-                logger.debug("NODE {}: Switch All report, device included in All Off group.", (Object)this.getNode().getNodeId());
-                break;
-            case SWITCH_ALL_INCLUDE_ON_OFF:
-                logger.debug("NODE {}: Switch All report, device included in All On and All Off group.", (Object)this.getNode().getNodeId());
-                break;
-            default:
-                logger.warn(String.format("Unsupported Switch All mode 0x%02X.", mode));
-        }
-        ZWaveSwitchAllModeEvent zEvent = new ZWaveSwitchAllModeEvent(this.getNode().getNodeId(), endpoint, new Integer(mode));
-        this.getController().notifyEventListeners(zEvent);
-    }
+	protected void processSwitchAllReport(SerialMessage serialMessage,
+			int offset, int endpoint) {
+		int m = serialMessage.getMessagePayloadByte(offset + 1);
+		mode = SwitchAllMode.fromInteger(m);
 
-    public SerialMessage getValueMessage() {
-        if (!this.isGetSupported) {
-            logger.debug("NODE {}: Node doesn't support get requests", (Object)this.getNode().getNodeId());
-            return null;
-        }
-        
-        logger.debug("NODE {}: Creating new message for command SWITCH_ALL_GET", (Object)this.getNode().getNodeId());
-        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.ApplicationCommandHandler, SerialMessage.SerialMessagePriority.Get);
-        byte[] newPayload = { 
-        		(byte)this.getNode().getNodeId(), 
-        		2, 
-        		(byte) this.getCommandClass().getKey(), 
-        		(byte) SWITCH_ALL_GET };
-        result.setMessagePayload(newPayload);
-        return result;
-    }
+		if (mode != null) {
+			logger.debug("NODE {}: Switch All report, {}.", (Object) this
+					.getNode().getNodeId(), mode.getDescription());
+		} else {
+			logger.debug("NODE {}: Switch All unsupported mode.", (Object) this
+					.getNode().getNodeId());
+			return;
+		}
 
-    /**
-     * Create a new SwitchAll set message
-     * @param mode as (0x00 - Exclude, 0x01 Only All On, 0x02 Only All Off, 0xFF Both All on and All off)
-     * @return SerialMessage
-     */
-    public SerialMessage setValueMessage(int mode) {
-        switch (mode) {
-	        case SWITCH_ALL_EXCLUDED:
-	            logger.debug("NODE {}: Switch All report, device is not included in either All On or All Off groups.", (Object)this.getNode().getNodeId());
-	            break;
-	        case SWITCH_ALL_INCLUDE_ON_ONLY:
-	            logger.debug("NODE {}: Switch All report, device included in All On group.", (Object)this.getNode().getNodeId());
-	            break;
-	        case SWITCH_ALL_INCLUDE_OFF_ONLY:
-	            logger.debug("NODE {}: Switch All report, device included in All Off group.", (Object)this.getNode().getNodeId());
-	            break;
-	        case SWITCH_ALL_INCLUDE_ON_OFF:
-	            logger.debug("NODE {}: Switch All report, device included in All On and All Off group.", (Object)this.getNode().getNodeId());
-	            break;
-	        default:
-	            logger.warn(String.format("Unsupported Switch All mode 0x%02X.", mode));
-        }
-	        
-        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessagePriority.Set);
-        byte[] newPayload = {
-        		(byte)this.getNode().getNodeId(), 
-        		3, 
-        		(byte) this.getCommandClass().getKey(), 
-        		(byte) SWITCH_ALL_SET, 
-        		(byte) mode };
- 
-        result.setMessagePayload(newPayload);
-        return result;
-    }
+		ZWaveSwitchAllModeEvent zEvent = new ZWaveSwitchAllModeEvent(this
+				.getNode().getNodeId(), endpoint, new Integer(m));
+		this.getController().notifyEventListeners(zEvent);
+	}
 
-    /**
-     * Create the All On message
-     * @return
-     */
-    public SerialMessage allOnMessage() {
-        logger.debug("NODE {}: Switch All - Creating All On message.", (Object)this.getNode().getNodeId());
-        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessagePriority.Set);
-        byte[] newPayload = { (byte)this.getNode().getNodeId(), 
-        		2, 
-        		(byte) this.getCommandClass().getKey(), 
-        		(byte) SWITCH_ALL_ON };
-        result.setMessagePayload(newPayload);
-        return result;
-    }
+	public SerialMessage getValueMessage() {
+		if (!this.isGetSupported) {
+			logger.debug("NODE {}: Node doesn't support get requests",
+					(Object) this.getNode().getNodeId());
+			return null;
+		}
 
-    /**
-     * Create the All Off message
-     * @return
-     */
-    public SerialMessage allOffMessage() {
-        logger.debug("NODE {}: Switch All - Creating All Off message.", (Object)this.getNode().getNodeId());
-        SerialMessage result = new SerialMessage(this.getNode().getNodeId(), SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessageType.Request, SerialMessage.SerialMessageClass.SendData, SerialMessage.SerialMessagePriority.Set);
-        byte[] newPayload = { (byte)this.getNode().getNodeId(), 
-        		2, 
-        		(byte) this.getCommandClass().getKey(), 
-        		(byte) SWITCH_ALL_OFF };
-        result.setMessagePayload(newPayload);
-        return result;
-    }
+		logger.debug(
+				"NODE {}: Creating new message for command SWITCH_ALL_GET",
+				(Object) this.getNode().getNodeId());
+		SerialMessage result = new SerialMessage(this.getNode().getNodeId(),
+				SerialMessage.SerialMessageClass.SendData,
+				SerialMessage.SerialMessageType.Request,
+				SerialMessage.SerialMessageClass.ApplicationCommandHandler,
+				SerialMessage.SerialMessagePriority.Get);
+		byte[] newPayload = { (byte) this.getNode().getNodeId(), 2,
+				(byte) this.getCommandClass().getKey(), (byte) SWITCH_ALL_GET };
+		result.setMessagePayload(newPayload);
+		return result;
+	}
 
-    @Override
-    public boolean setOptions(ZWaveDbCommandClass options) {
-        if (options.isGetSupported != null) {
-            this.isGetSupported = options.isGetSupported;
-        }
-        return true;
-    }
-    
-    /**
-     * get the Switch All mode
-     * @return the mode
-     */
-    public int getMode() {
-    	return mode;
-    }
-    
-    /**
-	 * ZWave Switch All mode received event.
-	 * Sent from the Switch All Command Class to the binding
-	 * when the switch all mode is received.
+	/**
+	 * Create a new SwitchAll set message
+	 * 
+	 * @param mode
+	 *            as (0x00 - Exclude, 0x01 Only All On, 0x02 Only All Off, 0xFF
+	 *            Both All on and All off)
+	 * @return SerialMessage
+	 */
+	public SerialMessage setValueMessage(int m) {
+		mode = SwitchAllMode.fromInteger(m);
+
+		if (mode != null) {
+			logger.debug("NODE {}: Switch All report, {}.", (Object) this
+					.getNode().getNodeId(), mode.getDescription());
+		} else {
+			logger.debug("NODE {}: Switch All unsupported mode.", (Object) this
+					.getNode().getNodeId());
+			return null;
+		}
+
+		SerialMessage result = new SerialMessage(this.getNode().getNodeId(),
+				SerialMessage.SerialMessageClass.SendData,
+				SerialMessage.SerialMessageType.Request,
+				SerialMessage.SerialMessageClass.SendData,
+				SerialMessage.SerialMessagePriority.Set);
+		byte[] newPayload = { (byte) this.getNode().getNodeId(), 3,
+				(byte) this.getCommandClass().getKey(), (byte) SWITCH_ALL_SET,
+				(byte) m };
+
+		result.setMessagePayload(newPayload);
+		return result;
+	}
+
+	/**
+	 * Create the All On message
+	 * 
+	 * @return
+	 */
+	public SerialMessage allOnMessage() {
+		logger.debug("NODE {}: Switch All - Creating All On message.",
+				(Object) this.getNode().getNodeId());
+		SerialMessage result = new SerialMessage(this.getNode().getNodeId(),
+				SerialMessage.SerialMessageClass.SendData,
+				SerialMessage.SerialMessageType.Request,
+				SerialMessage.SerialMessageClass.SendData,
+				SerialMessage.SerialMessagePriority.Set);
+		byte[] newPayload = { (byte) this.getNode().getNodeId(), 2,
+				(byte) this.getCommandClass().getKey(), (byte) SWITCH_ALL_ON };
+		result.setMessagePayload(newPayload);
+		return result;
+	}
+
+	/**
+	 * Create the All Off message
+	 * 
+	 * @return
+	 */
+	public SerialMessage allOffMessage() {
+		logger.debug("NODE {}: Switch All - Creating All Off message.",
+				(Object) this.getNode().getNodeId());
+		SerialMessage result = new SerialMessage(this.getNode().getNodeId(),
+				SerialMessage.SerialMessageClass.SendData,
+				SerialMessage.SerialMessageType.Request,
+				SerialMessage.SerialMessageClass.SendData,
+				SerialMessage.SerialMessagePriority.Set);
+		byte[] newPayload = { (byte) this.getNode().getNodeId(), 2,
+				(byte) this.getCommandClass().getKey(), (byte) SWITCH_ALL_OFF };
+		result.setMessagePayload(newPayload);
+		return result;
+	}
+
+	@Override
+	public boolean setOptions(ZWaveDbCommandClass options) {
+		if (options.isGetSupported != null) {
+			this.isGetSupported = options.isGetSupported;
+		}
+		return true;
+	}
+
+	/**
+	 * get the Switch All mode
+	 * 
+	 * @return the mode
+	 */
+	public SwitchAllMode getMode() {
+		return mode;
+	}
+
+	/**
+	 * ZWave Switch All mode received event. Sent from the Switch All Command
+	 * Class to the binding when the switch all mode is received.
 	 * 
 	 * @author Pedro Paixao
 	 * @since 1.8.0
@@ -226,19 +293,33 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass {
 		/**
 		 * Constructor. Creates a new instance of the ZWaveSwitchAllModeEvent
 		 * class.
-		 * @param nodeId the nodeId of the event
+		 * 
+		 * @param nodeId
+		 *            the nodeId of the event
 		 */
 		public ZWaveSwitchAllModeEvent(int nodeId, int endpoint, Integer mode) {
 			super(nodeId, endpoint, CommandClass.SWITCH_ALL, mode);
 		}
 
 		/**
-		 * Returns the switch all mode that was received as event. 
+		 * Returns the switch all mode that was received as event.
+		 * 
 		 * @return the mode.
 		 */
 		public Integer getParameter() {
 			return (Integer) this.getValue();
 		}
 	}
-}
 
+	@Override
+	public Collection<SerialMessage> initialize(boolean refresh) {
+		ArrayList<SerialMessage> result = new ArrayList<SerialMessage>();
+		// If we're already initialized, then don't do it again unless we're
+		// refreshing
+		if (refresh == true || initialiseDone == false) {
+			result.add(this.getValueMessage());
+		}
+
+		return result;
+	}
+}

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
@@ -206,6 +206,14 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass {
     }
     
     /**
+     * get the Switch All mode
+     * @return the mode
+     */
+    public int getMode() {
+    	return mode;
+    }
+    
+    /**
 	 * ZWave Switch All mode received event.
 	 * Sent from the Switch All Command Class to the binding
 	 * when the switch all mode is received.

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
@@ -137,11 +137,6 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass {
      * @return SerialMessage
      */
     public SerialMessage setValueMessage(int mode) {
-        if (!this.isGetSupported) {
-            logger.debug("NODE {}: Node doesn't support get requests", (Object)this.getNode().getNodeId());
-            return null;
-        }
-        
         switch (mode) {
 	        case SWITCH_ALL_EXCLUDED:
 	            logger.debug("NODE {}: Switch All report, device is not included in either All On or All Off groups.", (Object)this.getNode().getNodeId());


### PR DESCRIPTION
Added support for Switch All Command Class.

To use add a new switch item 

    Switch AllOnOff "All On/Off" {zwave="4:command=SWITCH_ALL"}

When user toggles this switch an All On or All Off message will be sent to ALL Z-Wave nodes that support the Switch All Command Class 
The node ID used in the zwave binding MUST be the ID of any one node that supports the SwitchAll command class. 

Then on the sitemap you could do:

    Frame {
        Group item=gGF label="Ground Floor" icon="groundfloor"
        Group item=gFF label="First Floor" icon="firstfloor"
        Group item=Outdoor icon="garden" 
        Switch item=AllOnOff icon="" mappings=[ON="All On", OFF="All Off"]
    }

Added support for the SWITCH_ALL_SET message although it is not needed in OpenHab operation but would be needed to configure nodes.
How could it be added to Habmin so we can configure AllOn and AllOff membership of nodes like in all other Z-Wave Controllers?