### PR TITLE
[Nest] Quiesce logging on status poll

### DIFF
--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
@@ -166,7 +166,11 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider> impl
 				readNest(oauthCredentials);
 			}
 		} catch (Exception e) {
-			logger.error("Error reading from Nest:", e);
+			if (logger.isDebugEnabled()) {
+				logger.warn("Exception reading from Nest.", e);
+			} else {
+				logger.warn("Exception reading from Nest: {}", e.getMessage());
+			}
 		}
 	}
 


### PR DESCRIPTION
If there is an error polling the Nest API (usually due to network issues), the failed poll would log as an ERROR and dump a stacktrace to openhab.log which is typically unhelpful.  Since network issues are usually temporary, this PR changes the log to WARN and the stacktrace is now not dumped (only the exception message is logged).  However, at the DEBUG level the stacktrace is dumped to the log for the non-typical failure situation.  @mrguessed, do you agree that this would be better?