### PR TITLE
Fix URL of GoogleTTS service after API changes

### DIFF
--- a/bundles/io/org.openhab.io.multimedia.tts.googletts/src/main/java/org/openhab/io/multimedia/internal/tts/TTSServiceGoogleTTS.java
+++ b/bundles/io/org.openhab.io.multimedia.tts.googletts/src/main/java/org/openhab/io/multimedia/internal/tts/TTSServiceGoogleTTS.java
@@ -53,7 +53,7 @@ public class TTSServiceGoogleTTS implements TTSService, ManagedService {
 	private static final String TRANSLATE_URL_PROPERTY = "translateUrl";
 
 	private String ttsLanguage = "en";
-	private String translateUrl = "http://translate.google.com/translate_tts?tl=%s&q=%s";
+	private String translateUrl = "http://translate.google.com/translate_tts?tl=%s&q=%s&client=t";
 
 	private final GoogleTTSTextProcessor textProcessor = new GoogleTTSTextProcessor(MAX_SENTENCE_LENGTH);
 

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -298,7 +298,7 @@ chart:provider=default
 # Sentence delimiters used to split text into sentences (optional, default: !.?:;)
 # googletts:sentenceDelimiters=
 # Google Translate URL to be used for converting text to speech (optional, 
-# defaults to http://translate.google.com/translate_tts?tl=%s&q=%s).
+# defaults to http://translate.google.com/translate_tts?tl=%s&q=%s&client=t).
 # googletts:translateUrl=
 
 ####################################################################################### 


### PR DESCRIPTION
Fix URL of GoogleTTS by adding a `client` parameter to the URL as discussed in the [openHAB forum](https://groups.google.com/forum/#!msg/openhab/Sb8CuHDDCBk/O2OulKYCAwAJ) and on [stackoverflow](http://stackoverflow.com/a/31791632/3049015).