### PR TITLE
Allow Location items to receive commands and updates (ref #3104)

### DIFF
--- a/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/items/LocationItem.java
+++ b/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/items/LocationItem.java
@@ -32,6 +32,7 @@ public class LocationItem extends GenericItem {
 	static {
 		acceptedDataTypes.add(PointType.class);
 		acceptedDataTypes.add(UnDefType.class);
+		acceptedCommandTypes.add(PointType.class);
 	}
 	
 	public LocationItem(String name) {

--- a/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/PointType.java
+++ b/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/PointType.java
@@ -30,8 +30,8 @@ public class PointType implements ComplexType, Command, State {
 	public static final double WGS84_a = 6378137; // The equatorial radius of
 													// WGS84 ellipsoid (6378137
 													// m).
-	private BigDecimal latitude; // in decimal degrees
-	private BigDecimal longitude; // in decimal degrees
+	private BigDecimal latitude = BigDecimal.ZERO; // in decimal degrees
+	private BigDecimal longitude = BigDecimal.ZERO; // in decimal degrees
 	private BigDecimal altitude = BigDecimal.ZERO; // in decimal meters
 	// constants for the constituents
 	static final public String KEY_LATITUDE = "lat";
@@ -42,6 +42,15 @@ public class PointType implements ComplexType, Command, State {
 	private static final BigDecimal right = new BigDecimal(90);
 	public static final PointType EMPTY = new PointType(new DecimalType(0),
 			new DecimalType(0));
+
+	/**
+	 * Default constructor creates a point at sea level where the equator
+	 * (0° latitude) and the prime meridian (0° longitude) intersect. (A
+	 * nullary constructor is needed by
+	 * {@link org.openhab.core.internal.items.ItemUpdater#receiveUpdate})
+	 */
+	@SuppressWarnings("restriction")
+	public PointType() {}
 
 	public PointType(DecimalType latitude, DecimalType longitude) {
 		canonicalize(latitude, longitude);


### PR DESCRIPTION
* Location items could not receive any commands; now they can receive PointType commands.
* Location items could not receive PointType updates because PointType had no zero-arg (nullary) constructor, which [this code](https://github.com/openhab/openhab/blob/master/bundles/core/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemUpdater.java#L59) requires of State classes.

I have not yet tested these changes.  @clinique and @teichsta, please comment when you can.

This code diff looks wrong because these two files previously had Windows CR/LF line endings.  They now have LF line endings.  Here is the readable diff output:
```
$ git diff --ignore-space-at-eol
diff --git a/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/items/LocationItem.java b/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/items/LocationItem.java
index 6f2cbb9..4e99604 100644
--- a/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/items/LocationItem.java
+++ b/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/items/LocationItem.java
@@ -32,6 +32,7 @@ public class LocationItem extends GenericItem {
        static {
                acceptedDataTypes.add(PointType.class);
                acceptedDataTypes.add(UnDefType.class);
+               acceptedCommandTypes.add(PointType.class);
        }
        
        public LocationItem(String name) {
diff --git a/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/PointType.java b/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/PointType.java
index b2c85c0..dd825a1 100644
--- a/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/PointType.java
+++ b/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/PointType.java
@@ -30,8 +30,8 @@ public class PointType implements ComplexType, Command, State {
        public static final double WGS84_a = 6378137; // The equatorial radius of
                                                                                                        // WGS84 ellipsoid (6378137
                                                                                                        // m).
-       private BigDecimal latitude; // in decimal degrees
-       private BigDecimal longitude; // in decimal degrees
+       private BigDecimal latitude = BigDecimal.ZERO; // in decimal degrees
+       private BigDecimal longitude = BigDecimal.ZERO; // in decimal degrees
        private BigDecimal altitude = BigDecimal.ZERO; // in decimal meters
        // constants for the constituents
        static final public String KEY_LATITUDE = "lat";
@@ -43,6 +43,15 @@ public class PointType implements ComplexType, Command, State {
        public static final PointType EMPTY = new PointType(new DecimalType(0),
                        new DecimalType(0));
 
+       /**
+        * Default constructor creates a point at sea level where the equator
+        * (0° latitude) and the prime meridian (0° longitude) intersect. (A
+        * nullary constructor is needed by
+        * {@link org.openhab.core.internal.items.ItemUpdater#receiveUpdate})
+        */
+       @SuppressWarnings("restriction")
+       public PointType() {}
+
        public PointType(DecimalType latitude, DecimalType longitude) {
                canonicalize(latitude, longitude);
        }
```