### PR TITLE
Added new Reference for Linear NGD00Z-4

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -112,6 +112,10 @@
 		<Product>
 			<Reference>
 				<Type>4744</Type>
+				<Id>3030</Id>
+			</Reference>
+			<Reference>
+				<Type>4744</Type>
 				<Id>3530</Id>
 			</Reference>
 			<Model>NGD00Z-4</Model>


### PR DESCRIPTION
The device I have has a different device ID than what was in the xml and on pepper1 database. I have added it.