### PR TITLE
Update Plex binding to support Plex Home

### DIFF
--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexActivator.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexActivator.java
@@ -10,6 +10,7 @@ package org.openhab.binding.plex.internal;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +48,14 @@ public final class PlexActivator implements BundleActivator {
 	 */
 	public static BundleContext getContext() {
 		return context;
+	}
+	
+	/**
+	 * Returns the current version of the bundle.
+	 * @return the current version of the bundle.
+	 */
+	public static Version getVersion() {
+		return context.getBundle().getVersion();
 	}
 	
 }

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexBinding.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexBinding.java
@@ -28,7 +28,6 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.types.Command;
-import org.openhab.core.types.State;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 import org.slf4j.Logger;
@@ -173,6 +172,12 @@ public class PlexBinding extends AbstractActiveBinding<PlexBindingProvider> impl
 					connectionProperties.setHost(value);
 				else if ("port".equals(key))
 					connectionProperties.setPort(Integer.valueOf(value));
+				else if ("token".equals(key))
+					connectionProperties.setToken(value);
+				else if ("username".equals(key))
+					connectionProperties.setUsername(value);
+				else if ("password".equals(key))
+					connectionProperties.setPassword(value);
 				else if ("refresh".equals(key))
 					if (StringUtils.isNumeric(value))
 						refreshInterval = Integer.valueOf(value);

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnectionProperties.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnectionProperties.java
@@ -19,6 +19,12 @@ public class PlexConnectionProperties {
 	private String host;
 	
 	private int port = 32400;
+	
+	private String token;
+	
+	private String username;
+	
+	private String password;
 
 	public String getHost() {
 		return host;
@@ -35,4 +41,29 @@ public class PlexConnectionProperties {
 	public void setPort(int port) {
 		this.port = port;
 	}
+
+	public String getToken() {
+		return token;
+	}
+
+	public void setToken(String token) {
+		this.token = token;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+	
 }

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/User.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/User.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.plex.internal.communication;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Holds information for the Plex user account   
+ * 
+ * @author Jeroen Idserda
+ * @since 1.8.0
+ */
+@XmlRootElement(name = "user")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class User {
+	
+	private String username;
+	
+	private String email;
+	
+	@XmlElement(name = "authentication-token")
+	private String authenticationToken;
+	
+	public String getUsername() {
+		return username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	public String getAuthenticationToken() {
+		return authenticationToken;
+	}
+
+	public void setAuthenticationToken(String authenticationToken) {
+		this.authenticationToken = authenticationToken;
+	}
+
+}

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1837,6 +1837,17 @@ tcp:refreshinterval=250
 # Refresh interval in ms. Default = 5000. 
 #plex:refresh=5000
 
+ # If you're using Plex Home you need to supply the username and password of your
+ # Plex account here. If you don't want to enter your credentials you can also
+ # directly set your account token below instead. 
+#plex:username=Plex username
+
+ # Plex password
+#plex:password=Plex password
+
+# Plex account token, use instead of username/password when using Plex Home. 
+#plex:token=abcdefghijklmnopqrst
+
 ############################### Denon Binding #########################################
 #
 # denon:<instance>.<property>=value


### PR DESCRIPTION
If you're using Plex Home the binding needs to know additional credentials to access the Plex server. This fixes #3120.