### PR TITLE
Remove spurious whitespace

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -1387,8 +1387,7 @@
 			<Model>FGD211</Model>
 			<Label lang="en">Universal Dimmer 500W</Label>
 			<ConfigFile VersionMax="1.8">fibaro/fgd211-14.xml</ConfigFile> <!-- VersionMin="1.4" -->
-			<ConfigFile VersionMin="1.9" VersionMax="1.11">fibaro/fgd211-19.xml
-			</ConfigFile>
+			<ConfigFile VersionMin="1.9" VersionMax="1.11">fibaro/fgd211-19.xml</ConfigFile>
 			<ConfigFile VersionMin="2.1">fibaro/fgd211-21.xml</ConfigFile> <!-- VersionMax="2.3" -->
 		</Product>
 		<Product>


### PR DESCRIPTION
Error message in logs is:

2015-09-21 22:10:31.061 [ERROR] [o.b.z.i.c.ZWaveProductDatabase:125 ]- Unable to load ZWave product file: 'fibaro/fgd211-19.xml
                        '