### PR TITLE
Add support for 'On/Off plug-in unit' in hue binding

### DIFF
--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java
@@ -151,9 +151,13 @@ public class HueSettings {
 			logger.error("Hue bridge settings not initialized correctly.");
 			return 0;
 		}
-		return (Integer) settingsData.node("lights")
-				.node(deviceId).node("state")
-				.value("bri");
+		Object bri = settingsData.node("lights").node(deviceId).node("state").value("bri");
+		if(bri instanceof Integer) {
+			return (Integer) bri;
+		} else {
+			//probably not dimmable, return on state
+			return isBulbOn(deviceId)?254:0;
+		}
 	}
 
 	/**


### PR DESCRIPTION
This patch adds support for hue devices that offer only on/off switching, no dimming. They deliver no brightness information so without this change, an exception is thrown. The patch returns 0 or 254 based on the "on" state of the hue device.