### PR TITLE
Add BeNext Power Switch and Door Sensor as supported Z-Wave devices

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/benext/doorsensor.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/benext/doorsensor.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+	<Model>doorSensor</Model>
+	<Label lang="en">BeNext Door Sensor</Label>
+	<CommandClasses>
+		<Class>
+			<id>0x20</id>
+		</Class>		
+		<Class>
+			<id>0x30</id>
+		</Class>
+		<Class>
+			<id>0x31</id>
+		</Class>
+		<Class>
+			<id>0x70</id>
+		</Class>
+		<Class>
+			<id>0x71</id>
+		</Class>
+		<Class>
+			<id>0x72</id>
+		</Class>
+		<Class>
+			<id>0x73</id>
+		</Class>
+		<Class>
+			<id>0x84</id>
+		</Class>
+		<Class>
+			<id>0x85</id>
+		</Class>
+		<Class>
+			<id>0x86</id>
+		</Class>
+	</CommandClasses>
+	<Configuration>
+		<Parameter>
+			<Index>1</Index>
+			<Type>byte</Type>
+			<Minimum>0</Minimum>
+			<Maximum>256</Maximum>
+			<Default>0</Default>
+			<Size>1</Size>
+			<Label lang="en">Reset to factory settings</Label>
+			<Help lang="en">Set all configuration values to default values (factory settings).</Help>
+		</Parameter>
+		<Parameter>
+			<Index>2</Index>
+			<Type>list</Type>
+			<Default>0</Default>
+			<Size>1</Size>
+			<Label lang="en">External contact behavior</Label>
+			<Help lang="en">Configure what the external contact sends when triggered.</Help>
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">Send alarm</Label>
+				<Help lang="en">Send an alarm report with type 2.</Help>				
+			</Item>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">Send basic frame</Label>
+				<Help lang="en">Send a Basic set frame to all nodes in association group 2.</Help>	
+			</Item>			
+		</Parameter>
+		<Parameter>
+			<Index>5</Index>
+			<Type>list</Type>
+			<Default>1</Default>
+			<Size>1</Size>
+			<Label lang="en">Operating mode.</Label>
+			<Help lang="en">The main operating mode for the device.</Help>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">Normal</Label>
+				<Help lang="en">Normal operating mode.</Help>
+			</Item>
+			<Item>
+				<Value>2</Value>
+				<Label lang="en">Mode 1 report</Label>
+				<Help lang="en">If any mode other then 3, that value will be reported after a get but will be handled in SW as mode 1.</Help>
+			</Item>
+			<Item>
+				<Value>3</Value>
+				<Label lang="en">Always-on</Label>
+				<Help lang="en">Z-Wave chip is always on to request e.g. version or manufacturer id.</Help>
+			</Item>
+		</Parameter>
+		<Parameter>
+			<Index>6</Index>
+			<Type>int</Type>
+			<Default>0</Default>
+			<Minimum>-32768</Minimum>
+            <Maximum>32767</Maximum>
+			<Size>2</Size>
+			<Label lang="en">Temperature offset</Label>
+			<Help lang="en">An offset for the temperature.</Help>
+		</Parameter>		
+	</Configuration>
+	<Associations>
+		<Group>
+			<Index>1</Index>
+			<Maximum>5</Maximum>
+			<Label lang="en">Send frame to every node in this group (internal contact)</Label>
+			<Help lang="en">If the internal door contact (magnet) is triggered it sends a Z-Wave frame to every node in this group.</Help>
+			<SetToController>true</SetToController>			
+		</Group>		
+		<Group>
+			<Index>2</Index>
+			<Maximum>5</Maximum>
+			<Label lang="en">Send frame to every node in this group (external contact)</Label>
+			<Help lang="en">If the external door contact is triggered it sends a Z-Wave frame to every node in this group if it is.</Help>
+		</Group>		
+	</Associations>
+</Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/benext/switch.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/benext/switch.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+	<Model>powerSwitch</Model>
+	<Label lang="en">BeNext PowerSwitch EU</Label>
+	<CommandClasses>
+		<Class>
+			<id>0x20</id>
+		</Class>
+		<Class>
+			<id>0x26</id>
+		</Class>
+		<Class>
+			<id>0x27</id>
+		</Class>
+		<Class>
+			<id>0x31</id>
+		</Class>
+		<Class>
+			<id>0x32</id>
+		</Class>
+		<Class>
+			<id>0x70</id>
+		</Class>
+		<Class>
+			<id>0x72</id>
+		</Class>
+		<Class>
+			<id>0x73</id>
+		</Class>
+		<Class>
+			<id>0x85</id>
+		</Class>
+		<Class>
+			<id>0x86</id>
+		</Class>
+	</CommandClasses>
+	<Associations>
+		<Group>
+			<Index>1</Index>
+			<Maximum>1</Maximum>
+			<Label lang="en">Group 1</Label>
+		</Group>		
+	</Associations>
+</Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/benext/switch.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/benext/switch.xml
@@ -39,6 +39,7 @@
 			<Index>1</Index>
 			<Maximum>1</Maximum>
 			<Label lang="en">Group 1</Label>
+			<SetToController>true</SetToController>
 		</Group>		
 	</Associations>
 </Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -2398,13 +2398,22 @@
 		<Name>BeNext</Name>
 		<Product>
 			<Reference>
+				<Type>0008</Type>
+				<Id>0101</Id>
+			</Reference>
+			<Model>powerSwitch</Model>
+			<Label lang="en">BeNext Power Switch EU</Label>
+			<ConfigFile>benext/switch.xml</ConfigFile>
+		</Product>
+		<Product>
+			<Reference>
 				<Type>000d</Type>
 				<Id>0100</Id>
 			</Reference>
 			<Model>builtInDimmer</Model>
 			<Label lang="en">BeNext Built-in Dimmer</Label>
 			<ConfigFile>benext/builtindimmer.xml</ConfigFile>
-		</Product>
+		</Product>		
 		<Product>
 			<Reference>
 				<Type>0018</Type>

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -2398,6 +2398,15 @@
 		<Name>BeNext</Name>
 		<Product>
 			<Reference>
+				<Type>0004</Type>
+				<Id>0101</Id>
+			</Reference>
+			<Model>doorSensor</Model>
+			<Label lang="en">BeNext Door Sensor</Label>
+			<ConfigFile>benext/doorsensor.xml</ConfigFile>
+		</Product>
+		<Product>
+			<Reference>
 				<Type>0008</Type>
 				<Id>0101</Id>
 			</Reference>


### PR DESCRIPTION
Add BeNext Power Switch as supported Z-Wave device, based on http://www.pepper1.net/zwavedb/device/299, but with Product ID 0x0101 instead of Product ID 0x0100