### PR TITLE
InsteonPLM binding: better thermostat support, FAST On/Off, bug fixes and new devices

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.insteonplm/META-INF/MANIFEST.MF
@@ -11,6 +11,13 @@ Bundle-ManifestVersion: 2
 Bundle-Description: This is the Insteon PLM binding of the open Home Automation Bus (openHAB)
 Import-Package: gnu.io,
  org.apache.commons.lang,
+ org.apache.http,
+ org.apache.http.auth,
+ org.apache.http.client,
+ org.apache.http.client.methods,
+ org.apache.http.impl.client,
+ org.apache.http.params;version="4.1.4",
+ org.apache.http.util,
  org.openhab.core.autoupdate,
  org.openhab.core.binding,
  org.openhab.core.events,
@@ -23,15 +30,10 @@ Import-Package: gnu.io,
  org.osgi.service.cm,
  org.osgi.service.component,
  org.osgi.service.event,
- org.slf4j,
- org.apache.http,
- org.apache.http.auth,
- org.apache.http.client,
- org.apache.http.client.methods,
- org.apache.http.impl.client,
- org.apache.http.util
+ org.slf4j
 Export-Package: org.openhab.binding.insteonplm
 Bundle-DocURL: http://www.openhab.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Service-Component: OSGI-INF/activebinding.xml, OSGI-INF/genericbindingprovider.xml
 Bundle-ClassPath: .
+Require-Bundle: org.apache.httpcomponents.httpcore

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/docs/insteoplm_v1.7.md
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/docs/insteoplm_v1.7.md
@@ -1,0 +1,366 @@
+## Introduction
+
+Insteon is a home area networking technology developed primarily for
+connecting light switches and loads. Insteon devices send messages
+either via the power line, or by means of radio frequency (RF) waves,
+or both (dual-band). A considerable number of Insteon compatible
+devices such as switchable relays, thermostats, sensors etc are
+available. More about Insteon can be found on [Wikipedia](http://en.wikipedia.org/wiki/Insteon).
+
+This binding provides access to the Insteon network by means of either an
+Insteon PowerLinc Modem (PLM), a legacy Insteon Hub (pre-2014) or the new 2245-222 ("2014") Insteon Hub.
+The modem can be connected to the openHAB server either via a serial port (Model 2413S) or a USB port
+(Model 2413U). The binding translates openHAB commands into Insteon
+messages and sends them on the Insteon network. Relevant messages from
+the Insteon network (like notifications about switches being toggled)
+are picked up by the modem and converted to openHAB status updates by
+the binding. The binding also supports sending and receiving of legacy X10 messages.
+
+OpenHAB is not a configuration tool! To configure and set up your devices, link the devices manually via the set buttons, or use the free [Insteon Terminal](https://github.com/pfrommerd/insteon-terminal) software.
+
+## Insteon devices
+
+Every Insteon device *type* is uniquely identified by its Insteon
+*product key*, a six digit hex number. For some of the older device
+types (in particular the SwitchLinc switches and dimmers), Insteon
+does not give a product key, so an arbitrary fake one of the format
+Fxx.xx.xx (or Xxx.xx.xx for X10 devices) is assigned by the binding.
+
+Finally, each Insteon device comes with a hard-coded Insteon *address*
+that can be found on a label on the device. This address should be
+recorded for every device in the network, as it is a mandatory part of
+the binding configuration string. X10 devices are addressed with `houseCode.unitCode`, e.g. `A.2`.
+
+The following devices have been tested and should work out of the box:
+<table>
+<tr>
+<td>Model</td><td>Description</td><td>Product Key</td><td>Comments</td><td>tested by</td>
+</tr>
+<tr>
+<td>2477D</td><td>SwitchLinc Dimmer</td><td>F00.00.01</td><td></td><td>Bernd Pfrommer</td>
+</tr>
+<tr>
+<td>2477S</td><td>SwitchLinc Switch</td><td>F00.00.02</td><td></td><td>Bernd Pfrommer</td>
+</tr>
+<tr>
+<td>2845-222</td><td>Hidden Door Sensor</td><td>F00.00.03</td><td>battery level available as #data,field=battery_level</td><td>Josenivaldo Benito</td>
+</tr>
+<tr>
+<td>2876S</td><td>ICON Switch</td><td>F00.00.04</td><td></td><td>Patrick Giasson</td>
+</tr>
+<tr>
+<td>2456D3</td><td>LampLinc V2</td><td>F00.00.05</td><td></td><td>Patrick Giasson</td>
+</tr>
+<tr>
+<td>2442-222</td><td>Micro Dimmer</td><td>F00.00.06</td><td></td><td>Josenivaldo Benito</td>
+</tr>
+<tr>
+<td>2453-222</td><td>DIN Rail On/Off</td><td>F00.00.07</td><td></td><td>Josenivaldo Benito</td>
+</tr>
+<tr>
+<td>2452-222</td><td>DIN Rail Dimmer</td><td>F00.00.08</td><td></td><td>Josenivaldo Benito</td>
+</tr>
+<tr>
+<td>2458-A1</td><td>MorningLinc RF Lock Controller</td><td>F00.00.09</td><td>
+Read the instructions very carefully: Sync with lock within 5 feet to avoid bad connection, link twice for both ON and OFF functionality.
+</td><td>cdeadlock</td>
+</tr>
+<tr>
+<td>2852-222</td><td>Leak Sensor</td><td>F00.00.0A</td><td></td><td>Kirk McCann</td>
+</tr>
+<tr>
+<td>2672-422</td><td>LED Dimmer</td><td>F00.00.0B</td><td></td><td></td>
+</tr>
+<tr>
+<td>2476D</td><td>SwitchLinc Dimmer</td><td>F00.00.0C</td><td></td><td>LiberatorUSA</td>
+</tr>
+<tr>
+<td>2634-222</td><td>On/Off Dual-Band Outdoor Module</td><td>F00.00.0D</td><td></td><td>LiberatorUSA</td>
+</tr>
+<tr>
+<td>2342-2</td><td>Mini Remote</td><td>F00.00.10</td><td></td><td>Bernd Pfrommer</td>
+</tr>
+<tr>
+<td>2466D</td><td>ToggleLinc Dimmer</td><td>F00.00.11</td><td></td><td>Rob Nielsen</td>
+</tr>
+<tr>
+<td>2466S</td><td>ToggleLinc Switch</td><td>F00.00.12</td><td></td><td>Rob Nielsen</td>
+</tr>
+<tr>
+<td>2672-222</td><td>LED Bulb</td><td>F00.00.13</td><td></td><td>Rob Nielsen</td>
+</tr>
+<tr>
+<td>2487S</td><td>KeypadLinc On/Off 6-Button</td><td>F00.00.14</td><td>link scene buttons via modem groups</td><td>Bernd Pfrommer</td>
+</tr>
+<tr>
+<td>2334-232</td><td>KeypadLink Dimmer 6-Button</td><td>F00.00.15</td><td>link scene buttons via modem groups</td><td>Rob Nielsen</td>
+</tr>
+<tr>
+<td>2334-232</td><td>KeypadLink Dimmer 8-Button</td><td>F00.00.16</td><td>link scene button via modem groups</td><td>Rob Nielsen</td>
+</tr>
+<tr>
+<td>2423A1</td><td>iMeter Solo Power Meter</td><td>F00.00.17</td><td></td><td>Rob Nielsen</td>
+</tr>
+<tr>
+<td>2423A1</td><td>Thermostat 2441TH</td><td>F00.00.18</td><td></td><td>Daniel Campbell</td>
+</tr>
+<tr>
+<td>2457D2</td><td>LampLinc Dimmer</td><td>F00.00.19</td><td></td><td>Jonathan Huizingh</td>
+</tr>
+<tr>
+<td>2475SDB</td><td>In-LineLinc Relay</td><td>F00.00.1A</td><td></td><td>Jim Howard</td>
+</tr>
+<tr>
+<td>2635-222</td><td>On/Off Module</td><td>F00.00.1B</td><td></td><td>Jonathan Huizingh</td>
+</tr>
+<tr>
+<td>2450</td><td>IO Link</td><td>0x00001A</td><td></td><td>Bernd Pfrommer</td>
+</tr>
+<tr>
+<td>2486D</td><td>KeypadLinc Dimmer</td><td>0x000037</td><td></td><td>Patrick Giasson, Joe Barnum</td>
+</tr>
+<tr>
+<td>2484DWH8</td><td>KeypadLinc Countdown Timer</td><td>0x000041</td><td></td><td>Rob Nielsen</td>
+</tr>
+<tr>
+<td>2413U</td><td>PowerLinc 2413U USB modem</td><td>0x000045</td><td></td><td>Bernd Pfrommer</td>
+</tr>
+<tr>
+<td>2843-222</td><td>Wireless Open/Close Sensor</td><td>0x000049</td><td></td><td>Josenivaldo Benito</td>
+</tr>
+<tr>
+<td>2842-222</td><td>Motion Sensor</td><td>0x00004A</td><td>battery level available as #data,field=battery_level<br>light level available as #data,field=light_level</td><td>Bernd Pfrommer</td>
+</tr>
+<tr>
+<td>2486DWH8</td><td>KeypadLinc Dimmer</td><td>0x000051</td><td></td><td>Chris Graham</td>
+</tr>
+<tr>
+<td>2472D</td><td>OutletLincDimmer</td><td>0x000068</td><td></td><td>Chris Graham</td>
+</tr>
+<tr>
+<td>X10 switch</td><td>generic X10 switch</td><td>X00.00.01</td><td></td><td>Bernd Pfrommer</td>
+</tr>
+<tr>
+<td>X10 dimmer</td><td>generic X10 dimmer</td><td>X00.00.02</td><td></td><td>Bernd Pfrommer</td>
+</tr>
+<tr>
+<td>X10 motion</td><td>generic X10 motion sensor</td><td>X00.00.03</td><td></td><td>Bernd Pfrommer</td>
+</tr>
+</table>
+
+## Insteon binding process
+
+Before Insteon devices communicate with one another, they must be
+linked. During the linking process, one of the devices
+will be the "Controller", the other the "Responder" (see e.g. the
+[SwitchLinc Instructions](https://www.insteon.com/pdf/2477S.pdf)).
+
+The responder listens to messages from the controller, and reacts to them. Note that except for
+the case of a motion detector (which is just a controller to the
+modem), the modem controls the device (e.g. send on/off messages to
+it), and the device controls the modem (so the modem learns about the
+switch being toggled). For this reason, most devices and in particular
+switches/dimmers should be linked twice, with one taking the role of
+controller during the first linking, and the other acting as
+controller during the second linking process. To do so, first press
+and hold the "Set" button on the modem until the light starts
+blinking. Then press and hold the "Set" button on the remote device,
+e.g. the light switch, until it double beeps (the light on the modem
+should go off as well). Now do exactly the reverse: press and hold the
+"Set" button on the remote device until its light starts blinking,
+then press and hold the "Set" button on the modem until it double
+beeps, and the light of the remote device (switch) goes off. Done.
+
+## Installation and Configuration
+
+The binding does not support linking new devices on the fly, i.e. all
+devices must be linked with the modem *before* starting the InsteonPLM
+binding. Each device has an Insteon address of the format 'xx.xx.xx'
+which can usually be found on a label on the device.
+
+1. Copy the binding (e.g. `openhab.binding.insteonplm-<version>.jar` into the `openhab/addons` folder
+2. Edit the relevant section in the openhab configuration file
+   (`openhab/configurations/openhab.cfg`). Note that while multiple
+   modems and/or hubs can be configured, the binding has never been tested for more
+   than *one* port!
+3. Add configuration information to the `.items` file (see below)
+4. Optional: configure for debug logging into a separate file (see
+trouble shooting section)
+
+## Item Binding Configuration
+
+Since Insteon devices can have multiple features (for instance a
+switchable relay and a contact sensor) under a single Insteon address,
+an openHAB item is not bound to a device, but to a given feature of a
+device:
+
+    insteonplm="<insteon_address>:<product_key>#feature[,<parameter>=value, ...]>"
+
+The following lines in your insteonplm.items file would configure a
+light switch, a dimmer, a motion sensor, and a garage door opener with
+contact sensor, a front door lock, a button of a mini remote, a KeypadLinc 2487, and a 6-button keypad dimmer 2334-232:
+
+    Switch officeLight "office light" {insteonplm="24.02.dc:F00.00.02#switch"}
+    Dimmer kitchenChandelier "kitchen chandelier" {insteonplm="20.c4.43:F00.00.01#dimmer"}
+
+    Contact garageMotionSensor "motion sensor [MAP(contact.map):%s]" {insteonplm="27.8c.c3:0x00004A#contact"}
+    Number garageMotionSensorBatteryLevel "motion sensor battery level [%.1f]" {insteonplm="27.8c.c3:0x00004A#data,field=battery_level"}
+    Number garageMotionSensorLightLevel "motion sensor light level [%.1f]" {insteonplm="27.8c.c3:0x00004A#data,field=light_level"}
+
+    Switch garageDoorOpener "garage door opener" <garagedoor> {insteonplm="28.c3.f1:0x00001A#switch"}
+    Contact garageDoorContact "garage door contact [MAP(contact.map):%s]"    {insteonplm="28.c3.f1:0x00001A#contact"}
+
+    Switch frontDoorLock "Front Door [MAP(lock.map):%s]" {insteonplm="xx.xx.xx:F00.00.09#switch"}
+    Switch miniRemoteContactButton1	    "mini remote button 1" {insteonplm="2e.7c.9a:F00.00.02#buttonA"}
+
+    Switch keypadSwitch    "main load" {insteonplm="xx.xx.xx:F00.00.14#loadswitch"}
+    Switch keypadSwitchButtonA   "keypad switch button A"	{insteonplm="xx.xx.xx:F00.00.14#keypadbuttonA,group=2"}
+
+    Dimmer keypadDimmer "dimmer" {insteonplm="xx.xx.xx:F00.00.15#loaddimmer"}
+    Switch keypadDimmerButtonA    "keypad dimmer button A"	{insteonplm="xx.xx.xx:F00.00.15#keypadbuttonA,group=2"}
+    Dimmer dimmerWithMax "dimmer 2"   {insteonplm="xx.xx.xx:F00.00.11#dimmer,dimmermax=70"}
+
+For the meaning of the ``group`` parameter, please see notes on groups and keypad buttons below.
+Note the use of a `MAP(contact.map)`, which should go into the
+transforms directory and look like this:
+
+    OPEN=open
+    CLOSED=closed
+    -=unknown
+
+'MAP(lock.map)`, which should go into the transforms directory and look like this:
+
+    ON=Lock
+    OFF=Unlock
+    -=unknown
+
+If you have a garage door opener, see the I/O Linc documentation for
+the meaning of the `momentary` keyword (not supported/needed for other devices).
+
+Dimmers can be configured with a maximum level when turning a device on or setting a percentage level. If a maximum level is configured, openHAB will never set the level of the dimmer above the level specified. The below example sets a maximum level of 70% for dim 1 and 60% for dim 2:
+
+    Dimmer d1 "dim 1" {insteonplm="xx.xx.xx:F00.00.11#dimmer,dimmermax=70"}
+    Dimmer d2 "dim 2" {insteonplm="xx.xx.xx:F00.00.15#loaddimmer,dimmermax=60"}
+
+Setting a maximum level does not affect manual turning on or dimming a switch.
+
+When an Insteon device changes its state because it is directly operated (for example by flipping a switch manually), it sends out a broadcast message to announce the state change, and the binding (if the PLM modem is properly linked as a responder) should update the corresponding openHAB items. Other linked devices however may also change their state in response, but those devices will *not* send out a broadcast message, and so openHAB will not learn about their state change until the next poll. One common scenario is e.g. a switch in a 3-way configuration, with one switch controlling the load, and the other switch being linked as a controller. In this scenario, the "related" keyword can be used to cause the binding to poll a related device whenever a state change occurs for another device. A typical example would be two dimmers (A and B) in a 3-way configuration:
+
+    Dimmer A "dimmer 1" {insteonplm="aa.bb.cc:F00.00.01#dimmer,related=dd.ee.ff"}
+    Dimmer B "dimmer 2" {insteonplm="dd.ee.ff:F00.00.01#dimmer,related=aa.bb.cc"}
+
+More than one device can be polled by separating them with "+" sign, e.g. "related=aa.bb.cc+xx.yy.zz" would poll both of these devices.
+
+The iMeter Solo reports both wattage and kilowatt hours, and is updated during the normal polling process of the devices. You can also manually update the current values from the device and reset the device. See the example below:
+ 
+    Number iMeterWatts   "iMeter [%d watts]"  {insteonplm="xx.xx.xx:F00.00.17#meter,field=watts"}
+    Number iMeterKwh     "iMeter [%.04f kwh]" {insteonplm="xx.xx.xx:F00.00.17#meter,field=kwh"}
+    Switch iMeterUpdate  "iMeter Update"      {insteonplm="xx.xx.xx:F00.00.17#meter,cmd=update"}
+    Switch iMeterReset   "iMeter Reset"       {insteonplm="xx.xx.xx:F00.00.17#meter,cmd=reset"}
+
+Here are some examples for configuring X10 devices. Note that X10 switches/dimmers send no status updates, i.e. openHAB will not learn about switches that are toggled manually.
+
+    Switch x10Switch	"X10 switch" {insteonplm="A.1:X00.00.01#switch"}
+    Dimmer x10Dimmer	"X10 dimmer" {insteonplm="A.5:X00.00.02#dimmer"}
+    Contact x10Motion	"X10 motion" {insteonplm="A.3:X00.00.03#contact"}
+
+Here are the recommended item and sitemap configurations for the Insteon Thermostat 2441TH:
+
+**Items**
+
+    Number  FF_Temperature     "Temperature [%d °F]"        { insteonplm="xx.xx.xx:F00.00.18#temperature" }
+    Number  FF_Humidity        "Humidity [%d %%]"           { insteonplm="xx.xx.xx:F00.00.18#humidity" }
+    Number  FF_Cool_SetPoint   "Cool SetPoint [%.1f °F]"    { insteonplm="xx.xx.xx:F00.00.18#coolsetpoint" }
+    Number  FF_Heat_SetPoint   "Heat SetPoint [%.1f °F]"    { insteonplm="xx.xx.xx:F00.00.18#heatsetpoint" }
+    Number  FF_Thermostat_FanMode       "Fan"               { insteonplm="xx.xx.xx:F00.00.18#fancontrol" }
+    Number  FF_Thermostat_OpMode        "Mode"              { insteonplm="xx.xx.xx:F00.00.18#modecontrol" }
+    Number  FF_Thermostat_MasterMode    "Master Mode"       { insteonplm="xx.xx.xx:F00.00.18#mastercontrol" }
+
+**Sitemap**
+
+    Text item=FF_Temperature
+    Text item=FF_Humidity
+    Setpoint item=FF_Cool_SetPoint icon="temperature" minValue=63 maxValue=85 step=1
+    Setpoint item=FF_Heat_SetPoint icon="temperature"
+    Switch item=FF_Thermostat_OpMode label="Mode" mappings=[1="Cool", 2="Heat", 3="Auto"]
+    Switch item=FF_Thermostat_FanMode label="Fan" mappings=[1="Off", 2="On", 3="Auto"]
+    Switch item=FF_Thermostat_MasterMode mappings=[1="FF", 2="SF"]        
+
+## Insteon groups and how to enable buttons on the keypads
+When a button is pressed on a keypad button, a broadcast message is sent out on the Insteon network to all members of a pre-configured group. Let's say you press the keypad button A on a 2487S, it will send out a message to group 3. You first need to configure your modem to be a responder to that group. That can be simply done by pressing the keypad button and then holding the set button (for details see instructions), just as for any Insteon device. After this step, the binding will be notified whenever you press a keypad button, and you can configure a Switch item that will reflect its state. However, if the switch is flipped from within openHAB, the keypad button will not update its state. For that you need to configure the keypad button to be a responder to broadcast messages on a given Insteon group. Use the  [Insteon Terminal](https://github.com/pfrommerd/insteon-terminal) to get the button configured, such that the keypad button responds to modem broadcast messages on e.g modem group 2. Then add the parameter ``group=2`` to the binding config string (see example above). Now toggling the switch item will send out a broadcast message to group 2, which should toggle the keypad button. You need to configure each button into a different modem group to switch them separately.
+
+## Trouble shooting
+
+To get additional debugging information, insert the following into
+your `logback.xml` file:
+
+    <appender name="INSTEONPLMFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/insteonplm.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>logs/insteonplm-%d{yyyy-ww}.log.zip</fileNamePattern>
+        <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{30}[:%line]- %msg%n%ex{5}</pattern>
+        </encoder>
+    </appender>
+    <!-- Change DEBUG->TRACE for even more detailed logging -->
+    <logger name="org.openhab.binding.insteonplm" level="DEBUG" additivity="false">
+    <appender-ref ref="INSTEONPLMFILE" />
+    </logger>
+
+This will log additional debugging messages to a separate file in the
+log directory.
+
+### Adding new device types (using existing device features)
+
+Device types are defined in the file `device_types.xml`, which is inside the InsteonPLM bundle and thus not visible to the user. You can however load your own device_types.xml by referencing it in the openhab.cfg file like so:
+
+    insteonplm:more_devices=/usr/local/openhab/rt/my_own_devices.xml
+
+Where the `my_own_devices.xml` file defines a new device like this:
+
+    <xml>
+     <device productKey="F00.00.XX">
+      <model>2456-D3</model>
+      <description>LampLinc V2</description>
+      <feature name="dimmer">GenericDimmer</feature>
+      <feature name="lastheardfrom">GenericLastTime</feature>
+     </device>
+    </xml>
+
+Finding the Insteon product key can be tricky since Insteon has not updated the product key table (http://www.insteon.com/pdf/insteon_devcats_and_product_keys_20081008.pdf) since 2008. If a web search does not turn up the product key, make one up, starting with "F", like: F00.00.99. Avoid duplicate keys by finding the highest fake product key in the `device_types.xml` file, and incrementing by one.
+
+### Adding new device features
+
+If you can't can't build a new device out of the existing device features (for a complete list see `device_features.xml`) you can add new features by specifying a file (let's call it `my_own_features.xml`) with the "more_devices" option in the `openhab.cfg` file:
+
+    insteonplm:more_features=/usr/local/openhab/rt/my_own_features.xml
+
+  In this file you can define your own features (or even overwrite an existing feature). In the example below a new feature "MyFeature" is defined, which can then be referenced from the `device_types.xml` file (or from `my_own_devices.xml`):
+
+    <xml>
+     <feature name="MyFeature">
+	 <message-dispatcher>DefaultDispatcher</message-dispatcher>
+	 <message-handler cmd="0x03">NoOpMsgHandler</message-handler>
+	 <message-handler cmd="0x06">NoOpMsgHandler</message-handler>
+	 <message-handler cmd="0x11">NoOpMsgHandler</message-handler>
+	 <message-handler cmd="0x13">NoOpMsgHandler</message-handler>
+	 <message-handler cmd="0x19">LightStateSwitchHandler</message-handler>
+	 <command-handler command="OnOffType">IOLincOnOffCommandHandler</command-handler>
+	 <poll-handler>DefaultPollHandler</poll-handler>
+     </feature>
+    </xml>
+
+If you cannot cobble together a suitable device feature out of existing handlers you will have to define new ones by editing the corresponding Java classes in the source tree (see below).
+
+### Adding new handlers (for developers experienced with Eclipse IDE)
+
+If all else fails there are the Java sources, in particular the classes MessageHandler.java (what to do with messages coming in from the Insteon network), PollHandler.java (how to form outbound messages for device polling), and CommandHandler.java (how to translate openhab commands to Insteon network messages). To that end you'll need to become a bonafide openHAB developer, and set up an openHAB Eclipse build environment, following the online instructions. Before you write new handlers have a good look at the existing ones, they are quite flexible and configurable via parameters in `device_features.xml`.
+
+## Known Limitations and Issues
+1. Devices cannot be linked to the modem while the binding is
+running. If new devices are linked, the binding must be restarted.
+2. Setting up Insteon groups and linking devices cannot be done from within openHAB. Use the [Insteon Terminal](https://github.com/pfrommerd/insteon-terminal) for that.
+3. Very rarely during binding startup, a message arrives at the modem while the initial read of the modem
+database happens. Somehow the modem then stops sending the remaining link records and the binding no longer is able to address the missing devices. The fix is to simply restart the binding.

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/DeviceFeature.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/DeviceFeature.java
@@ -67,12 +67,13 @@ public class DeviceFeature {
 	private InsteonDevice				m_device = null;
 	private String						m_name	 = "INVALID_FEATURE_NAME";
 	private boolean						m_isStatus = false;
+	private int							m_directAckTimeout = 6000;
 	private QueryStatus	                m_queryStatus = QueryStatus.NEVER_QUERIED;
 	
 	private MessageHandler				m_defaultMsgHandler = new MessageHandler.DefaultMsgHandler(this);
 	private CommandHandler				m_defaultCommandHandler = new CommandHandler.WarnCommandHandler(this);
 	private PollHandler					m_pollHandler = null;
-	private	 MessageDispatcher			m_dispatcher = null;
+	private	MessageDispatcher			m_dispatcher = null;
 
 	private HashMap<Integer, MessageHandler> m_msgHandlers =
 				new HashMap<Integer, MessageHandler>();
@@ -105,6 +106,7 @@ public class DeviceFeature {
 	public synchronized QueryStatus	getQueryStatus()	{ return m_queryStatus; }
 	public InsteonDevice getDevice() 		{ return m_device; }
 	public boolean		isStatusFeature()	{ return m_isStatus; }
+	public int			getDirectAckTimeout() { return m_directAckTimeout; }
 	public MessageHandler getDefaultMsgHandler() { return m_defaultMsgHandler; }
 	public HashMap<Integer, MessageHandler> getMsgHandlers() {
 		return this.m_msgHandlers;
@@ -123,6 +125,17 @@ public class DeviceFeature {
 	public synchronized void setQueryStatus(QueryStatus status)	{
 		logger.trace("{} set query status to: {}", m_name, status);
 		m_queryStatus = status;
+	}
+	
+	public void setTimeout(String s) {
+		if (s != null && !s.isEmpty()) {
+			try {
+				m_directAckTimeout = Integer.parseInt(s);
+				logger.trace("ack timeout set to {}", m_directAckTimeout);
+			} catch (NumberFormatException e) {
+				logger.error("invalid number for timeout: {}", s);
+			}
+		}
 	}
 
 	/**

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/FeatureTemplate.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/FeatureTemplate.java
@@ -23,8 +23,9 @@ import org.openhab.core.types.Command;
  */
 public class FeatureTemplate {
 	private String	m_name				= null;
+	private String	m_timeout			= null;
 	private boolean m_isStatus			= false;
-	private String	m_dispatcher		= null;
+	private HandlerEntry	m_dispatcher		= null;
 	private HandlerEntry	m_pollHandler		= null;
 	private HandlerEntry	m_defaultMsgHandler	= null;
 	private HandlerEntry	m_defaultCmdHandler	= null;
@@ -35,9 +36,10 @@ public class FeatureTemplate {
 	
 	// simple getters
 	public String getName() { return m_name; }
+	public String getTimeout() { return m_timeout; }
 	public boolean isStatusFeature() { return m_isStatus; }
 	public HandlerEntry getPollHandler() { return m_pollHandler; }
-	public String getDispatcher() { return m_dispatcher; }
+	public HandlerEntry getDispatcher() { return m_dispatcher; }
 	public HandlerEntry getDefaultCommandHandler() { return m_defaultCmdHandler; }
 	public HandlerEntry getDefaultMessageHandler() { return m_defaultMsgHandler; }
 	
@@ -57,7 +59,8 @@ public class FeatureTemplate {
 	// simple setters
 	public void setName(String name) { m_name = name; }
 	public void setStatusFeature(boolean status) { m_isStatus = status; }
-	public void setMessageDispatcher(String dispatcher) { m_dispatcher = dispatcher; }
+	public void setTimeout(String s) { m_timeout = s; }
+	public void setMessageDispatcher(HandlerEntry he) { m_dispatcher = he; }
 	public void setPollHandler(HandlerEntry he) { m_pollHandler = he; }
 	public void setDefaultCommandHandler(HandlerEntry cmd) { m_defaultCmdHandler = cmd; }
 	public void setDefaultMessageHandler(HandlerEntry he) {	m_defaultMsgHandler = he; }
@@ -84,8 +87,9 @@ public class FeatureTemplate {
 	public DeviceFeature build() {
 		DeviceFeature f = new DeviceFeature(m_name);
 		f.setStatusFeature(m_isStatus);
-		
-		if (m_dispatcher != null) f.setMessageDispatcher(MessageDispatcher.s_makeMessageDispatcher(m_dispatcher, f));
+		f.setTimeout(m_timeout);
+		if (m_dispatcher != null) f.setMessageDispatcher(MessageDispatcher.s_makeHandler(m_dispatcher.getName(),
+								m_dispatcher.getParams(), f));
 		if (m_pollHandler != null) f.setPollHandler(PollHandler.s_makeHandler(m_pollHandler, f));
 		if (m_defaultCmdHandler != null) f.setDefaultCommandHandler(CommandHandler.s_makeHandler(m_defaultCmdHandler.getName(),
 								m_defaultCmdHandler.getParams(), f));

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/FeatureTemplateLoader.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/FeatureTemplateLoader.java
@@ -76,7 +76,8 @@ public class FeatureTemplateLoader {
 		FeatureTemplate feature = new FeatureTemplate();
 		feature.setName(name);
 		feature.setStatusFeature(statusFeature);
-		
+		feature.setTimeout(e.getAttribute("timeout"));
+
 		NodeList nodes = e.getChildNodes();
 		
 		for (int i = 0; i < nodes.getLength(); i++) {
@@ -130,10 +131,13 @@ public class FeatureTemplateLoader {
 		}
 	}
 	private static void s_parseMessageDispatcher(Element e, FeatureTemplate f) throws DOMException, ParsingException {
-		String dispatcher = e.getTextContent();
-		if (dispatcher == null) throw new ParsingException("Could not find MessageDispatcher for: " + e.getTextContent());
-		f.setMessageDispatcher(dispatcher);
+		HandlerEntry he = s_makeHandlerEntry(e);
+		f.setMessageDispatcher(he);
+		if (he.getName() == null) throw new ParsingException("Could not find MessageDispatcher for: " + e.getTextContent());
 	}
+		
+
+		
 	private static void s_parsePollHandler(Element e, FeatureTemplate f) throws ParsingException {
 		HandlerEntry he = s_makeHandlerEntry(e);
 		f.setPollHandler(he);
@@ -154,7 +158,7 @@ public class FeatureTemplateLoader {
 		ArrayList<FeatureTemplate> features = s_readTemplates(s);
 		for (FeatureTemplate feature : features) {
 			System.out.println(feature);
-			System.out.println("\tPOLL: " + feature.getPollHandler() + "\n\tDISPATCH: " + feature.getDispatcher());
+			System.out.println("\tPOLL: " + feature.getPollHandler() + "\n\tDISPATCH: " + feature.getDispatcher().getName());
 			System.out.println("\tDCH: " + feature.getDefaultCommandHandler() + "\n\tDMH: " + feature.getDefaultMessageHandler());
 			System.out.println("\tMSG HANDLERS: " + feature.getMessageHandlers().size());
 			System.out.println("\tCMD HANDLERS: " + feature.getCommandHandlers());

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/InsteonDevice.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/InsteonDevice.java
@@ -53,8 +53,6 @@ public class InsteonDevice {
 	private boolean						m_isModem		= false;
 	private	PriorityQueue<QEntry>		m_requestQueue  = new PriorityQueue<QEntry>();
 	private	DeviceFeature				m_featureQueried = null;
-	/** time to wait for reply after direct message */
-	private static final long			TIMEOUT_DIRECT_MESSAGE_REPLY	= 30000;
 	/** need to wait after query to avoid misinterpretation of duplicate replies */
 	private static final int			QUIET_TIME_DIRECT_MESSAGE = 2000;
 	/** how far to space out poll messages */
@@ -191,9 +189,11 @@ public class InsteonDevice {
 			for (DeviceFeature i : m_features.values()) {
 				if (i.hasListeners()) {
 					Msg m = i.makePollMsg();
-					if (m != null) l.add(new QEntry(i, m, now + delay + spacing));
+					if (m != null) {
+						l.add(new QEntry(i, m, now + delay + spacing));
+						spacing += TIME_BETWEEN_POLL_MESSAGES;
+					}
 				}
-				spacing += TIME_BETWEEN_POLL_MESSAGES;
 			}
 		}
 		if (l.isEmpty()) return;
@@ -305,17 +305,52 @@ public class InsteonDevice {
 	 * @throws IOException
 	 */
 	public Msg makeExtendedMessage(byte flags, byte cmd1, byte cmd2)
+				throws FieldException, IOException {
+		return makeExtendedMessage(flags, cmd1, cmd2, new byte[] {});
+	}
+	/**
+	 * Helper method to make extended message
+	 * @param flags
+	 * @param cmd1
+	 * @param cmd2
+	 * @param data array with userdata
+	 * @return extended message
+	 * @throws FieldException
+	 * @throws IOException
+	 */
+	public Msg makeExtendedMessage(byte flags, byte cmd1, byte cmd2, byte[] data)
 			throws FieldException, IOException {
 		Msg m = Msg.s_makeMessage("SendExtendedMessage");
 		m.setAddress("toAddress", getAddress());
 		m.setByte("messageFlags", (byte) (((flags & 0xff) | 0x10) & 0xff));
 		m.setByte("command1", cmd1);
 		m.setByte("command2", cmd2);
-		int checksum = (~(cmd1 + cmd2) + 1) &0xff;
-		m.setByte("userData14", (byte)checksum);
+		m.setUserData(data);
+		m.setCRC();
 		return m;
 	}
-
+	/**
+	 * Helper method to make extended message, but with different CRC calculation
+	 * @param flags
+	 * @param cmd1
+	 * @param cmd2
+	 * @param data array with user data
+	 * @return extended message
+	 * @throws FieldException
+	 * @throws IOException
+	 */
+	public Msg makeExtendedMessageCRC2(byte flags, byte cmd1, byte cmd2, byte[] data)
+			throws FieldException, IOException {
+		Msg m = Msg.s_makeMessage("SendExtendedMessage");
+		m.setAddress("toAddress", getAddress());
+		m.setByte("messageFlags", (byte) (((flags & 0xff) | 0x10) & 0xff));
+		m.setByte("command1", cmd1);
+		m.setByte("command2", cmd2);
+		m.setUserData(data);
+		m.setCRC2();
+		return m;
+	}
+	
 	/**
 	 * Called by the RequestQueueManager when the queue has expired
 	 * @param timeNow
@@ -330,7 +365,7 @@ public class InsteonDevice {
 				// A feature has been queried, but
 				// the response has not been digested yet.
 				// Must wait for the query to be processed.
-				long dt = timeNow - (m_lastQueryTime + TIMEOUT_DIRECT_MESSAGE_REPLY);
+				long dt = timeNow - (m_lastQueryTime + m_featureQueried.getDirectAckTimeout());
 				if (dt < 0) {
 					logger.debug("still waiting for query reply from {} for another {} usec",
 							m_address, -dt);
@@ -457,7 +492,8 @@ public class InsteonDevice {
 		dev.instantiateFeatures(dt);
 		return dev;
 	}
-	
+	 
+
 	/**
 	 * Queue entry helper class
 	 * @author Bernd Pfrommer

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageDispatcher.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageDispatcher.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.insteonplm.internal.device;
 
+import java.util.HashMap;
+
 import org.openhab.binding.insteonplm.internal.message.FieldException;
 import org.openhab.binding.insteonplm.internal.message.Msg;
 import org.openhab.binding.insteonplm.internal.utils.Utils;
@@ -24,6 +26,8 @@ public abstract class MessageDispatcher {
 	private static final Logger logger = LoggerFactory.getLogger(MessageDispatcher.class);
 
 	DeviceFeature m_feature = null;
+	HashMap<String, String> m_parameters = new HashMap<String, String>();
+
 	/**
 	 * Constructor
 	 * @param f DeviceFeature to which this MessageDispatcher belongs
@@ -31,6 +35,8 @@ public abstract class MessageDispatcher {
 	MessageDispatcher(DeviceFeature f) {
 		m_feature = f;
 	}
+	
+	public void setParameters(HashMap<String, String> hm) { m_parameters = hm; }
 	/**
 	 * Generic handling of incoming ALL LINK messages
 	 * @param msg the message received
@@ -59,10 +65,14 @@ public abstract class MessageDispatcher {
 			int group = (msg.isCleanup() ? msg.getByte("command2") : a.getLowByte()) & 0xff;
 			MessageHandler h = m_feature.getMsgHandlers().get(cmd1 & 0xFF);
 			if (h == null) h = m_feature.getDefaultMsgHandler();
-			logger.debug("{}:{}->{} cmd1:{} group {}/{}:{}", m_feature.getDevice().getAddress(), m_feature.getName(),
-						h.getClass().getSimpleName(), Utils.getHexByte(cmd1), group, h.getGroup(), msg);
-			if (h.getGroup() == group) {
-				h.handleMessage(group, cmd1, msg, m_feature, port);
+			logger.debug("all link message: {}", msg);
+			if (!h.isDuplicate(msg)) {
+				logger.debug("all link message is no duplicate: {}/{}", h.matchesGroup(group), h.matches(msg));
+				if (h.matchesGroup(group) && h.matches(msg)) {
+					logger.debug("{}:{}->{} cmd1:{} group {}/{}:{}", m_feature.getDevice().getAddress(), m_feature.getName(),
+							h.getClass().getSimpleName(), Utils.getHexByte(cmd1), group, h.getGroup(), msg);
+					h.handleMessage(group, cmd1, msg, m_feature, port);
+				}
 			}
 		} catch (FieldException e) {
 			logger.error("couldn't parse ALL_LINK message: {}", msg, e);
@@ -93,7 +103,7 @@ public abstract class MessageDispatcher {
 	//
 	//
 	
-	private static class DefaultDispatcher extends MessageDispatcher {
+	public static class DefaultDispatcher extends MessageDispatcher {
 		DefaultDispatcher(DeviceFeature f) { super(f); }
 		@Override
 		public boolean dispatch(Msg msg, String port) {
@@ -120,9 +130,9 @@ public abstract class MessageDispatcher {
 				// in the case of direct ack, the cmd1 code is useless.
 				// you have to know what message was sent before to
 				// interpret the reply message
-				logger.debug("defdisp: {}:{} qs:{} cmd: {}", m_feature.getDevice().getAddress(), m_feature.getName(),
-						m_feature.getQueryStatus(), cmd);
 				if (isMyDirectAck(msg)) {
+					logger.debug("{}:{} DIRECT_ACK: q:{} cmd: {}", m_feature.getDevice().getAddress(), m_feature.getName(),
+							m_feature.getQueryStatus(), cmd);
 					isConsumed = true;
 					if (cmd == 0x50) {
 						// must be a reply to our message, tweak the cmd1 code!
@@ -136,9 +146,13 @@ public abstract class MessageDispatcher {
 			if (key != -1 || m_feature.isStatusFeature()) {
 				MessageHandler h = m_feature.getMsgHandlers().get(key);
 				if (h == null) h = m_feature.getDefaultMsgHandler();
-				logger.debug("{}:{}->{} DIRECT: {}", m_feature.getDevice().getAddress(), m_feature.getName(),
-						h.getClass().getSimpleName(), msg);
-				h.handleMessage(-1, cmd1, msg, m_feature, port);
+				if (h.matches(msg)) {
+					if (!isConsumed) {
+						logger.debug("{}:{}->{} DIRECT", m_feature.getDevice().getAddress(), m_feature.getName(),
+								h.getClass().getSimpleName());
+					}
+					h.handleMessage(-1, cmd1, msg, m_feature, port);
+				}
 			}
 			if (isConsumed) {
 				m_feature.setQueryStatus(DeviceFeature.QueryStatus.QUERY_ANSWERED);
@@ -149,7 +163,7 @@ public abstract class MessageDispatcher {
 		}
 	}
 
-	private static class DefaultGroupDispatcher extends MessageDispatcher {
+	public static class DefaultGroupDispatcher extends MessageDispatcher {
 		DefaultGroupDispatcher(DeviceFeature f) { super(f); }
 		@Override
 		public boolean dispatch(Msg msg, String port) {
@@ -176,9 +190,9 @@ public abstract class MessageDispatcher {
 				// in the case of direct ack, the cmd1 code is useless.
 				// you have to know what message was sent before to
 				// interpret the reply message
-				logger.debug("defdisp: {}:{} qs:{} cmd: {}", m_feature.getDevice().getAddress(), m_feature.getName(),
-						m_feature.getQueryStatus(), cmd);
 				if (isMyDirectAck(msg)) {
+					logger.debug("{}:{} qs:{} cmd: {}", m_feature.getDevice().getAddress(), m_feature.getName(),
+							m_feature.getQueryStatus(), cmd);
 					isConsumed = true;
 					if (cmd == 0x50) {
 						// must be a reply to our message, tweak the cmd1 code!
@@ -193,23 +207,50 @@ public abstract class MessageDispatcher {
 				for (DeviceFeature f : m_feature.getConnectedFeatures()) {
 					MessageHandler h = f.getMsgHandlers().get(key);
 					if (h == null) h = f.getDefaultMsgHandler();
-					logger.debug("{}:{}->{} DIRECT: {}", f.getDevice().getAddress(), f.getName(),
-							h.getClass().getSimpleName(), msg);
-					h.handleMessage(-1, cmd1, msg, f, port);
+					if (h.matches(msg)) {
+						if (!isConsumed) {
+							logger.debug("{}:{}->{} DIRECT", f.getDevice().getAddress(), f.getName(),
+									h.getClass().getSimpleName());
+						}
+						h.handleMessage(-1, cmd1, msg, f, port);
+					}
 					
 				}
 			}
 			if (isConsumed) {
 				m_feature.setQueryStatus(DeviceFeature.QueryStatus.QUERY_ANSWERED);
-				logger.debug("defdisp: {}:{} set status to: {}", m_feature.getDevice().getAddress(), m_feature.getName(),
-						m_feature.getQueryStatus());
+				logger.debug("{}:{} set status to: {}", m_feature.getDevice().getAddress(), m_feature.getName(),
+							m_feature.getQueryStatus());
 			}
 			return isConsumed;
 		}
 	}
 
+	public static class PollGroupDispatcher extends MessageDispatcher {
+		PollGroupDispatcher(DeviceFeature f) { super(f); }
+		@Override
+		public boolean dispatch(Msg msg, String port) {
+			if (msg.isAllLinkCleanupAckOrNack()) {
+				// Had cases when a KeypadLinc would send an ALL_LINK_CLEANUP_ACK
+				// in response to a direct status query message
+				return false; 
+			}
+			if (handleAllLinkMessage(msg, port)) {
+				return false;
+			}
+			if (msg.isAckOfDirect()) {
+				boolean isMyAck = isMyDirectAck(msg);
+				if (isMyAck) {
+					logger.debug("{}:{} got poll ACK", m_feature.getDevice().getAddress(), m_feature.getName());
+				}
+				return (isMyAck);
+			}
+			return (false); // not a direct ack, so we didn't consume it either
+		}
+	}
+
 	
-	private static class SimpleDispatcher extends MessageDispatcher {
+	public static class SimpleDispatcher extends MessageDispatcher {
 		SimpleDispatcher(DeviceFeature f) { super(f); }
 		@Override
 		public boolean dispatch(Msg msg, String port) {
@@ -232,14 +273,16 @@ public abstract class MessageDispatcher {
 			int key = (cmd1 & 0xFF);
 			MessageHandler h = m_feature.getMsgHandlers().get(key);
 			if (h == null) h = m_feature.getDefaultMsgHandler();
-			logger.trace("{}:{}->{} {}", m_feature.getDevice().getAddress(), m_feature.getName(),
-					h.getClass().getSimpleName(), msg);
-			h.handleMessage(-1, cmd1, msg, m_feature, port);
+			if (h.matches(msg)) {
+				logger.trace("{}:{}->{} {}", m_feature.getDevice().getAddress(), m_feature.getName(),
+						h.getClass().getSimpleName(), msg);
+				h.handleMessage(-1, cmd1, msg, m_feature, port);
+			}
 			return isConsumed;
 		}
 	}
 
-	private static class X10Dispatcher extends MessageDispatcher {
+	public static class X10Dispatcher extends MessageDispatcher {
 		X10Dispatcher(DeviceFeature f) { super(f); }
 		@Override
 		public boolean dispatch(Msg msg, String port) {
@@ -250,7 +293,9 @@ public abstract class MessageDispatcher {
 				if (h == null) h = m_feature.getDefaultMsgHandler();
 				logger.debug("{}:{}->{} {}", m_feature.getDevice().getAddress(), m_feature.getName(),
 								h.getClass().getSimpleName(), msg);
-						h.handleMessage(-1, (byte)cmd, msg, m_feature, port);
+				if (h.matches(msg)) {
+					h.handleMessage(-1, (byte)cmd, msg, m_feature, port);
+				}
 			} catch (FieldException e) {
 				logger.error("error parsing {}: ", msg, e);
 			}
@@ -258,34 +303,49 @@ public abstract class MessageDispatcher {
 		}
 	}
 
-	private static class PassThroughDispatcher extends MessageDispatcher {
+	public static class PassThroughDispatcher extends MessageDispatcher {
 		PassThroughDispatcher(DeviceFeature f) { super(f); }
 		@Override
 		public boolean dispatch(Msg msg, String port) {
 			MessageHandler h = m_feature.getDefaultMsgHandler();
-			logger.trace("{}:{}->{} {}", m_feature.getDevice().getAddress(), m_feature.getName(),
-					h.getClass().getSimpleName(), msg);
-			h.handleMessage(-1, (byte)0x01, msg, m_feature, port);
+			if (h.matches(msg)) {
+				logger.trace("{}:{}->{} {}", m_feature.getDevice().getAddress(), m_feature.getName(),
+						h.getClass().getSimpleName(), msg);
+				h.handleMessage(-1, (byte)0x01, msg, m_feature, port);
+			}
 			return false;
 		}
 	}
-
 	/**
-	 * Factory method for creating device dispatchers given a name.
-	 * The name is usually the class name.
-	 * @param name the name of the dispatcher to create
-	 * @param f the feature for which to create the dispatcher
-	 * @return the dispatcher which was created
+	 * Drop all incoming messages silently
 	 */
-	public static MessageDispatcher s_makeMessageDispatcher(String name, DeviceFeature f) {
-		if (name.equals("PassThroughDispatcher")) return new PassThroughDispatcher(f);
-		else if (name.equals("DefaultDispatcher")) return new DefaultDispatcher(f);
-		else if (name.equals("DefaultGroupDispatcher")) return new DefaultGroupDispatcher(f);
-		else if (name.equals("SimpleDispatcher")) return new SimpleDispatcher(f);
-		else if (name.equals("X10Dispatcher")) return new X10Dispatcher(f);
-		else {
-			logger.error("unimplemented message dispatcher requested: {}", name);
-			return null;
+	public static class NoOpDispatcher extends MessageDispatcher {
+		NoOpDispatcher(DeviceFeature f) { super(f); }
+		@Override
+		public boolean dispatch(Msg msg, String port) {
+			return false;
 		}
+	}
+	
+	/**
+	 * Factory method for creating a dispatcher of a given name using java reflection
+	 * @param name the name of the dispatcher to create
+	 * @param params 
+	 * @param f the feature for which to create the dispatcher
+	 * @return the handler which was created
+	 */
+	public static <T extends MessageDispatcher> T s_makeHandler(String name, HashMap<String, String> params, DeviceFeature f) {
+		String cname = MessageDispatcher.class.getName() + "$" + name;
+		try {
+			Class<?> c = Class.forName(cname);
+			@SuppressWarnings("unchecked")
+			Class<? extends T> dc = (Class <? extends T>) c;
+			T ch = dc.getDeclaredConstructor(DeviceFeature.class).newInstance(f);
+			ch.setParameters(params);
+			return ch;
+		} catch (Exception e) {
+			logger.error("error trying to create dispatcher: {}", name, e);
+		}
+		return null;
 	}
 }

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
@@ -81,6 +81,15 @@ public abstract class MessageHandler {
 		}
 	}
 	/**
+	 * Check if group matches
+	 * @param group group to test for
+	 * @return true if group matches or no group is specified
+	 */
+	public boolean  matchesGroup(int group) {
+		int g = getIntParameter("group", -1);
+		return (g == -1 || g == group);
+	}
+	/**
 	 * Retrieve group parameter or -1 if no group is specified
 	 * @return group parameter
 	 */
@@ -94,15 +103,42 @@ public abstract class MessageHandler {
 	 * @return value of int parameter (or default if not found)
 	 */
 	protected int getIntParameter(String key, int def) {
+		String val = m_parameters.get(key);
+		if (val == null) return (def); // param not found
+		int ret = def;
+		try {
+			ret = Utils.strToInt(val);
+		} catch (NumberFormatException e) {
+			logger.error("malformed int parameter in message handler: {}", key);
+		}
+		return ret;
+	}
+	/**
+	 * Helper function to get a String parameter for the handler
+	 * @param key name of the String parameter (as specified in device features!)
+	 * @param def default to return if parameter not found
+	 * @return value of parameter (or default if not found)
+	 */
+	protected String getStringParameter(String key, String def) {
+		return (m_parameters.get(key) == null ? def : m_parameters.get(key));
+	}
+	/**
+	 * Helper function to get a double parameter for the handler
+	 * @param key name of the parameter (as specified in device features!)
+	 * @param def default to return if parameter not found
+	 * @return value of parameter (or default if not found)
+	 */
+	protected double getDoubleParameter(String key, double def) {
 		try {
 			if (m_parameters.get(key) != null) {
-				return Integer.parseInt(m_parameters.get(key));
+				return Double.parseDouble(m_parameters.get(key));
 			}
 		} catch (NumberFormatException e) {
 			logger.error("malformed int parameter in message handler: {}", key);
 		}
 		return def;
 	}
+	
 	/**
 	 * Test if message refers to the button configured for given feature
 	 * @param msg received message
@@ -119,6 +155,51 @@ public abstract class MessageHandler {
 		int button = getButtonInfo(msg, f);
 		return button != -1 && myButton == button;
 	}
+			
+	/**
+	 * Test if parameter matches value
+	 * @param param name of parameter to match
+	 * @param msg message to search
+	 * @param field field name to match
+	 * @return true if parameter matches
+	 * @throws FieldException if field not there
+	 */
+	protected boolean testMatch(String param, Msg msg, String field) throws FieldException {
+		int mp = getIntParameter(param, -1);
+		// parameter not filtered for, declare this a match!
+		if (mp == -1) return (true);
+		byte value = msg.getByte(field);
+		return ((int)value == mp);
+	}
+
+	/**
+	 * Test if message matches the filter parameters
+	 * @param msg message to be tested against
+	 * @return true if message matches
+	 */
+	public boolean matches(Msg msg) {
+		try {
+			int ext = getIntParameter("ext", -1);
+			if (ext != -1) {
+				if ((msg.isExtended() && ext != 1) ||
+						(!msg.isExtended() && ext != 0)) {
+					return (false);
+				}
+				if (!testMatch("match_cmd1", msg, "command1")) {
+					return (false);
+				}
+			}
+			if (!testMatch("match_cmd2", msg, "command2")) return (false);
+			if (!testMatch("match_d1", msg, "userData1")) return (false);
+			if (!testMatch("match_d2", msg, "userData2")) return (false);
+			if (!testMatch("match_d3", msg, "userData3")) return (false);
+		} catch (FieldException e) {
+			logger.error("error matching message: {}", msg, e);
+			return (false);
+		}
+		return (true);
+	}
+
 	/**
 	 * Determines is an incoming ALL LINK message is a duplicate
 	 * @param msg the received ALL LINK message
@@ -166,7 +247,7 @@ public abstract class MessageHandler {
 			m = new GroupMessageStateMachine();
 			m_groupState.put(new Integer(group), m);
 		}
-		logger.debug("updating group state for {} to {}", group, a);
+		logger.trace("updating group state for {} to {}", group, a);
 		return (m.action(a, hops));
 	}
 	
@@ -227,7 +308,7 @@ public abstract class MessageHandler {
 		@Override
 		public void handleMessage(int group, byte cmd1, Msg msg,
 				DeviceFeature f, String fromPort) {
-			logger.debug("{} ignore msg {}: {}", nm(), Utils.getHexByte(cmd1), msg);
+			logger.trace("{} ignore msg {}: {}", nm(), Utils.getHexByte(cmd1), msg);
 		}
 	}
 
@@ -236,14 +317,16 @@ public abstract class MessageHandler {
 		@Override
 		public void handleMessage(int group, byte cmd1, Msg msg,
 				DeviceFeature f, String fromPort) {
-			if (isDuplicate(msg) || !isMybutton(msg, f)) {
+			if (!isMybutton(msg, f)) {
 				return;
 			}
 			InsteonAddress a = f.getDevice().getAddress();
 			if (msg.isAckOfDirect()) {
 				logger.error("{}: device {}: ignoring ack of direct.", nm(), a);
 			} else {
-				logger.info("{}: device {} was turned on. Sending poll request to get actual level", nm(), a);
+				String mode = getStringParameter("mode", "REGULAR");
+				logger.info("{}: device {} was turned on {}. " +
+						"Sending poll request to get actual level", nm(), a, mode);
 				m_feature.publish(PercentType.HUNDRED, StateChangeType.ALWAYS);
 				// need to poll to find out what level the dimmer is at now.
 				// it may not be at 100% because dimmers can be configured
@@ -254,30 +337,32 @@ public abstract class MessageHandler {
 		}
 	}
 
-	public static class LightOnSwitchHandler extends MessageHandler {
-		LightOnSwitchHandler(DeviceFeature p) { super(p); }
-		@Override
-		public void handleMessage(int group, byte cmd1, Msg msg,
-				DeviceFeature f, String fromPort) {
-			if (!isDuplicate(msg) && isMybutton(msg, f)) {
-				logger.info("{}: device {} was switched on.", nm(),
-								f.getDevice().getAddress());
-				f.publish(OnOffType.ON, StateChangeType.ALWAYS);
-			} else {
-				logger.debug("ignored message: {} or {}", isDuplicate(msg), isMybutton(msg,f));
-			}
-		}
-	}
-
 	public static class LightOffDimmerHandler extends MessageHandler {
 		LightOffDimmerHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(int group, byte cmd1, Msg msg,
 				DeviceFeature f, String fromPort) {
-			if (!isDuplicate(msg) && isMybutton(msg, f)) {
-				logger.info("{}: device {} was turned off.", nm(),
-						f.getDevice().getAddress());
+			if (isMybutton(msg, f)) {
+				String mode = getStringParameter("mode", "REGULAR");
+				logger.info("{}: device {} was turned off {}.", nm(),
+						f.getDevice().getAddress(), mode);
 				f.publish(PercentType.ZERO, StateChangeType.ALWAYS);
+			}
+		}
+	}
+
+	public static class LightOnSwitchHandler extends MessageHandler {
+		LightOnSwitchHandler(DeviceFeature p) { super(p); }
+		@Override
+		public void handleMessage(int group, byte cmd1, Msg msg,
+				DeviceFeature f, String fromPort) {
+			if (isMybutton(msg, f)) {
+				String mode = getStringParameter("mode", "REGULAR");
+				logger.info("{}: device {} was switched on {}.", nm(),
+								f.getDevice().getAddress(), mode);
+				f.publish(OnOffType.ON, StateChangeType.ALWAYS);
+			} else {
+				logger.debug("ignored message: {}", isMybutton(msg,f));
 			}
 		}
 	}
@@ -287,9 +372,10 @@ public abstract class MessageHandler {
 		@Override
 		public void handleMessage(int group, byte cmd1, Msg msg,
 				DeviceFeature f, String fromPort) {
-			if (!isDuplicate(msg) && isMybutton(msg, f)) {
-				logger.info("{}: device {} was switched off.", nm(),
-						f.getDevice().getAddress());
+			if (isMybutton(msg, f)) {
+				String mode = getStringParameter("mode", "REGULAR");
+				logger.info("{}: device {} was switched off {}.", nm(),
+						f.getDevice().getAddress(), mode);
 				f.publish(OnOffType.OFF, StateChangeType.ALWAYS);
 			}
 		}
@@ -399,13 +485,41 @@ public abstract class MessageHandler {
 		}
 	}
 
-	public static class StopManualChangeHandler extends MessageHandler {
-		StopManualChangeHandler(DeviceFeature p) { super(p); }
+	public static class DimmerStopManualChangeHandler extends MessageHandler {
+		DimmerStopManualChangeHandler(DeviceFeature p) { super(p); }
 		@Override
 		public void handleMessage(int group, byte cmd1, Msg msg,
 				DeviceFeature f, String fromPort) {
 			Msg m = f.makePollMsg();
 			if (m != null)	f.getDevice().enqueueMessage(m, f);
+		}
+	}
+
+	public static class StartManualChangeHandler extends MessageHandler {
+		StartManualChangeHandler(DeviceFeature p) { super(p); }
+		@Override
+		public void handleMessage(int group, byte cmd1, Msg msg,
+				DeviceFeature f, String fromPort) {
+			try {
+				int cmd2	= (int) (msg.getByte("command2") & 0xff);
+				int upDown	= (cmd2 == 0) ? 0 : 2;
+				logger.info("{}: dev {} manual state change: {}", nm(),
+						f.getDevice().getAddress(), (upDown  == 0) ? "DOWN" : "UP");
+				m_feature.publish(new DecimalType(upDown), StateChangeType.ALWAYS);
+			} catch (FieldException e) {
+				logger.error("{} error parsing {}: ", nm(), msg, e);
+			}
+		}
+	}
+	public static class StopManualChangeHandler extends MessageHandler {
+		StopManualChangeHandler(DeviceFeature p) { super(p); }
+		@Override
+		public void handleMessage(int group, byte cmd1, Msg msg,
+				DeviceFeature f, String fromPort) {
+			logger.info("{}: dev {} manual state change: {}", nm(),
+					f.getDevice().getAddress(), 0);
+			m_feature.publish(new DecimalType(1), StateChangeType.ALWAYS);
+
 		}
 	}
 
@@ -643,6 +757,7 @@ public abstract class MessageHandler {
 		}
 	}
 
+
 	public static class OpenedSleepingContactHandler extends MessageHandler {
 		OpenedSleepingContactHandler(DeviceFeature p) { super(p); }
 		@Override
@@ -652,6 +767,138 @@ public abstract class MessageHandler {
 			sendExtendedQuery(f, (byte)0x2e, (byte) 00);
 		}
 	}
+
+	/**
+	 * Triggers a poll when a message comes in. Use this handler to react
+	 * to messages that notify of a status update, but don't carry the information
+	 * that you are interested in. Example: you send a command to change a setting,
+	 * get a DIRECT ack back, but the ack does not have the value of the updated setting.
+	 * Then connect this handler to the ACK, such that the device will be polled, and
+	 * the settings updated.
+	 */
+	public static class TriggerPollMsgHandler extends MessageHandler {
+		TriggerPollMsgHandler(DeviceFeature p) { super(p); }
+		@Override
+		public void handleMessage(int group, byte cmd1, Msg msg,
+				DeviceFeature f, String fromPort) {
+			m_feature.getDevice().doPoll(2000); // 2000 ms delay
+		}
+	}
+
+	/**
+	 * Flexible handler to extract numerical data from messages.
+	 */
+	public static class NumberMsgHandler extends MessageHandler {
+		NumberMsgHandler(DeviceFeature p) { super(p); }
+		@Override
+		public void handleMessage(int group, byte cmd1, Msg msg,
+				DeviceFeature f, String fromPort) {
+			try {
+				// first do the bit manipulations to focus on the right area
+				int mask = getIntParameter("mask", 0xFFFF);
+				int rawValue = extractValue(msg);
+				int cooked = (rawValue & mask) >> getIntParameter("rshift", 0);
+				// now do an arbitrary transform on the data
+				double value = (double)transform(cooked);
+				// last, multiply with factor and add an offset
+				double dvalue = getDoubleParameter("offset", 0) +  value * getDoubleParameter("factor", 1.0);
+				m_feature.publish(new DecimalType(dvalue), StateChangeType.CHANGED);
+			} catch (FieldException e) {
+				logger.error("error parsing {}: ", msg, e);
+			}
+		}
+		public int transform(int raw) {
+			return (raw);
+		}
+		private int extractValue(Msg msg) throws FieldException {
+			String lowByte = getStringParameter("low_byte", "");
+			if (lowByte == "") {
+				logger.error("{} handler misconfigured, missing low_byte!", nm());
+				return 0;
+			}
+			
+			int value = (int) (msg.getByte(lowByte) & 0xFF);
+			String highByte = getStringParameter("high_byte", "");
+			if (highByte != "") {
+				value |= ((int) (msg.getByte(highByte) & 0xFF)) << 8;
+			}
+			return (value);
+		}
+	}
+
+	/**
+	 * Convert system mode field to number 0...4. Insteon has two different
+	 * conventions for numbering, we use the one of the status update messages
+	 */
+	public static class ThermostatSystemModeMsgHandler extends NumberMsgHandler {
+		ThermostatSystemModeMsgHandler(DeviceFeature p) { super(p); }
+		@Override
+		public int transform(int raw) {
+			switch (raw) {
+			case 0: return (0);	// off
+			case 1: return (3);	// auto
+			case 2:	return (1);	// heat
+			case 3:	return (2);	// cool
+			case 4:	return (4);	// program
+			default: break;
+			}
+			return (4); // when in doubt assume to be in "program" mode 
+		}
+	}
+
+	/**
+	 * Handle reply to system mode change command
+	 */
+	public static class ThermostatSystemModeReplyHandler extends NumberMsgHandler {
+		ThermostatSystemModeReplyHandler(DeviceFeature p) { super(p); }
+		@Override
+		public int transform(int raw) {
+			switch (raw) {
+			case 0x09:	return (0);	// off
+			case 0x04:	return (1);	// heat
+			case 0x05:	return (2);	// cool
+			case 0x06:	return (3);	// auto
+			case 0x0A:	return (4);	// program
+			default: break;
+			}
+			return (4); // when in doubt assume to be in "program" mode 
+		}
+	}
+	/**
+	 * Handle reply to fan mode change command
+	 */
+	public static class ThermostatFanModeReplyHandler extends NumberMsgHandler {
+		ThermostatFanModeReplyHandler(DeviceFeature p) { super(p); }
+		@Override
+		public int transform(int raw) {
+			switch (raw) {
+			case 0x08:	return (0);	// auto
+			case 0x07:	return (1);	// always on
+			default: break;
+			}
+			return (0); // when in doubt assume to be auto mode 
+		}
+	}
+
+	/**
+	 * Handle reply to fanlinc fan speed change command
+	 */
+	public static class FanLincFanReplyHandler extends NumberMsgHandler {
+		FanLincFanReplyHandler(DeviceFeature p) { super(p); }
+		@Override
+		public int transform(int raw) {
+			switch (raw) {
+			case 0x00:	return (0);	// off
+			case 0x55:	return (1);	// low
+			case 0xAA:	return (2);	// medium
+			case 0xFF:	return (3);	// high
+			default:
+				logger.warn("fanlinc got unexpected level: {}", raw);
+			}
+			return (0); // when in doubt assume to be off 
+		}
+	}
+	
 	/**
 	 * Process X10 messages that are generated when another controller
 	 * changes the state of an X10 device.
@@ -712,253 +959,6 @@ public abstract class MessageHandler {
 			InsteonAddress a = f.getDevice().getAddress();
 			logger.info("{}: set X10 device {} to CLOSED", nm(), a);
 			m_feature.publish(OpenClosedType.CLOSED, StateChangeType.ALWAYS);
-		}
-	}
-
-	/**
-	 * Handles Thermostat replies to Set Cool SetPoint requests.
-	 */
-	public static class ThermostatSetPointMsgHandler extends  MessageHandler {
-		ThermostatSetPointMsgHandler(DeviceFeature p) { super(p); }
-		@Override
-		public void handleMessage(int group, byte cmd1, Msg msg,
-				DeviceFeature f, String fromPort) {
-			InsteonDevice dev = f.getDevice();
-			try {
-				if (msg.isExtended()) {
-					logger.info("{}: received msg for feature {}", nm(), f.getName());
-					int level = ((f.getName()).equals("ThermostatCoolSetPoint")) ? (int)(msg.getByte("userData7") & 0xff) : (int)(msg.getByte("userData8") & 0xff);
-					logger.info("{}: got SetPoint from {} of value: {}", nm(), dev.getAddress(), level);
-					f.publish(new DecimalType(level), StateChangeType.CHANGED);
-				} else {
-					logger.info("{}: received msg for feature {}", nm(), f.getName());
-					int cmd2 = (int) (msg.getByte("command2") & 0xff);
-					int level = cmd2/2;
-					logger.info("{}: got SETPOINT from {} of value: {}", nm(), dev.getAddress(), level);
-					f.publish(new DecimalType(level), StateChangeType.CHANGED);
-				}
-			} catch (FieldException e) {
-				logger.debug("{} no cmd2 found, dropping msg {}", nm(), msg);
-				return;
-			}
-		}
-	}
-
-	/**
-	 * Handles Thermostat replies to Temperature requests.
-	 */
-	public static class ThermostatTemperatureRequestReplyHandler extends  MessageHandler {
-		ThermostatTemperatureRequestReplyHandler(DeviceFeature p) { super(p); }
-		@Override
-		public void handleMessage(int group, byte cmd1, Msg msg,
-				DeviceFeature f, String fromPort) {
-			InsteonDevice dev = f.getDevice();
-			try {
-				int cmd1Msg = (int) (msg.getByte("command1") & 0xff);
-				if (cmd1Msg != 0x6a) {
-					logger.warn("{}: ignoring bad TEMPERATURE reply from {}", nm(), dev.getAddress());
-					return;
-				}
-				int cmd2 = (int) (msg.getByte("command2") & 0xff);
-				int level = cmd2/2;
-				logger.info("{}: got TEMPERATURE from {} of value: {}", nm(), dev.getAddress(), level);
-				logger.info("{}: set device {} to level {}", nm(), dev.getAddress(), level);
-				f.publish(new DecimalType(level), StateChangeType.CHANGED);
-			} catch (FieldException e) {
-				logger.debug("{} no cmd2 found, dropping msg {}", nm(), msg);
-				return;
-			}
-		}
-	}	
-		
-	/**
-	 * Handles Thermostat replies to Humidity requests.
-	 */
-	public static class ThermostatHumidityRequestReplyHandler extends  MessageHandler {
-		ThermostatHumidityRequestReplyHandler(DeviceFeature p) { super(p); }
-		@Override
-		public void handleMessage(int group, byte cmd1, Msg msg,
-				DeviceFeature f, String fromPort) {
-			InsteonDevice dev = f.getDevice();
-			try {
-				int cmd1Msg = (int) (msg.getByte("command1") & 0xff);
-				if (cmd1Msg != 0x6a) {
-					logger.warn("{}: ignoring bad HUMIDITY reply from {}", nm(), dev.getAddress());
-					return;
-				}
-				int cmd2 = (int) msg.getByte("command2");
-				logger.info("{}: got HUMIDITY from {} of value: {}", nm(), dev.getAddress(), cmd2);
-				logger.info("{}: set device {} to level {}", nm(), dev.getAddress(), cmd2);
-				f.publish(new PercentType(cmd2), StateChangeType.CHANGED);
-			} catch (FieldException e) {
-				logger.debug("{} no cmd2 found, dropping msg {}", nm(), msg);
-				return;
-			}
-		}
-	}
-	
-	/**
-	 * Handles Thermostat replies to Mode requests.
-	 */
-	public static class ThermostatModeControlReplyHandler extends  MessageHandler {
-		ThermostatModeControlReplyHandler(DeviceFeature p) { super(p); }
-		@Override
-		public void handleMessage(int group, byte cmd1, Msg msg,
-				DeviceFeature f, String fromPort) {
-			InsteonDevice dev = f.getDevice();
-			try {
-				/**
-				* Cmd2 Description 										Thermostat Support 	Comments
-				* 0x04 set mode to heat and returns 04 in ACK 			yes 				On Heat
-				* 0x05 set mode to cool and returns 05 in ACK 			yes 				On Cool
-				* 0x06 set mode to manual auto and returns 06 in ACK 	yes 				Manual Auto
-				*/
-				byte cmd2 = msg.getByte("command2");
-				switch (cmd2) {
-				case 0x04:
-					logger.info("{}: set device {} to {}", nm(),
-							dev.getAddress(), "HEAT");
-					f.publish(new DecimalType(2), StateChangeType.CHANGED);
-					break;
-				case 0x05:
-					logger.info("{}: set device {} to {}", nm(),
-							dev.getAddress(), "COOL");
-					f.publish(new DecimalType(1), StateChangeType.CHANGED);
-					break;
-				case 0x06:
-					logger.info("{}: set device {} to {}", nm(),
-							dev.getAddress(), "AUTO");
-					f.publish(new DecimalType(3), StateChangeType.CHANGED);
-					break;
-				default: // do nothing
-					break;
-				}
-			} catch (FieldException e) {
-				logger.debug("{} no cmd2 found, dropping msg {}", nm(), msg);
-				return;
-			}
-		}
-	}
-
-	/**
-	 * Handles Thermostat replies to Fan requests.
-	 */
-	public static class ThermostatFanControlReplyHandler extends  MessageHandler {
-		ThermostatFanControlReplyHandler(DeviceFeature p) { super(p); }
-		@Override
-		public void handleMessage(int group, byte cmd1, Msg msg,
-				DeviceFeature f, String fromPort) {
-			InsteonDevice dev = f.getDevice();
-			try {
-				/**
-				* Cmd2 Description 										Thermostat Support 	Comments
-				* 0x07 Turn fan on and returns 07 in ACK 				yes 				On Fan
-				* 0x08 Turn fan auto mode and returns 08 in ACK 		yes 				Auto Fan
-				* 0x09 Turn all off and returns 09 in ACK 				yes 				Off All
-				*/
-				byte cmd2 = msg.getByte("command2");
-				switch (cmd2) {
-				case 0x07:
-					logger.info("{}: set device {} to {}", nm(),
-							dev.getAddress(), "ON");
-					f.publish(new DecimalType(2), StateChangeType.CHANGED);
-					break;
-				case 0x08:
-					logger.info("{}: set device {} to {}", nm(),
-							dev.getAddress(), "AUTO");
-					f.publish(new DecimalType(3), StateChangeType.CHANGED);
-					break;	
-				case 0x09:
-					logger.info("{}: set device {} to {}", nm(),
-							dev.getAddress(), "OFF");
-					f.publish(new DecimalType(1), StateChangeType.CHANGED);
-					break;	
-				default: // do nothing
-					break;
-				}
-			} catch (FieldException e) {
-				logger.debug("{} no cmd2 found, dropping msg {}", nm(), msg);
-				return;
-			}
-		}
-	}
-
-	/**
-	 * Handles Thermostat replies to Master requests.
-	 */
-	public static class ThermostatMasterControlReplyHandler extends  MessageHandler {
-		ThermostatMasterControlReplyHandler(DeviceFeature p) { super(p); }
-		@Override
-		public void handleMessage(int group, byte cmd1, Msg msg,
-				DeviceFeature f, String fromPort) {
-			try {
-				/**
-				* 
-				*/
-				byte cmd2 = msg.getByte("userData3");
-				switch (cmd2) {
-				case 0x00:
-					logger.info("{}: set PRIMARY Thermostat to MASTER", nm());
-					f.publish(new DecimalType(1), StateChangeType.CHANGED);
-					break;
-				case 0x01:
-					logger.info("{}: set SECONDARY Thermostat to MASTER", nm());
-					f.publish(new DecimalType(2), StateChangeType.CHANGED);
-					break;	
-				case 0x02:
-					logger.info("{}: set TERTIARY Thermostat to MASTER", nm());
-					f.publish(new DecimalType(3), StateChangeType.CHANGED);
-					break;	
-				default: // do nothing
-					break;
-				}
-			} catch (FieldException e) {
-				logger.debug("{} no cmd2 found, dropping msg {}", nm(), msg);
-				return;
-			}
-		}
-	}
-	
-	/**
-	 * Handles FanLinc replies to Fan requests.
-	 */
-	public static class FanLincFanControlReplyHandler extends  MessageHandler {
-		FanLincFanControlReplyHandler(DeviceFeature p) { super(p); }
-		@Override
-		public void handleMessage(int group, byte cmd1, Msg msg,
-				DeviceFeature f, String fromPort) {
-			InsteonDevice dev = f.getDevice();
-			try {
-				byte cmd2 = msg.getByte("command2");
-				switch (cmd2) {
-				case (byte) 0x00:
-					logger.info("{}: set device {} to {}", nm(),
-							dev.getAddress(), "OFF");
-					f.publish(new DecimalType(1), StateChangeType.CHANGED);
-					break;
-				case (byte) 0x55:
-					logger.info("{}: set device {} to {}", nm(),
-							dev.getAddress(), "LOW");
-					f.publish(new DecimalType(2), StateChangeType.CHANGED);
-					break;	
-				case (byte) 0xAA:
-					logger.info("{}: set device {} to {}", nm(),
-							dev.getAddress(), "MED");
-					f.publish(new DecimalType(3), StateChangeType.CHANGED);
-					break;	
-				case (byte) 0xFF:
-					logger.info("{}: set device {} to {}", nm(),
-							dev.getAddress(), "HIGH");
-					f.publish(new DecimalType(4), StateChangeType.CHANGED);
-					break;
-				default: // do nothing, but log.
-					logger.warn("{} unexpected cmd2 value received: {}. Dropping msg {}", nm(), cmd2, msg);
-					break;
-				}
-			} catch (FieldException e) {
-				logger.debug("{} no cmd2 found, dropping msg {}", nm(), msg);
-				return;
-			}
 		}
 	}
 	

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/ModemDBBuilder.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/ModemDBBuilder.java
@@ -32,7 +32,7 @@ public class ModemDBBuilder implements MsgListener, Runnable {
 	private boolean	m_isComplete 	= false;
 	private Port	m_port 			= null;
 	private	Thread	m_writeThread	= null;
-	private int		m_timeoutMillis = 30000;
+	private int		m_timeoutMillis = 60000;
 
 	public ModemDBBuilder(Port port) {
 		m_port = port;
@@ -106,7 +106,7 @@ public class ModemDBBuilder implements MsgListener, Runnable {
 				}
 			} else if (msg.getByte("Cmd") == 0x57) {
 				// we got the link record response
-				updateModemDB(msg);
+				updateModemDB(msg.getAddress("LinkAddr"), m_port, msg);
 				m_port.writeMessage(Msg.s_makeMessage("GetNextALLLinkRecord"));
 			}
 		} catch (FieldException e) {
@@ -153,21 +153,17 @@ public class ModemDBBuilder implements MsgListener, Runnable {
 		return Utils.getHexString(b);
 	}
 	
-	private void updateModemDB(Msg m) 	{
-		try {
-			HashMap<InsteonAddress, ModemDBEntry> dbes = m_port.getDriver().lockModemDBEntries();
-			InsteonAddress linkAddr = m.getAddress("LinkAddr");
-			ModemDBEntry dbe = dbes.get(linkAddr);
-			if (dbe == null) {
-				dbe = new ModemDBEntry(linkAddr);
-				dbes.put(linkAddr, dbe);
-			}
-			dbe.setPort(m_port);
-			dbe.addLinkRecord(m);
-		} catch (FieldException e) {
-			logger.error("cannot access field:", e);
-		} finally {
-			m_port.getDriver().unlockModemDBEntries();
+	public void updateModemDB(InsteonAddress linkAddr, Port port, Msg m) 	{
+		HashMap<InsteonAddress, ModemDBEntry> dbes = port.getDriver().lockModemDBEntries();
+		ModemDBEntry dbe = dbes.get(linkAddr);
+		if (dbe == null) {
+			dbe = new ModemDBEntry(linkAddr);
+			dbes.put(linkAddr, dbe);
 		}
+		dbe.setPort(port);
+		if (m != null) {
+			dbe.addLinkRecord(m);
+		}
+		port.getDriver().unlockModemDBEntries();
 	}
 }

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/IOStream.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/IOStream.java
@@ -38,20 +38,19 @@ public abstract class IOStream {
 	 * @param readSize size to read
 	 * @return number of bytes read
 	 */
-	public int read(byte [] b, int offset, int readSize) {
+	public int read(byte [] b, int offset, int readSize) throws InterruptedException {
 		int len = 0;
 		while (len < 1) {
 			try {
 				len = m_in.read(b, offset, readSize);
+				if (Thread.interrupted()) {
+					throw new InterruptedException();
+				}
 			} catch (IOException e) {
 				logger.trace("got exception while reading: {}", e.getMessage());
 				while (!reconnect()) {
-					try {
-						logger.trace("sleeping before reconnecting");
-						Thread.sleep(10000);
-					} catch (InterruptedException ie) {
-						logger.warn("interrupted while sleeping on read reconnect");
-					}
+					logger.trace("sleeping before reconnecting");
+					Thread.sleep(10000); 
 				}
 			}
 		}

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/Poller.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/Poller.java
@@ -180,6 +180,7 @@ public class Poller {
 						readPollQueue();
 					} catch (InterruptedException e) {
 						logger.warn("poll queue reader thread interrupted!");
+						break;
 					}
 				}
 			}

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/SerialIOStream.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/SerialIOStream.java
@@ -59,7 +59,8 @@ public class SerialIOStream extends IOStream {
 			logger.debug("setting port speed to {}", m_speed);
 			m_port.disableReceiveFraming();
 			m_port.enableReceiveThreshold(1);
-			m_port.disableReceiveTimeout();
+			//m_port.disableReceiveTimeout();
+			m_port.enableReceiveTimeout(1000);
 			m_in	= m_port.getInputStream();
 			m_out	= m_port.getOutputStream();
 			logger.info("successfully opened port {}", m_devName);

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/hub/HubIOStream.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/hub/HubIOStream.java
@@ -20,6 +20,7 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.util.EntityUtils;
 import org.openhab.binding.insteonplm.internal.driver.IOStream;
 import org.slf4j.Logger;
@@ -70,7 +71,9 @@ public class HubIOStream extends IOStream implements Runnable {
 		if (m_user != null && m_pass != null) {
 			m_client.getCredentialsProvider().setCredentials(new AuthScope(m_host, m_port),  
 															 new UsernamePasswordCredentials(m_user, m_pass));
-		}	
+		}
+		HttpConnectionParams.setConnectionTimeout(m_client.getParams(), 5000);
+
 		m_in = new HubInputStream();
 
 		m_pollThread = new Thread(this);
@@ -100,7 +103,13 @@ public class HubIOStream extends IOStream implements Runnable {
 	 */
 	private synchronized String bufferStatus() throws IOException {
 		String result = getURL("/buffstatus.xml");
-		result = result.split("<BS>")[1].split("</BS>")[0].trim();
+		String[] parts = result.split("<BS>");
+		if (parts.length > 1) {
+			result = parts[1].split("</BS>")[0].trim();
+		} else {
+			logger.error("got invalid buffer status: {}", result);
+			throw new IOException("malformed bufferstatus.xml");
+		}
 		return result;
 	}
 	/**
@@ -180,7 +189,7 @@ public class HubIOStream extends IOStream implements Runnable {
 	 * @throws IOException
 	 */
 	private String getURL(String resource) throws IOException {
-		synchronized(m_client) {
+		synchronized (m_client) {
 			StringBuilder b = new StringBuilder();
 			b.append("http://");
 			b.append(m_host);
@@ -204,7 +213,7 @@ public class HubIOStream extends IOStream implements Runnable {
 			try {
 				poll();
 			} catch (IOException e) {
-				e.printStackTrace();
+				logger.error("got exception while polling: {}", e.toString());
 			}
 			try {
 				Thread.sleep(m_pollTime);
@@ -264,7 +273,7 @@ public class HubIOStream extends IOStream implements Runnable {
 		private ByteArrayOutputStream m_out = new ByteArrayOutputStream();
 		
 		@Override
-		public void write(int b) throws IOException {
+		public void write(int b) {
 			m_out.write(b);
 			flushBuffer();
 		}
@@ -278,9 +287,8 @@ public class HubIOStream extends IOStream implements Runnable {
 			try {
 				HubIOStream.this.write(buffer);
 			} catch (IOException e) {
-				logger.error("failed to write to hub", e);
+				logger.error("failed to write to hub: {}", e.toString());
 			}
-			
 			m_out.reset();
 		}
 	}

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/hub/ReadByteBuffer.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/hub/ReadByteBuffer.java
@@ -45,7 +45,7 @@ public class ReadByteBuffer {
     		try {
     			wait();
     		} catch (InterruptedException e) {
-    			// do nothin'
+    			return (0);
     		}
     	}
     	return m_buf[m_index++];
@@ -62,7 +62,7 @@ public class ReadByteBuffer {
     		try {
     			wait();
     		} catch (InterruptedException e) {
-    			// do nothing
+    			return 0;
     		}
     	}
     	int b = Math.min(len, remaining());

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/message/Msg.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/message/Msg.java
@@ -10,6 +10,7 @@ package org.openhab.binding.insteonplm.internal.message;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.TreeSet;
@@ -280,6 +281,23 @@ public class Msg {
 		if (m_definition == null) throw new FieldException("no msg definition!");
 		return (m_definition.getField(key).getByte(m_data));
 	}
+
+	/**
+	 * Will fetch a byte array starting at a certain field
+	 * @param key the name of the first field
+	 * @param number of bytes to get
+	 * @return the byte array
+	 */
+	public byte[] getBytes(String key, int numBytes) throws FieldException {
+		if (m_definition == null) throw new FieldException("no msg definition!");
+		int offset = m_definition.getField(key).getOffset();
+		if (offset < 0 || offset + numBytes > m_data.length) {
+			throw new FieldException("data index out of bounds!");
+		}
+		byte [] section = new byte[numBytes];
+		System.arraycopy(m_data, offset, section, 0, numBytes);
+		return section;
+	}
 	
 	/**
 	 * Will fetch address from field
@@ -313,7 +331,82 @@ public class Msg {
 		}
 		return super.toString();
 	}
+	/**
+	 * Sets the userData fields from a byte array
+	 * @param data
+	 */
+	public void setUserData(byte[] arg) {
+		byte[] data = Arrays.copyOf(arg, 14); // appends zeros if short
+		try {
+			setByte("userData1", data[0]);
+			setByte("userData2", data[1]);
+			setByte("userData3", data[2]);
+			setByte("userData4", data[3]);
+			setByte("userData5", data[4]);
+			setByte("userData6", data[5]);
+			setByte("userData7", data[6]);
+			setByte("userData8", data[7]);
+			setByte("userData9", data[8]);
+			setByte("userData10", data[9]);
+			setByte("userData11", data[10]);
+			setByte("userData12", data[11]);
+			setByte("userData13", data[12]);
+			setByte("userData14", data[13]);
+		} catch (FieldException e) {
+			logger.error("got field exception for msg {}:", e);
+		}
+	}
 	
+	/**
+	 * Calculate and set the CRC with the older 1-byte method
+	 * @return the calculated crc
+	 */
+	public int setCRC() {
+		int crc;
+		try {
+			crc = getByte("command1") + getByte("command2");
+			byte[] bytes = getBytes("userData1", 13); // skip userData14!
+			for (byte b : bytes) {
+				crc += b;
+			}
+			crc = ((~crc) + 1) & 0xFF;
+			setByte("userData14", (byte)(crc & 0xFF));
+		} catch (FieldException e) {
+			logger.error("got field exception on msg {}:", this, e);
+			crc = 0;
+		}
+		return crc;
+	}
+
+	/**
+	 * Calculate and set the CRC with the newer 2-byte method
+	 * @return the calculated crc
+	 */
+	public int setCRC2() {
+		int crc = 0;
+		try {
+			byte[] bytes = getBytes("command1", 14);
+			for (int loop = 0; loop < bytes.length; loop++) {
+				int b = bytes[loop] & 0xFF;
+				for (int bit = 0; bit < 8; bit++) {
+					int fb = b & 0x01;
+					if ((crc & 0x8000) == 0) fb = fb ^ 0x01;
+					if ((crc & 0x4000) == 0) fb = fb ^ 0x01;
+					if ((crc & 0x1000) == 0) fb = fb ^ 0x01;
+					if ((crc & 0x0008) == 0) fb = fb ^ 0x01;
+					crc = ((crc << 1) | fb) & 0xFFFF;
+					b = b >> 1;
+				}
+			}
+			setByte("userData13", (byte)((crc >> 8)& 0xFF));
+			setByte("userData14", (byte)(crc & 0xFF));
+		} catch (FieldException e) {
+			logger.error("got field exception on msg {}:", this, e);
+			crc = 0;
+		}
+		return crc;
+	}
+
 	public String toString() {
 		String s = (m_direction == Direction.TO_MODEM) ? "OUT:" : "IN:";
 		if (m_definition == null || m_data == null) return toHexString();

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/utils/Utils.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/utils/Utils.java
@@ -35,6 +35,16 @@ public class Utils {
 		return result;
 	}
 	
+	public static int strToInt(String s) throws NumberFormatException {
+		int ret = -1;
+		if (s.startsWith("0x")) {
+			ret = Integer.parseInt(s.substring(2), 16);
+		} else {
+			ret = Integer.parseInt(s);
+		}
+		return (ret);
+	}
+
 	public static int fromHexString(String string) {
 		return Integer.parseInt(string, 16);
 	}

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
@@ -1,13 +1,31 @@
 <xml>
-<feature name="GenericSwitch">
+<feature name="GenericSwitch" timeout="5000">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x11" group="1">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x12" group="1" mode="FAST">LightOnSwitchHandler</message-handler>
 	<message-handler cmd="0x13" group="1">LightOffSwitchHandler</message-handler>
+	<message-handler cmd="0x14" group="1" mode="FAST">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
-	<poll-handler>DefaultPollHandler</poll-handler>
+	<poll-handler ext="0" cmd1="0x19" cmd2="0x00" >FlexPollHandler</poll-handler>
 </feature>
+<feature name="FastOnOff">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x12" mode="FAST">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x14" mode="FAST">LightOffSwitchHandler</message-handler>
+	<command-handler command="OnOffType">FastOnOffCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+
+<feature name="ManualChange">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x17">StartManualChangeHandler</message-handler>
+	<message-handler cmd="0x18">StopManualChangeHandler</message-handler>
+	<command-handler command="DecimalType">ManualChangeCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+
 <feature name="RemoteButtonA">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
@@ -40,83 +58,249 @@
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x11" button="1" group="1">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x12" button="1" group="1" mode="FAST">LightOnSwitchHandler</message-handler>
 	<message-handler cmd="0x13" button="1" group="1">LightOffSwitchHandler</message-handler>
+	<message-handler cmd="0x14" button="1" group="1" mode="FAST">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="1" group="1">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
-	<poll-handler>LEDBitPollHandler</poll-handler>
+	<poll-handler ext="0" cmd1="0x19" cmd2="0x00" >FlexPollHandler</poll-handler>
+</feature>
+<feature name="LoadSwitchManualChange">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x17" group="1">StartManualChangeHandler</message-handler>
+	<message-handler cmd="0x18" group="1">StopManualChangeHandler</message-handler>
+	<command-handler command="DecimalType">ManualChangeCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+
+<feature name="LoadSwitchFastOnOff">
+    <message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x12" group="1" mode="FAST">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x19" group="1">SwitchRequestReplyHandler</message-handler>
+	<message-handler cmd="0x14" group="1" mode="FAST">LightOffSwitchHandler</message-handler>
+	<command-handler command="OnOffType">FastOnOffCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
 </feature>
 <feature name="LoadDimmerButton">
     <message-dispatcher>DefaultDispatcher</message-dispatcher>
     <message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
     <message-handler cmd="0x11" button="1" group="1">LightOnDimmerHandler</message-handler>
+    <message-handler cmd="0x12" button="1" group="1" mode="FAST">LightOnDimmerHandler</message-handler>
     <message-handler cmd="0x13" button="1" group="1">LightOffDimmerHandler</message-handler>
+    <message-handler cmd="0x14" button="1" group="1" mode="FAST">LightOffDimmerHandler</message-handler>
     <message-handler cmd="0x17" button="1" group="1">NoOpMsgHandler</message-handler>
-    <message-handler cmd="0x18" button="1" group="1">StopManualChangeHandler</message-handler>
+    <message-handler cmd="0x18" button="1" group="1">DimmerStopManualChangeHandler</message-handler>
     <message-handler cmd="0x19" button="1" group="1">DimmerRequestReplyHandler</message-handler>
     <command-handler command="PercentType">PercentHandler</command-handler>
     <command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
-    <poll-handler>DefaultPollHandler</poll-handler>
+	<poll-handler ext="0" cmd1="0x19" cmd2="0x00" >FlexPollHandler</poll-handler>
 </feature>
+<feature name="LoadDimmerFastOnOff">
+    <message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x12" group="1" mode="FAST">LightOnDimmerHandler</message-handler>
+	<message-handler cmd="0x14" group="1" mode="FAST">LightOffDimmerHandler</message-handler>
+	<command-handler command="OnOffType">FastOnOffCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+<feature name="LoadDimmerManualChange">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x17" group="1">StartManualChangeHandler</message-handler>
+	<message-handler cmd="0x18" group="1">StopManualChangeHandler</message-handler>
+	<command-handler command="DecimalType">ManualChangeCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+
 <feature name="KeyPadButtonGroup">
 	<message-dispatcher>DefaultGroupDispatcher</message-dispatcher>
-	<poll-handler>LEDBitPollHandler</poll-handler>
+	<poll-handler ext="0" cmd1="0x19" cmd2="0x01" >FlexPollHandler</poll-handler>
+</feature>
+<feature name="FastOnOffButtonGroup">
+	<message-dispatcher>DefaultGroupDispatcher</message-dispatcher>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+<feature name="ManualChangeButtonGroup">
+	<message-dispatcher>DefaultGroupDispatcher</message-dispatcher>
+	<poll-handler>NoPollHandler</poll-handler>
 </feature>
 <feature name="KeyPadButton2">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x11" button="2" group="2">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x12" button="2" group="2" mode="FAST">LightOnSwitchHandler</message-handler>
 	<message-handler cmd="0x13" button="2" group="2">LightOffSwitchHandler</message-handler>
+	<message-handler cmd="0x14" button="2" group="2" mode="FAST">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="2" group="2">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
 </feature>
+<feature name="FastOnOffButton2">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x12" group="2" mode="FAST">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x14" group="2" mode="FAST">LightOffSwitchHandler</message-handler>
+	<command-handler command="OnOffType">FastOnOffCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+<feature name="ManualChangeButton2">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x17" group="2">StartManualChangeHandler</message-handler>
+	<message-handler cmd="0x18" group="2">StopManualChangeHandler</message-handler>
+	<command-handler command="DecimalType">ManualChangeCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+
+
 <feature name="KeyPadButton3">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x11" button="3" group="3">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x12" button="3" group="3" mode="FAST">LightOnSwitchHandler</message-handler>
 	<message-handler cmd="0x13" button="3" group="3">LightOffSwitchHandler</message-handler>
+	<message-handler cmd="0x14" button="3" group="3" mode="FAST">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="3" group="3">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
 </feature>
+<feature name="FastOnOffButton3">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x12" group="3" mode="FAST">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x14" group="3" mode="FAST">LightOffSwitchHandler</message-handler>
+	<command-handler command="OnOffType">FastOnOffCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+<feature name="ManualChangeButton3">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x17" group="3">StartManualChangeHandler</message-handler>
+	<message-handler cmd="0x18" group="3">StopManualChangeHandler</message-handler>
+	<command-handler command="DecimalType">ManualChangeCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+
 <feature name="KeyPadButton4">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x11" button="4" group="4">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x12" button="4" group="4" mode="FAST">LightOnSwitchHandler</message-handler>
 	<message-handler cmd="0x13" button="4" group="4">LightOffSwitchHandler</message-handler>
+	<message-handler cmd="0x14" button="4" group="4" mode="FAST">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="4" group="4">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
 </feature>
+<feature name="FastOnOffButton4">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x12" group="4" mode="FAST">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x14" group="4" mode="FAST">LightOffSwitchHandler</message-handler>
+	<command-handler command="OnOffType">FastOnOffCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+<feature name="ManualChangeButton4">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x17" group="4">StartManualChangeHandler</message-handler>
+	<message-handler cmd="0x18" group="4">StopManualChangeHandler</message-handler>
+	<command-handler command="DecimalType">ManualChangeCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+
+
 <feature name="KeyPadButton5">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x11" button="5" group="5">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x12" button="5" group="5" mode="FAST">LightOnSwitchHandler</message-handler>
 	<message-handler cmd="0x13" button="5" group="5">LightOffSwitchHandler</message-handler>
+	<message-handler cmd="0x14" button="5" group="5" mode="FAST">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="5" group="5">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
 </feature>
+<feature name="FastOnOffButton5">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x12" group="5" mode="FAST">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x14" group="5" mode="FAST">LightOffSwitchHandler</message-handler>
+	<command-handler command="OnOffType">FastOnOffCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+<feature name="ManualChangeButton5">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x17" group="5">StartManualChangeHandler</message-handler>
+	<message-handler cmd="0x18" group="5">StopManualChangeHandler</message-handler>
+	<command-handler command="DecimalType">ManualChangeCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+
+
 <feature name="KeyPadButton6">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x11" button="6" group="6">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x12" button="6" group="6" mode="FAST">LightOnSwitchHandler</message-handler>
 	<message-handler cmd="0x13" button="6" group="6">LightOffSwitchHandler</message-handler>
+	<message-handler cmd="0x14" button="6" group="6" mode="FAST">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="6" group="6">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
 </feature>
+<feature name="FastOnOffButton6">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x12" group="6" mode="FAST">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x14" group="6" mode="FAST">LightOffSwitchHandler</message-handler>
+	<command-handler command="OnOffType">FastOnOffCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+<feature name="ManualChangeButton6">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x17" group="6">StartManualChangeHandler</message-handler>
+	<message-handler cmd="0x18" group="6">StopManualChangeHandler</message-handler>
+	<command-handler command="DecimalType">ManualChangeCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+
 <feature name="KeyPadButton7">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x11" button="7" group="7">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x12" button="7" group="7" mode="FAST">LightOnSwitchHandler</message-handler>
 	<message-handler cmd="0x13" button="7" group="7">LightOffSwitchHandler</message-handler>
+	<message-handler cmd="0x14" button="7" group="7" mode="FAST">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="7" group="7">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
 </feature>
+<feature name="FastOnOffButton7">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x12" group="7" mode="FAST">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x14" group="7" mode="FAST">LightOffSwitchHandler</message-handler>
+	<command-handler command="OnOffType">FastOnOffCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+<feature name="ManualChangeButton7">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x17" group="7">StartManualChangeHandler</message-handler>
+	<message-handler cmd="0x18" group="7">StopManualChangeHandler</message-handler>
+	<command-handler command="DecimalType">ManualChangeCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+
 <feature name="KeyPadButton8">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x11" button="8" group="8">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x12" button="8" group="8" mode="FAST">LightOnSwitchHandler</message-handler>
 	<message-handler cmd="0x13" button="8" group="8">LightOffSwitchHandler</message-handler>
+	<message-handler cmd="0x14" button="8" group="8" mode="FAST">LightOffSwitchHandler</message-handler>
 	<message-handler cmd="0x19" button="8" group="8">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>	
 </feature>
+<feature name="FastOnOffButton8">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x12" group="8" mode="FAST">LightOnSwitchHandler</message-handler>
+	<message-handler cmd="0x14" group="8" mode="FAST">LightOffSwitchHandler</message-handler>
+	<command-handler command="OnOffType">FastOnOffCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+<feature name="ManualChangeButton8">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x17" group="8">StartManualChangeHandler</message-handler>
+	<message-handler cmd="0x18" group="8">StopManualChangeHandler</message-handler>
+	<command-handler command="DecimalType">ManualChangeCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler>
+</feature>
+
+
 <feature name="GenericLastTime" statusFeature="true">
 	<message-dispatcher>PassThroughDispatcher</message-dispatcher>
 	<message-handler default="true">LastTimeHandler</message-handler>
@@ -126,14 +310,16 @@
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x11" group="1">LightOnDimmerHandler</message-handler>
+	<message-handler cmd="0x12" group="1" mode="FAST">LightOnDimmerHandler</message-handler>
 	<message-handler cmd="0x13" group="1">LightOffDimmerHandler</message-handler>
+	<message-handler cmd="0x14" group="1" mode="FAST">LightOffDimmerHandler</message-handler>
 	<message-handler cmd="0x17" group="1">NoOpMsgHandler</message-handler>
-	<message-handler cmd="0x18" group="1">StopManualChangeHandler</message-handler>
+	<message-handler cmd="0x18" group="1">DimmerStopManualChangeHandler</message-handler>
 	<message-handler cmd="0x19">DimmerRequestReplyHandler</message-handler>
 	<command-handler command="PercentType">PercentHandler</command-handler>
 	<command-handler command="IncreaseDecreaseType">IncreaseDecreaseCommandHandler</command-handler>
 	<command-handler command="OnOffType">LightOnOffCommandHandler</command-handler>
-	<poll-handler>DefaultPollHandler</poll-handler>
+	<poll-handler ext="0" cmd1="0x19" cmd2="0x00" >FlexPollHandler</poll-handler>
 </feature>
 <feature name="IOLincContact">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
@@ -142,7 +328,7 @@
 	<message-handler cmd="0x13" group="1">ClosedContactHandler</message-handler>
 	<message-handler cmd="0x19">ContactRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">NoOpCommandHandler</command-handler>
-	<poll-handler>LEDBitPollHandler</poll-handler>
+	<poll-handler ext="0" cmd1="0x19" cmd2="0x01" >FlexPollHandler</poll-handler>
 </feature>
 <feature name="IOLincSwitch">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
@@ -151,7 +337,7 @@
 	<message-handler cmd="0x13" group="1">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x19">SwitchRequestReplyHandler</message-handler>
 	<command-handler command="OnOffType">IOLincOnOffCommandHandler</command-handler>
-	<poll-handler>DefaultPollHandler</poll-handler>
+	<poll-handler ext="0" cmd1="0x19" cmd2="0x00" >FlexPollHandler</poll-handler>
 </feature>
 <feature name="WirelessMotionSensorContact">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
@@ -191,15 +377,15 @@
 </feature>
 <feature name="LeakSensorContact">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
-	<message-handler cmd="0x03" group="1">NoOpMsgHandler</message-handler>
-	<message-handler cmd="0x11" group="1">OpenedOrClosedContactHandler</message-handler>
+	<message-handler cmd="0x03">NoOpMsgHandler</message-handler>
+	<message-handler cmd="0x11">OpenedOrClosedContactHandler</message-handler>
 	<command-handler command="OnOffType">NoOpCommandHandler</command-handler>
 	<poll-handler>NoPollHandler</poll-handler>
 </feature>
-<feature name="GenericModemControl">
-	<message-dispatcher>PassThroughDispatcher</message-dispatcher>
+<feature name="GroupBroadcastOnOff">
+	<message-dispatcher>NoOpDispatcher</message-dispatcher>
+	<command-handler command="OnOffType">GroupBroadcastCommandHandler</command-handler>
 	<message-handler default="true">NoOpMsgHandler</message-handler>
-	<command-handler command="OnOffType">ModemCommandHandler</command-handler>
 </feature>
 <feature name="PowerMeter">
 	<message-dispatcher>SimpleDispatcher</message-dispatcher>
@@ -207,7 +393,7 @@
 	<message-handler cmd="0x80">PowerMeterResetHandler</message-handler>
 	<message-handler cmd="0x82">PowerMeterUpdateHandler</message-handler>
 	<command-handler command="OnOffType">PowerMeterCommandHandler</command-handler>
-	<poll-handler>PowerMeterPollHandler</poll-handler>
+	<poll-handler ext="0" cmd1="0x82" cmd2="0x00" >FlexPollHandler</poll-handler>
 </feature>
 <feature name="X10Dimmer">
 	<message-dispatcher>X10Dispatcher</message-dispatcher>
@@ -239,63 +425,183 @@
 	<command-handler default="true">NoOpCommandHandler</command-handler>
 	<poll-handler>NoPollHandler</poll-handler>
 </feature>
-<feature name="ThermostatTemperature">
-	<message-dispatcher>DefaultDispatcher</message-dispatcher>
-	<message-handler cmd="0x19" >ThermostatTemperatureRequestReplyHandler</message-handler>
-	<message-handler default="true">NoOpMsgHandler</message-handler>
-	<command-handler default="true">NoOpCommandHandler</command-handler>
-	<poll-handler>ThermostatTemperaturePollHandler</poll-handler>
+<feature name="ThermostatData1Group"> <!-- just does the polling for various quantities -->
+	<message-dispatcher>PollGroupDispatcher</message-dispatcher>
+	<poll-handler ext="1" cmd1="0x2e" cmd2="0x00" >FlexPollHandler</poll-handler>
+</feature>
+<feature name="ThermostatData1bGroup"> <!-- just does the polling for various quantities -->
+	<message-dispatcher>PollGroupDispatcher</message-dispatcher>
+	<poll-handler ext="2" cmd1="0x2e" cmd2="0x00" d3="0x01" >FlexPollHandler</poll-handler>
+</feature>
+<feature name="ThermostatData2Group"> <!-- just does the polling for various quantities -->
+	<message-dispatcher>PollGroupDispatcher</message-dispatcher>
+	<poll-handler ext="2" cmd1="0x2e" cmd2="0x02" >FlexPollHandler</poll-handler>
 </feature>
 <feature name="ThermostatCoolSetPoint">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
-	<message-handler cmd="0x6c" >ThermostatSetPointMsgHandler</message-handler>
-	<message-handler cmd="0x2e" >ThermostatSetPointMsgHandler</message-handler>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x02" match_d1="0x01" low_byte="userData7">NumberMsgHandler</message-handler>
+	<!-- handles direct ack after set point has been changed-->
+	<message-handler cmd="0x19" ext="0" match_cmd1="0x6c" low_byte="command2" factor="0.5">NumberMsgHandler</message-handler>
+	<!-- handles out-of band status messages -->
+	<message-handler cmd="0x71" ext="0" match_cmd1="0x71" low_byte="command2">NumberMsgHandler</message-handler>
 	<message-handler default="true">NoOpMsgHandler</message-handler>
-	<command-handler command="DecimalType">ThermostatCoolSetPointCommandHandler</command-handler>
-	<command-handler default="true" >NoOpCommandHandler</command-handler>
-	<poll-handler>ThermostatHeatCoolSetPointPollHandler</poll-handler>
+	<command-handler command="DecimalType" ext="1" cmd1="0x6c" factor="2" value="command2">NumberCommandHandler</command-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData2Group -->
 </feature>
 <feature name="ThermostatHeatSetPoint">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
-	<message-handler cmd="0x6d" >ThermostatSetPointMsgHandler</message-handler>
-	<message-handler cmd="0x2e" >ThermostatSetPointMsgHandler</message-handler>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x02" match_d1="0x01" low_byte="userData12">NumberMsgHandler</message-handler>
+	<!-- handles direct ack after set point has been changed-->
+	<message-handler cmd="0x19" ext="0" match_cmd1="0x6d" low_byte="command2" factor="0.5">NumberMsgHandler</message-handler>
+	<!-- handles out-of band status messages -->
+	<message-handler cmd="0x72" ext="0" match_cmd1="0x72" low_byte="command2">NumberMsgHandler</message-handler>
 	<message-handler default="true">NoOpMsgHandler</message-handler>
-	<command-handler command="DecimalType">ThermostatHeatSetPointCommandHandler</command-handler>
-	<command-handler default="true" >NoOpCommandHandler</command-handler>
-	<poll-handler>ThermostatHeatCoolSetPointPollHandler</poll-handler>
+	<command-handler command="DecimalType" ext="1" cmd1="0x6d" factor="2" value="command2">NumberCommandHandler</command-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData2Group -->
+</feature>
+<feature name="ThermostatSystemMode">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x02" match_d1="0x01" low_byte="userData6" mask="0xf0" rshift="4">ThermostatSystemModeMsgHandler</message-handler>
+	<!-- handles direct ack after system mode has been changed-->
+	<message-handler cmd="0x19" ext="0" match_cmd1="0x6b" low_byte="command2">ThermostatSystemModeReplyHandler</message-handler>
+	<!-- handles out-of band status messages -->
+	<message-handler cmd="0x70" ext="0" match_cmd1="0x70" low_byte="command2" mask="0x0f">NumberMsgHandler</message-handler>
+	<message-handler default="true">NoOpMsgHandler</message-handler>
+	<command-handler command="DecimalType" ext="1" cmd1="0x6b" value="command2">ThermostatSystemModeCommandHandler</command-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData2Group -->
+</feature>
+<feature name="ThermostatFanMode">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x02" match_d1="0x01" low_byte="userData6" mask="0x0f">NumberMsgHandler</message-handler>
+	<!-- handles direct ack after fan mode has been changed-->
+	<message-handler cmd="0x19" ext="0" match_cmd1="0x6b" low_byte="command2">ThermostatFanModeReplyHandler</message-handler>
+	<!-- handles out-of band status messages -->
+	<message-handler cmd="0x70" ext="0" match_cmd1="0x70" low_byte="command2" mask="0xf0" rshift="4">NumberMsgHandler</message-handler>
+	<message-handler default="true">NoOpMsgHandler</message-handler>
+	<command-handler command="DecimalType" ext="1" cmd1="0x6b" value="command2">ThermostatFanModeCommandHandler</command-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData2Group -->
+</feature>
+<feature name="ThermostatIsHeating">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x02" match_d1="0x01" low_byte="userData11" mask="0x02" rshift="1">NumberMsgHandler</message-handler>
+	<!-- handles all-link broadcast message OFF -->
+	<message-handler cmd="0x13" ext="0" group="2" mask="0x00" low_byte="command1">NumberMsgHandler</message-handler>
+	<!-- handles all-link broadcast message ON -->
+	<message-handler cmd="0x11" ext="0" group="2" mask="0x01" low_byte="command1">NumberMsgHandler</message-handler>
+	<message-handler default="true">NoOpMsgHandler</message-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData2Group -->
+</feature>
+<feature name="ThermostatIsCooling">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x02" match_d1="0x01" low_byte="userData11" mask="0x01">NumberMsgHandler</message-handler>
+	<!-- handles all-link broadcast message OFF -->
+	<message-handler cmd="0x13" ext="0" group="1" mask="0x00" low_byte="command1">NumberMsgHandler</message-handler>
+	<!-- handles all-link broadcast message ON -->
+	<message-handler cmd="0x11" ext="0" group="1" mask="0x01" low_byte="command1">NumberMsgHandler</message-handler>
+	<message-handler default="true">NoOpMsgHandler</message-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData2Group -->
+</feature>
+<feature name="ThermostatTemperatureCelsius">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x02" match_d1="0x01" low_byte="userData10" high_byte="userData9" factor="0.1">NumberMsgHandler</message-handler>
+	<!-- handles out-of band status messages -->
+	<message-handler cmd="0x6e" ext="0" match_cmd1="0x6e" low_byte="command2" factor="0.5">NumberMsgHandler</message-handler>
+	<message-handler default="true">NoOpMsgHandler</message-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData2Group -->
+</feature>
+<feature name="ThermostatTemperatureFahrenheit">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x02" match_d1="0x01" low_byte="userData10" high_byte="userData9" offset="32" factor="0.18">NumberMsgHandler</message-handler>
+	<!-- handles out-of band status messages -->
+	<message-handler cmd="0x6e" ext="0" match_cmd1="0x6e" low_byte="command2" offset="32" factor="0.9">NumberMsgHandler</message-handler>
+	<message-handler default="true">NoOpMsgHandler</message-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData2Group -->
 </feature>
 <feature name="ThermostatHumidity">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
-	<message-handler cmd="0x19" >ThermostatHumidityRequestReplyHandler</message-handler>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x02" match_d1="0x01" low_byte="userData8">NumberMsgHandler</message-handler>
+	<!-- handles out-of band status messages -->
+	<message-handler cmd="0x6f" ext="0" match_cmd1="0x6f" low_byte="command2">NumberMsgHandler</message-handler>
 	<message-handler default="true">NoOpMsgHandler</message-handler>
 	<command-handler default="true">NoOpCommandHandler</command-handler>
-	<poll-handler>ThermostatHumidityPollHandler</poll-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData2Group -->
 </feature>
-<feature name="ThermostatModeControl">
+<feature name="ThermostatBackLightDuration">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
-	<message-handler cmd="0x19" >ThermostatModeControlReplyHandler</message-handler>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x00" match_d2="0x01" match_d3="0x00" low_byte="userData10">NumberMsgHandler</message-handler>
+	<!-- handles direct ack after backlight duration has been changed-->
+	<message-handler cmd="0x19">TriggerPollMsgHandler</message-handler>
 	<message-handler default="true">NoOpMsgHandler</message-handler>
-	<command-handler default="true" command="DecimalType">ThermostatModeControlCommandHandler</command-handler>
-	<poll-handler>NoPollHandler</poll-handler>
+	<command-handler command="DecimalType" ext="1" cmd1="0x2e" d1="0x01" d2="0x05" value="userData3">NumberCommandHandler</command-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData1Group -->
 </feature>
-<feature name="ThermostatFanControl">
+<feature name="ThermostatACDelay">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
-	<message-handler cmd="0x19" >ThermostatFanControlReplyHandler</message-handler>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x00" match_d2="0x01" match_d3="0x00" low_byte="userData11">NumberMsgHandler</message-handler>
+	<!-- handles direct ack after backlight duration has been changed-->
+	<message-handler cmd="0x19">TriggerPollMsgHandler</message-handler>
 	<message-handler default="true">NoOpMsgHandler</message-handler>
-	<command-handler default="true" command="DecimalType">ThermostatFanControlCommandHandler</command-handler>
-	<poll-handler>NoPollHandler</poll-handler>
+	<command-handler command="DecimalType" ext="1" cmd1="0x2e" d1="0x01" d2="0x06" value="userData3">NumberCommandHandler</command-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData1Group -->
 </feature>
-<feature name="ThermostatMasterControl">
+<feature name="ThermostatHumidityHigh">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
-	<message-handler cmd="0x19" >NoOpMsgHandler</message-handler>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x00" match_d2="0x01" match_d3="0x01" low_byte="userData4">NumberMsgHandler</message-handler>
+	<!-- handles direct ack after value has been changed-->
+	<message-handler cmd="0x19">TriggerPollMsgHandler</message-handler>
 	<message-handler default="true">NoOpMsgHandler</message-handler>
-	<command-handler default="true" command="DecimalType">ThermostatMasterControlCommandHandler</command-handler>
-	<poll-handler>NoPollHandler</poll-handler>
+	<command-handler command="DecimalType" ext="1" cmd1="0x2e" d1="0x01" d2="0x0b" value="userData3">NumberCommandHandler</command-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData1bGroup -->
 </feature>
-<feature name="FanLincFanControl">
+<feature name="ThermostatHumidityLow">
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
-	<message-handler cmd="0x19" >FanLincFanControlReplyHandler</message-handler>
-	<command-handler default="true" command="DecimalType">FanLincFanControlCommandHandler</command-handler>
-	<poll-handler>FanLincFanControlPollHandler</poll-handler>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x00" match_d2="0x01" match_d3="0x01" low_byte="userData5">NumberMsgHandler</message-handler>
+	<!-- handles direct ack after value has been changed-->
+	<message-handler cmd="0x19">TriggerPollMsgHandler</message-handler>
+	<message-handler default="true">NoOpMsgHandler</message-handler>
+	<command-handler command="DecimalType" ext="1" cmd1="0x2e" d1="0x01" d2="0x0c" value="userData3">NumberCommandHandler</command-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData1bGroup -->
+</feature>
+<feature name="ThermostatStage1Duration">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<!-- handles direct extended message after query -->
+	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x00" match_d2="0x01"  match_d3="0x01" low_byte="userData11">NumberMsgHandler</message-handler>
+	<!-- handles direct ack after value has been changed-->
+	<message-handler cmd="0x19">TriggerPollMsgHandler</message-handler>
+	<message-handler default="true">NoOpMsgHandler</message-handler>
+	<command-handler command="DecimalType" ext="1" cmd1="0x2e" d1="0x01" d2="0x0a" value="userData3">NumberCommandHandler</command-handler>
+	<command-handler default="true">NoOpCommandHandler</command-handler>
+	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData1bGroup -->
+</feature>
+<feature name="FanLincFan">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<message-handler cmd="0x19" ext="0" low_byte="command2">FanLincFanReplyHandler</message-handler>
+	<command-handler command="DecimalType" ext="1" cmd1="0x11" d1="0x02" value="command2">FanLincFanCommandHandler</command-handler>
+	<poll-handler ext="0" cmd1="0x19" cmd2="0x03" >FlexPollHandler</poll-handler>
 </feature>     
 </xml>

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
@@ -37,6 +37,8 @@ Example entry:
      <model>2486D</model>
      <description>KeypadLinc Dimmer</description>
      <feature name="dimmer">GenericDimmer</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">FastOnOff</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
  
@@ -44,13 +46,15 @@ Example entry:
      <model>2484DWH8</model>
      <description>KeypadLinc Countdown Timer</description>
      <feature name="dimmer">GenericDimmer</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">FastOnOff</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 
  <device productKey="0x000045">
      <model>2413U</model>
      <description>PowerLinc 2413U USB modem</description>
-     <feature name="control">GenericModemControl</feature>
+     <feature name="broadcastonoff">GroupBroadcastOnOff</feature>
  </device>
 
  <device productKey="0x000049">
@@ -71,16 +75,32 @@ Example entry:
      <model>2486DWH6</model>
      <description>KeypadLinc Dimmer - 6 Button</description>
      <feature name="loaddimmer">LoadDimmerButton</feature>
-     <feature name="keypadbuttonA">KeyPadButton3</feature>
-     <feature name="keypadbuttonB">KeyPadButton4</feature>
-     <feature name="keypadbuttonC">KeyPadButton5</feature>
-     <feature name="keypadbuttonD">KeyPadButton6</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">LoadDimmerFastOnOff</feature>
+     <feature_group name="button_group" type="KeyPadButtonGroup">
+     	<feature name="keypadbuttonA">KeyPadButton3</feature>
+     	<feature name="keypadbuttonB">KeyPadButton4</feature>
+     	<feature name="keypadbuttonC">KeyPadButton5</feature>
+     	<feature name="keypadbuttonD">KeyPadButton6</feature>
+     </feature_group>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
  <device productKey="0x000051">
      <model>2486DWH8</model>
-     <description>KeypadLinc Dimmer</description>
-     <feature name="dimmer">GenericDimmer</feature>
+     <description>KeypadLinc Dimmer - 8 Button</description>
+     <feature name="loaddimmer">LoadDimmerButton</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">LoadDimmerFastOnOff</feature>     
+     <feature_group name="button_group" type="KeyPadButtonGroup">
+     	<feature name="keypadbuttonB">KeyPadButton2</feature>
+     	<feature name="keypadbuttonC">KeyPadButton3</feature>
+     	<feature name="keypadbuttonD">KeyPadButton4</feature>
+     	<feature name="keypadbuttonE">KeyPadButton5</feature>
+     	<feature name="keypadbuttonF">KeyPadButton6</feature>
+     	<feature name="keypadbuttonG">KeyPadButton7</feature>
+     	<feature name="keypadbuttonH">KeyPadButton8</feature>
+     </feature_group>
+     
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 
@@ -88,6 +108,8 @@ Example entry:
      <model>2472D</model>
      <description>OutletLincDimmer</description>
      <feature name="dimmer">GenericDimmer</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">FastOnOff</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 
@@ -120,6 +142,8 @@ Example entry:
      <model>2477D</model>
      <description>SwitchLinc Dimmer</description>
      <feature name="dimmer">GenericDimmer</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">FastOnOff</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 
@@ -127,6 +151,7 @@ Example entry:
      <model>2477S</model>
      <description>SwitchLinc Switch</description>
      <feature name="switch">GenericSwitch</feature>
+     <feature name="fastonoff">FastOnOff</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 
@@ -149,6 +174,8 @@ Example entry:
      <model>2456D3</model>
      <description>LampLinc V2</description>
      <feature name="dimmer">GenericDimmer</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">FastOnOff</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 
@@ -156,6 +183,8 @@ Example entry:
      <model>2442-222</model>
      <description>Micro Dimmer</description>
      <feature name="dimmer">GenericDimmer</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">FastOnOff</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 
@@ -170,6 +199,8 @@ Example entry:
      <model>2452-222</model>
      <description>DIN Rail Dimmer</description>
      <feature name="dimmer">GenericDimmer</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">FastOnOff</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 
@@ -190,6 +221,8 @@ Example entry:
      <model>2672-422</model>
      <description>LED Dimmer</description>
      <feature name="dimmer">GenericDimmer</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">FastOnOff</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
  
@@ -197,6 +230,8 @@ Example entry:
      <model>2476D</model>
      <description>SwitchLinc Dimmer</description>
      <feature name="dimmer">GenericDimmer</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">FastOnOff</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 
@@ -221,6 +256,8 @@ Example entry:
      <model>2466D</model>
      <description>ToggleLinc Dimmer</description>
      <feature name="dimmer">GenericDimmer</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">FastOnOff</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 
@@ -235,6 +272,8 @@ Example entry:
      <model>2672-222</model>
      <description>LED Bulb</description>
      <feature name="dimmer">GenericDimmer</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">FastOnOff</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 
@@ -242,12 +281,27 @@ Example entry:
      <model>2487S</model>
      <description>KeypadLinc On/Off 6-Button Scene Control </description>
      <feature name="loadswitch">LoadSwitchButton</feature>
+     <feature name="loadswitchmanualchange">LoadSwitchManualChange</feature>
+     <feature name="loadswitchfastonoff">LoadSwitchFastOnOff</feature>
      <feature_group name="button_group" type="KeyPadButtonGroup">
      	<feature name="keypadbuttonA">KeyPadButton3</feature>
      	<feature name="keypadbuttonB">KeyPadButton4</feature>
      	<feature name="keypadbuttonC">KeyPadButton5</feature>
      	<feature name="keypadbuttonD">KeyPadButton6</feature>
      </feature_group>
+     <feature_group name="fastonoff_button_group" type="FastOnOffButtonGroup">
+        <feature name="fastonoffbuttonA">FastOnOffButton3</feature>
+        <feature name="fastonoffbuttonB">FastOnOffButton4</feature>
+        <feature name="fastonoffbuttonC">FastOnOffButton5</feature>
+        <feature name="fastonoffbuttonD">FastOnOffButton6</feature>
+     </feature_group>
+     <feature_group name="manualchange_button_group" type="ManualChangeButtonGroup">
+        <feature name="manualchangebuttonA">ManualChangeButton3</feature>
+        <feature name="manualchangebuttonB">ManualChangeButton4</feature>
+        <feature name="manualchangebuttonC">ManualChangeButton5</feature>
+        <feature name="manualchangebuttonD">ManualChangeButton6</feature>
+     </feature_group>
+     
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
  
@@ -255,6 +309,8 @@ Example entry:
      <model>2334-232</model>
      <description>Keypad Dimmer Switch, 6-Button </description>
      <feature name="loaddimmer">LoadDimmerButton</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">LoadDimmerFastOnOff</feature>
      <feature_group name="button_group" type="KeyPadButtonGroup">
      	<feature name="keypadbuttonA">KeyPadButton3</feature>
      	<feature name="keypadbuttonB">KeyPadButton4</feature>
@@ -268,6 +324,8 @@ Example entry:
      <model>2334-232</model>
      <description>Keypad Dimmer Switch, 8-Button </description>
      <feature name="loaddimmer">LoadDimmerButton</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">LoadDimmerFastOnOff</feature>     
      <feature_group name="button_group" type="KeyPadButtonGroup">
      	<feature name="keypadbuttonB">KeyPadButton2</feature>
      	<feature name="keypadbuttonC">KeyPadButton3</feature>
@@ -290,13 +348,26 @@ Example entry:
  <device productKey="F00.00.18">
      <model>2441TH</model>
      <description>Insteon Thermostat</description>
-     <feature name="temperature">ThermostatTemperature</feature>
-     <feature name="coolsetpoint">ThermostatCoolSetPoint</feature>
-     <feature name="heatsetpoint">ThermostatHeatSetPoint</feature>
-     <feature name="humidity">ThermostatHumidity</feature>
-     <feature name="modecontrol">ThermostatModeControl</feature>
-     <feature name="fancontrol">ThermostatFanControl</feature>
-     <feature name="mastercontrol">ThermostatMasterControl</feature>
+     <feature_group name="data1_group" type="ThermostatData1Group">     
+     	<feature name="backlightduration">ThermostatBackLightDuration</feature>
+     	<feature name="acdelay">ThermostatACDelay</feature>
+	 </feature_group>
+     <feature_group name="data1b_group" type="ThermostatData1bGroup">     
+     	<feature name="humidityhigh">ThermostatHumidityHigh</feature>
+     	<feature name="humiditylow">ThermostatHumidityLow</feature>
+     	<feature name="stage1duration">ThermostatStage1Duration</feature>
+	 </feature_group>
+	 <feature_group name="data2_group" type="ThermostatData2Group"> 
+	     <feature name="coolsetpoint">ThermostatCoolSetPoint</feature>
+     	 <feature name="heatsetpoint">ThermostatHeatSetPoint</feature>
+     	 <feature name="systemmode">ThermostatSystemMode</feature>
+     	 <feature name="fanmode">ThermostatFanMode</feature>
+	     <feature name="isheating">ThermostatIsHeating</feature>
+	     <feature name="iscooling">ThermostatIsCooling</feature>
+	     <feature name="tempcelsius">ThermostatTemperatureCelsius</feature>
+	     <feature name="tempfahrenheit">ThermostatTemperatureFahrenheit</feature>
+	     <feature name="humidity">ThermostatHumidity</feature>
+     </feature_group>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
  
@@ -304,6 +375,8 @@ Example entry:
      <model>2457D2</model>
      <description>LampLinc Dimmer</description>
      <feature name="dimmer">GenericDimmer</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">FastOnOff</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
 
@@ -325,8 +398,22 @@ Example entry:
      <model>2475F</model>
      <description>FanLinc Module</description>
      <feature name="lightdimmer">GenericDimmer</feature>
-     <feature name="fancontrol">FanLincFanControl</feature>
+     <feature name="fan">FanLincFan</feature>
      <feature name="lastheardfrom">GenericLastTime</feature>
  </device>
  
+ <device productKey="F00.00.1D">
+     <model>2456S3</model>
+     <description>ApplianceLinc</description>
+     <feature name="switch">GenericSwitch</feature>
+     <feature name="lastheardfrom">GenericLastTime</feature>
+ </device>
+ <device productKey="F00.00.1E">
+     <model>2674-222</model>
+     <description>LED Bulb (recessed)</description>
+     <feature name="dimmer">GenericDimmer</feature>
+     <feature name="manualchange">ManualChange</feature>
+     <feature name="fastonoff">FastOnOff</feature>
+     <feature name="lastheardfrom">GenericLastTime</feature>
+ </device>
 </xml>


### PR DESCRIPTION
Improved InsteonPLM binding:
- cleaner exit of binding for faster shutdown (it doesn't shut down any faster though)
- better diagnostic output in case Hub2 fails to connect
- added support for FAST On/Off
- added new device: 2456S3 Appliance link
- complete rewrite and expansion of the thermostat support
- removed modem control commands (no longer needed, use insteon terminal for that)
- shorter timeout for faster manipulation of switches that don't respond with ACK
- added feature to send group broadcasts directly from modem

Minor fix to the Alarmdecoder binding:
- cleaner exit