### PR TITLE
[Nest] Enh: Added support for Nest Cam

### DIFF
--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestActivator.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestActivator.java
@@ -10,6 +10,7 @@ package org.openhab.binding.nest.internal;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,7 @@ public final class NestActivator implements BundleActivator {
 	 */
 	public void start(BundleContext bc) throws Exception {
 		context = bc;
-		logger.debug("Nest binding has been started.");
+		logger.debug("Nest binding has been started. Version {}", NestActivator.getVersion());
 	}
 
 	/**
@@ -48,5 +49,13 @@ public final class NestActivator implements BundleActivator {
 	 */
 	public static BundleContext getContext() {
 		return context;
+	}
+
+	/**
+	 * Returns the current version of the bundle.
+	 * @return the current version of the bundle.
+	 */
+	public static Version getVersion() {
+		return context.getBundle().getVersion();
 	}
 }

--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
@@ -189,6 +189,8 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider> impl
 		if (dmres.isError()) {
 			logger.error("Error retrieving data model: {}", dmres.getError());
 			return;
+		} else {
+			logger.trace("Retrieved data model: {}", dmres);
 		}
 
 		DataModel newDataModel = dmres;

--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/Camera.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/Camera.java
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.nest.internal.messages;
+
+import java.util.Date;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+/**
+ * The Camera Java Bean represents a Nest Cam device. All objects relate in one way or another to a real Nest Cam. The
+ * Camera class defines the real camera device, from the API perspective.
+ * 
+ * @see <a href="https://developer.nest.com/documentation/api-reference">API Reference</a>
+ * @author John Cocula
+ * @since 1.8.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Camera extends AbstractDevice {
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Event extends AbstractMessagePart {
+		private Boolean has_sound;
+		private Boolean has_motion;
+		private Date start_time;
+		private Date end_time;
+		private Date urls_expire_time;
+		private String web_url;
+		private String app_url;
+		private String image_url;
+		private String animated_image_url;
+
+		/**
+		 * @return true if sound event - sound was detected.
+		 */
+		@JsonProperty("has_sound")
+		public Boolean getHas_sound() {
+			return this.has_sound;
+		}
+
+		/**
+		 * @return true if motion event - motion was detected.
+		 */
+		@JsonProperty("has_motion")
+		public Boolean getHas_motion() {
+			return this.has_motion;
+		}
+
+		/**
+		 * @return event start time.
+		 */
+		@JsonProperty("start_time")
+		public Date getStart_time() {
+			return this.start_time;
+		}
+
+		/**
+		 * @return event end time.
+		 */
+		@JsonProperty("end_time")
+		public Date getEnd_time() {
+			return this.end_time;
+		}
+
+		/**
+		 * @return timestamp that identifies when the last event URLs expire.
+		 */
+		@JsonProperty("urls_expire_time")
+		public Date getUrls_expire_time() {
+			return this.urls_expire_time;
+		}
+
+		/**
+		 * @return Web URL (deep link) to the last sound or motion event at home.nest.com. Used to display the recorded
+		 *         event from the camera at that physical location (where). NOTE: If the event URL has expired or the
+		 *         device does not have an active subscription, then this value is not included in the payload.
+		 */
+		@JsonProperty("web_url")
+		public String getWeb_url() {
+			return this.web_url;
+		}
+
+		/**
+		 * @return Nest App URL (deep link) to the last sound or motion event. Used to display the recorded event from
+		 *         the camera at that physical location (where). NOTE: If the event URL has expired or the device does
+		 *         not have an active subscription, then this value is not included in the payload.
+		 */
+		@JsonProperty("app_url")
+		public String getApp_url() {
+			return this.app_url;
+		}
+
+		/**
+		 * @return URL (link) to the image file captured at the start time of a sound or motion event.
+		 */
+		@JsonProperty("image_url")
+		public String getImage_url() {
+			return this.image_url;
+		}
+
+		/**
+		 * @return URL (link) to the gif file captured at the start time of a sound or motion event.
+		 */
+		@JsonProperty("animated_image_url")
+		public String getAnimated_image_url() {
+			return this.animated_image_url;
+		}
+
+		@Override
+		public String toString() {
+			final ToStringBuilder builder = createToStringBuilder();
+			builder.appendSuper(super.toString());
+			builder.append("has_sound", this.has_sound);
+			builder.append("has_motion", this.has_motion);
+			builder.append("start_time", this.start_time);
+			builder.append("end_time", this.end_time);
+			builder.append("urls_expire_time", this.urls_expire_time);
+			builder.append("web_url", this.web_url);
+			builder.append("app_url", this.app_url);
+			builder.append("image_url", this.image_url);
+			builder.append("animated_image_url", this.animated_image_url);
+			return builder.toString();
+		}
+	}
+
+	private Boolean is_streaming;
+	private Boolean is_audio_input_enabled;
+	private Date last_is_online_change;
+	private Boolean is_video_history_enabled;
+	private String web_url;
+	private String app_url;
+	private Event last_event;
+
+	public Camera(@JsonProperty("device_id") String device_id) {
+		super(device_id);
+	}
+
+	/**
+	 * @return true Camera status, either on and actively streaming video, or off.
+	 */
+	@JsonProperty("is_streaming")
+	public Boolean getIs_streaming() {
+		return this.is_streaming;
+	}
+
+	/**
+	 * Turn the camera off or on
+	 */
+	@JsonProperty("is_streaming")
+	public void setIs_streaming(Boolean streaming) {
+		this.is_streaming = streaming;
+	}
+
+	/**
+	 * return true if camera microphone is on and listening, else return false.
+	 */
+	@JsonProperty("is_audio_input_enabled")
+	public Boolean getIs_audio_input_enabled() {
+		return this.is_audio_input_enabled;
+	}
+
+	/**
+	 * @return the last change to the online status.
+	 */
+	@JsonProperty("last_is_online_change")
+	public Date getLast_is_online_change() {
+		return this.last_is_online_change;
+	}
+
+	/**
+	 * @return Nest Aware subscription status.
+	 */
+	@JsonProperty("is_video_history_enabled")
+	public Boolean getIs_video_history_enabled() {
+		return this.is_video_history_enabled;
+	}
+
+	/**
+	 * @return Web URL (deep link) to the device page at home.nest.com. Used to display the camera live feed at that
+	 *         physical location (where).
+	 */
+	@JsonProperty("web_url")
+	public String getWeb_url() {
+		return this.web_url;
+	}
+
+	/**
+	 * @return App URL (deep link) to the device screen in the Nest App. Used to display the camera live feed at that
+	 *         physical location (where).
+	 */
+	@JsonProperty("app_url")
+	public String getApp_url() {
+		return this.app_url;
+	}
+	
+	/**
+	 * @return the last event
+	 */
+	@JsonProperty("last_event")
+	public Event getLast_event() {
+		return this.last_event;
+	}
+
+	@Override
+	public String toString() {
+		final ToStringBuilder builder = createToStringBuilder();
+		builder.appendSuper(super.toString());
+		builder.append("is_streaming", this.is_streaming);
+		builder.append("is_audio_input_enabled", this.is_audio_input_enabled);
+		builder.append("last_is_online_change", this.last_is_online_change);
+		builder.append("is_video_history_enabled", this.is_video_history_enabled);
+		builder.append("web_url", this.web_url);
+		builder.append("app_url", this.app_url);
+		builder.append("last_event", this.last_event);
+		return builder.toString();
+	}
+}

--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/Structure.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/Structure.java
@@ -130,6 +130,9 @@ public class Structure extends AbstractMessagePart implements DataModelElement {
 	@JsonProperty("smoke_co_alarms")
 	private List<String> smoke_co_alarm_id_list;
 	private Map<String, SmokeCOAlarm> smoke_co_alarms_by_name;
+	@JsonProperty("cameras")
+	private List<String> camera_id_list;
+	private Map<String, Camera> cameras_by_name;
 	private AwayState away;
 	private String name;
 	private String country_code;
@@ -181,6 +184,22 @@ public class Structure extends AbstractMessagePart implements DataModelElement {
 
 	public void setSmoke_co_alarms_by_name(Map<String, SmokeCOAlarm> smoke_co_alarms_by_name) {
 		this.smoke_co_alarms_by_name = smoke_co_alarms_by_name;
+	}
+
+	/**
+	 * @return the cameras
+	 */
+	@JsonProperty("cameras")
+	public List<String> getCamera_id_list() {
+		return this.camera_id_list;
+	}
+
+	public Map<String, Camera> getCameras() {
+		return this.cameras_by_name;
+	}
+
+	public void setCameras_by_name(Map<String, Camera> cameras_by_name) {
+		this.cameras_by_name = cameras_by_name;
 	}
 
 	/**
@@ -288,6 +307,15 @@ public class Structure extends AbstractMessagePart implements DataModelElement {
 				}
 			}
 		}
+		this.cameras_by_name = new HashMap<String, Camera>();
+		if (this.camera_id_list != null) {
+			for (String id : this.camera_id_list) {
+				Camera cam = dataModel.getDevices().getCameras_by_id().get(id);
+				if (cam != null) {
+					this.cameras_by_name.put(cam.getName(), cam);
+				}
+			}
+		}
 	}
 
 	@Override
@@ -297,6 +325,7 @@ public class Structure extends AbstractMessagePart implements DataModelElement {
 		builder.append("structure_id", this.structure_id);
 		builder.append("thermostats", this.thermostat_id_list);
 		builder.append("smoke_co_alarms", this.smoke_co_alarm_id_list);
+		builder.append("cameras", this.camera_id_list);
 		builder.append("away", this.away);
 		builder.append("name", this.name);
 		builder.append("country_code", this.country_code);


### PR DESCRIPTION
The Nest Cloud API recently released support for the [Nest Cam](https://nest.com/camera/meet-nest-cam/).  This PR adds support for it.  The new API lets you start and stop the camera streaming, effectively turning the camera off an on.  All other values are read-only.

New binding strings available (full set available only if you set the proper permissions in your Nest Client, authorize the binding with new PIN, and subscribe to Nest Aware with Video History):
```
String CamDeviceId "CamDeviceId [%s]" { nest="<[cameras(Dining Room).device_id]" }
String CamSWVersion "CamSWVersion [%s]" { nest="<[cameras(Dining Room).software_version]" }
String CamName "CamName [%s]" { nest="<[cameras(Dining Room).name]" }
String CamNameLong "CamNameLong [%s]" { nest="<[cameras(Dining Room).name_long]" }
Switch CamIsOnline "CamIsOnline [%s]" { nest="<[cameras(Dining Room).is_online]" }
Switch CamIsStreaming "CamIsStreaming [%s]" { nest="=[cameras(Dining Room).is_streaming]" }
Switch CamIsAudioInputEnabled "CamIsAudioInputEnabled [%s]" { nest="<[cameras(Dining Room).is_audio_input_enabled]" }
DateTime CamLastIsOnlineChange "CamLastIsOnlineChange [%1$tm/%1$td %1$tH:%1$tM]" { nest="<[cameras(Dining Room).last_is_online_change]" }
Switch CamIsVideoHistoryEnabled "CamIsVideoHistoryEnable [%s]" { nest="<[cameras(Dining Room).is_video_history_enabled]" }
String CamWebUrl "CamWebUrl [%s]" { nest="<[cameras(Dining Room).web_url]" }
String CamAppUrl "CamAppUrl [%s]" { nest="<[cameras(Dining Room).app_url]" }
Switch CamLastEventHasSound "CamLastEventHasSound [%s]" { nest="<[cameras(Dining Room).last_event.has_sound]" }
Switch CamLastEventHasMotion "CamLastEventHasMotion [%s]" { nest="<[cameras(Dining Room).last_event.has_motion]" }
DateTime CamLastEventStartTime "CamLastEventStartTime [%1$tm/%1$td %1$tH:%1$tM]" { nest="<[cameras(Dining Room).last_event.start_time]" }
DateTime CamLastEventEndTime "CamLastEventEndTime [%1$tm/%1$td %1$tH:%1$tM]" { nest="<[cameras(Dining Room).last_event.end_time]" }
DateTime CamLastEventUrlsExpireTime "CamLastEventUrlsExpireTime [%1$tm/%1$td %1$tH:%1$tM]" { nest="<[cameras(Dining Room).last_event.urls_expire_time]" }
String CamLastEventWebUrl "CamLastEventWebUrl [%s]" { nest="<[cameras(Dining Room).last_event.web_url]" }
String CamLastEventAppUrl "CamLastEventAppUrl [%s]" { nest="<[cameras(Dining Room).last_event.app_url]" }
String CamLastEventImageUrl "CamLastEventImageUrl [%s]" { nest="<[cameras(Dining Room).last_event.image_url]" }
String CamLastEventAnimatedImageUrl "CamLastEventAnimatedImageUrl [%s]" { nest="<[cameras(Dining Room).last_event.animated_image_url]" }
```

As I don't have a Nest Cam myself, I will merge this PR (and update the wiki page) once users have tried it (for example, [this JAR](https://www.dropbox.com/s/ehfhy47am9y9gb0/org.openhab.binding.nest-1.8.0-SNAPSHOT.jar?dl=0)), and reported it works for them.