### PR TITLE
modify Cosm Persistence for compatibility with Xively

### DIFF
--- a/bundles/persistence/org.openhab.persistence.cosm/src/main/java/org/openhab/persistence/cosm/internal/CosmService.java
+++ b/bundles/persistence/org.openhab.persistence.cosm/src/main/java/org/openhab/persistence/cosm/internal/CosmService.java
@@ -55,7 +55,11 @@ public class CosmService implements PersistenceService {
 	public void store(Item item, String alias) {
 		if (initialized) {
 			try { 
-				String serviceUrl = url + alias;
+				String serviceUrl = url;
+				if(alias==null){
+					alias=item.getName();
+				}
+				serviceUrl+="/" + alias;
 	            URL url = new URL(serviceUrl); 
 	            HttpURLConnection httpCon = (HttpURLConnection) url.openConnection(); 
 	            httpCon.setDoOutput(true); 


### PR DESCRIPTION
modify Cosm Persistence for compatibility with actual Cosm, named Xively, where items alias ==null