### PR TITLE
Improve logging output for HueBinding when retrieving settings

### DIFF
--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java
@@ -52,7 +52,7 @@ public class HueSettings {
 			settingsData = new SettingsTree(mapper.readValue(settings,
 					Map.class));
 		} catch (Exception e) {
-			logger.error("Could not read Settings-Json from Hue Bridge.");
+			logger.error("Could not read Settings-Json from Hue Bridge.", e);
 		}
 	}
 

--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBridge.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBridge.java
@@ -143,6 +143,7 @@ public class HueBridge {
 						+ response.getStatus());
 				return null;
 			}
+			logger.trace("Received Hue Bridge Settings: {}", settingsString);
 			return settingsString;
 		} catch(ClientHandlerException e) {
 			logger.warn("Failed to connect to Hue bridge: HTTP request timed out.");


### PR DESCRIPTION
The error described in https://community.openhab.org/t/hue-pairing-error/2969 is difficult to analyze because the logging output is not sufficient.
Therefore this pull request improves logging output when retrieving JSON settings from the hue bridge.