### PR TITLE
Fix for DateTimeItem to accept DateTimeType commands.

### DIFF
--- a/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/items/DateTimeItem.java
+++ b/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/items/DateTimeItem.java
@@ -33,6 +33,8 @@ public class DateTimeItem extends GenericItem {
 	static {
 		acceptedDataTypes.add((DateTimeType.class));
 		acceptedDataTypes.add(UnDefType.class);
+
+		acceptedCommandTypes.add(DateTimeType.class);
 	}
 	
 	public DateTimeItem(String name) {


### PR DESCRIPTION
Some time ago I made DateTimeType a command, but forgot to add this type to accepted commands in DateTimeItem, which prevents sending commands as String. This PR fixes this issue.