### PR TITLE
Fix incorrect pairing message for hue binding

### DIFF
--- a/bundles/binding/org.openhab.binding.hue/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.hue/META-INF/MANIFEST.MF
@@ -12,6 +12,7 @@ Bundle-Description: This is the Hue binding of the open Home Aut
 Import-Package: com.sun.jersey.api.client,
  org.apache.commons.io,
  org.apache.commons.lang,
+ org.codehaus.jackson,
  org.codehaus.jackson.map,
  org.openhab.core.binding,
  org.openhab.core.events,

--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBinding.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/HueBinding.java
@@ -99,6 +99,9 @@ public class HueBinding extends AbstractActiveBinding<HueBindingProvider> implem
 			if (settings == null) {
 				logger.warn("Hue settings were null, maybe misconfigured bridge IP.");
 				return;
+			} else if (!settings.isAuthorized()){
+				logger.warn("openHAB not authorized to access Hue bridge");
+				return;
 			}
 			Set<String> keys = settings.getKeys();
 			for(String key: keys){				

--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java
@@ -8,9 +8,11 @@
  */
 package org.openhab.binding.hue.internal.data;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
+import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,25 +37,54 @@ public class HueSettings {
 	static final Logger logger = LoggerFactory.getLogger(HueSettings.class);
 
 	private SettingsTree settingsData = null;
+	private static final int ERROR_TYPE_UNAUTHORIZED_USER = 1;
+	private boolean isAuthorized = false;
 
 	/**
-	 * Constructor of HueSettings. It takes the settings of the Hue bridge to
-	 * enable the HueSettings to determine the needed information about the
-	 * bulbs.
+	 * Constructor of HueSettings. It takes the settings of the Hue bridge to enable the HueSettings to determine the
+	 * needed information about the bulbs.
 	 * 
 	 * @param settings
-	 *            This is the settings string in Json format returned by the Hue
-	 *            bridge.
+	 *            This is the settings string in Json format returned by the Hue bridge.
 	 */
 	@SuppressWarnings("unchecked")
 	public HueSettings(String settings) {
 		ObjectMapper mapper = new ObjectMapper();
 		try {
-			settingsData = new SettingsTree(mapper.readValue(settings,
-					Map.class));
-		} catch (Exception e) {
+			JsonNode rootNode = mapper.readTree(settings);
+			if (!isAuthorizationError(rootNode)) {
+				settingsData = new SettingsTree(mapper.readValue(rootNode, Map.class));
+				isAuthorized = true;
+			}
+		} catch (IOException e) {
 			logger.error("Could not read Settings-Json from Hue Bridge.", e);
 		}
+	}
+	
+	/**
+	 * Determines if the Hue Bridge reported an authorization error.
+	 * 
+	 * @return true if an authorization error occurred, else false
+	 */
+	private boolean isAuthorizationError(JsonNode rootNode) {
+		boolean isAuthorizationError = false;
+		// While normal answers from the bridge are of type object, the error message is of type array
+		if (rootNode.isArray()) {
+			JsonNode node = rootNode.get(0);
+			if (node.has("error")) {
+				if (node.get("error").get("type").getIntValue() == ERROR_TYPE_UNAUTHORIZED_USER) {
+					isAuthorizationError = true;
+				}
+			}
+		}
+		return isAuthorizationError;
+	}
+	
+	/**
+	 * @return True if openHAB is authorized on the Hue bridge, else false
+	 */
+	public boolean isAuthorized(){
+		return isAuthorized;
 	}
 
 	/**

--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBridge.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBridge.java
@@ -54,17 +54,14 @@ public class HueBridge {
 	}
 
 	/**
-	 * Checks if the secret is already registered in the Hue bridge. If not it
-	 * pings the bridge for an initial connect. This pinging will take place for
-	 * 100 seconds. In this time the connect button on the Hue bridge has to be
-	 * pressed to enable the pairing.
+	 * Checks if the secret is already registered in the Hue bridge. If not it pings the bridge for an initial connect.
+	 * This pinging will take place for 100 seconds. In this time the connect button on the Hue bridge has to be pressed
+	 * to enable the pairing.
 	 * 
 	 */
 	public void pairBridgeIfNecessary() {
-
-		String output = getSettingsJson();
-
-		if (output!=null && output.contains("error")) {
+		HueSettings settings = getSettings();
+		if (settings != null && !settings.isAuthorized()) {
 			logger.info("Hue bridge not paired.");
 			Thread pairingThread = new Thread(new BridgePairingProcessor());
 			pairingThread.start();


### PR DESCRIPTION
Probably caused by a recent hue API change, the hue binding incorrectly shows the message that pairing would be necessary on each startup (as discussed [here](https://community.openhab.org/t/openhab-continiously-loosing-connection-to-hue-bridge/3013))

Instead of just parsing the json result for "error", this pull requests checks if the JSON response is the one defined by the API for authorization error.
