### PR TITLE
[Satel] Items initial poll fix

### DIFF
--- a/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/SatelBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/SatelBindingConfig.java
@@ -40,11 +40,13 @@ public abstract class SatelBindingConfig implements BindingConfig {
 	private static final DecimalType DECIMAL_ONE = new DecimalType(1);
 
 	private Map<String, String> options;
+	private boolean itemInitialized;
 
 	/**
 	 * Checks whether given option is set to <code>true</code>.
 	 * 
-	 * @param option option to check
+	 * @param option
+	 *            option to check
 	 * @return <code>true</code> if option is enabled
 	 */
 	public boolean hasOptionEnabled(Options option) {
@@ -54,7 +56,8 @@ public abstract class SatelBindingConfig implements BindingConfig {
 	/**
 	 * Returns value of given option.
 	 * 
-	 * @param option option to get value for
+	 * @param option
+	 *            option to get value for
 	 * @return string value or <code>null</code> if option is not present
 	 */
 	public String getOption(Options option) {
@@ -68,6 +71,23 @@ public abstract class SatelBindingConfig implements BindingConfig {
 	 */
 	public String optionsAsString() {
 		return this.options.toString();
+	}
+
+	/**
+	 * Returns initialization state of bound item.
+	 * 
+	 * @return <code>true</code> if bound item has received state update,
+	 *         <code>false</code> if it is uninitialized
+	 */
+	public boolean isItemInitialized() {
+		return itemInitialized;
+	}
+
+	/**
+	 * Notifies that bound item has its state updated.
+	 */
+	public void setItemInitialized() {
+		this.itemInitialized = true;
 	}
 
 	/**
@@ -106,6 +126,7 @@ public abstract class SatelBindingConfig implements BindingConfig {
 
 	protected SatelBindingConfig(Map<String, String> options) {
 		this.options = options;
+		this.itemInitialized = false;
 	}
 
 	protected State booleanToState(Item item, boolean value) {
@@ -119,4 +140,5 @@ public abstract class SatelBindingConfig implements BindingConfig {
 
 		return null;
 	}
+
 }

--- a/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/config/ConnectionStatusBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/config/ConnectionStatusBindingConfig.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import org.openhab.binding.satel.SatelBindingConfig;
 import org.openhab.binding.satel.internal.event.ConnectionStatusEvent;
+import org.openhab.binding.satel.internal.event.NewStatesEvent;
 import org.openhab.binding.satel.internal.event.SatelEvent;
 import org.openhab.binding.satel.internal.protocol.SatelMessage;
 import org.openhab.binding.satel.internal.types.IntegraType;
@@ -81,7 +82,13 @@ public class ConnectionStatusBindingConfig extends SatelBindingConfig {
 	@Override
 	public State convertEventToState(Item item, SatelEvent event) {
 		if (!(event instanceof ConnectionStatusEvent)) {
-			return null;
+			// since we get event about changes, we assume connection has been established.
+			// if current items state is uninitialized, "generate" fake event to update its state
+			if (event instanceof NewStatesEvent && this.connectedSince == null) {
+				event = new ConnectionStatusEvent(true);
+			} else {
+				return null;
+			}
 		}
 
 		ConnectionStatusEvent statusEvent = (ConnectionStatusEvent) event;

--- a/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelBinding.java
+++ b/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelBinding.java
@@ -180,6 +180,7 @@ public class SatelBinding extends AbstractActiveBinding<SatelBindingProvider> im
 				if (newState != null) {
 					logger.debug("Updating item state: item = {}, state = {}, event = {}", itemName, newState, event);
 					eventPublisher.postUpdate(itemName, newState);
+					itemConfig.setItemInitialized();
 				}
 			}
 		}
@@ -213,10 +214,10 @@ public class SatelBinding extends AbstractActiveBinding<SatelBindingProvider> im
 					continue;
 				}
 
-				// either state has changed or this is status command, so likely
-				// RTC has changed or state is Undefined, so get the latest
-				// value from the module
-				if (forceRefresh || (nse != null && nse.isNew(message.getCommand()))
+				// either state has changed or this is status command (so likely RTC has changed)
+				// also if item hasn't received any update yet or refresh is forced
+				// get the latest value from the module
+				if (forceRefresh || !itemConfig.isItemInitialized() || (nse != null && nse.isNew(message.getCommand()))
 						|| message.getCommand() == IntegraStatusCommand.COMMAND_CODE) {
 					commands.add(message);
 				}


### PR DESCRIPTION
This PR fixes the way initial refresh is done for items added after connection is established. 
Since items are updated only when appropriate state in the alarm system changes, items require initial poll of current state when new item added. This is done through additional flag in binding configuration.