### PR TITLE
Added additional device Type/ID for Fibaro FGFS101

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -1519,6 +1519,10 @@
 			</Reference>
 			<Reference>
 				<Type>0B00</Type>
+				<Id>2001</Id>
+			</Reference>
+			<Reference>
+				<Type>0B00</Type>
 				<Id>3001</Id>
 			</Reference>
 			<Model>FGFS101</Model>


### PR DESCRIPTION
Added an additional Z-Wave Device Reference Type/ID for Fibaro FGFS101 for ID 2001
![screen shot 2015-10-12 at 2 01 48 am](https://cloud.githubusercontent.com/assets/645180/10422222/4cb0365e-7085-11e5-9d59-15e8560961ac.png)
