### PR TITLE
[Ecobee] Add runningEvent property for simpler access.

### DIFF
--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
@@ -414,7 +414,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 			try {
 				return createState(thermostat.getProperty(property));
 			} catch (Exception e) {
-				logger.error("Unable to get state from thermostat", e);
+				logger.debug("Unable to get state from thermostat", e);
 			}
 		}
 		return UnDefType.NULL;
@@ -868,7 +868,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider> 
 					selection.setIncludeManagement(true);
 				} else if (property.startsWith("weather")) {
 					selection.setIncludeWeather(true);
-				} else if (property.startsWith("events")) {
+				} else if (property.startsWith("events") || property.startsWith("runningEvent")) {
 					selection.setIncludeEvents(true);
 				} else if (property.startsWith("program")) {
 					selection.setIncludeProgram(true);

--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/messages/Thermostat.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/messages/Thermostat.java
@@ -459,6 +459,21 @@ public class Thermostat extends AbstractMessagePart {
 	}
 
 	/**
+	 * @return the running event or null if there is none
+	 */
+	@JsonIgnore
+	public Event getRunningEvent() {
+		if (this.events != null) {
+			for (Event event : this.events) {
+				if (event.isRunning()) {
+					return event;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * Create a named-based map of RemoteSensors from the list of RemoteSensors, for ease of access from beanutils.
 	 */
 	protected void sync() {
@@ -5014,6 +5029,7 @@ public class Thermostat extends AbstractMessagePart {
 	public static class Event extends AbstractMessagePart {
 		private String type;
 		private String name;
+		@JsonProperty("running")
 		private Boolean running;
 		// TODO Jackson 1.9 dates (@watou)
 		private String startDate;


### PR DESCRIPTION
Access to properties like `runningEvent.type`, `runningEvent.name`, `runningEvent.holdClimateRef` and any fields present in the [Event object](https://www.ecobee.com/home/developer/api/documentation/v1/objects/Event.shtml).

Access to events was already possible by indexing the list of events, but it was difficult in openHAB to locate the running event without this new property.  When there is no running event, this property set returns `UnDefType.NULL`.