### PR TITLE
Use https:// instead of http:// in forecast.io API

### DIFF
--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/ForecastIoProvider.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/ForecastIoProvider.java
@@ -18,7 +18,7 @@ import org.openhab.binding.weather.internal.parser.JsonWeatherParser;
  * @since 1.6.0
  */
 public class ForecastIoProvider extends AbstractWeatherProvider {
-	private static final String URL = "http://api.forecast.io/forecast/[API_KEY]/[LATITUDE],[LONGITUDE]?units=si&lang=[LANGUAGE]&exclude=hourly,flags";
+	private static final String URL = "https://api.forecast.io/forecast/[API_KEY]/[LATITUDE],[LONGITUDE]?units=si&lang=[LANGUAGE]&exclude=hourly,flags";
 
 	public ForecastIoProvider() {
 		super(new JsonWeatherParser());


### PR DESCRIPTION
The weather binding uses unencrypted http:// for the forecast.io API.
This stopped working two days ago.
Changing the URL from http:// to https:// solves the issue.
See also https://community.openhab.org/t/problem-with-weather-binding-and-forecast-io/3405