### PR TITLE
InsteonPLM binding bug fix: no wait for reply when sending X10 messages

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/InsteonDevice.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/InsteonDevice.java
@@ -371,7 +371,7 @@ public class InsteonDevice {
 							m_address, -dt);
 					return (timeNow + 2000L); // retry soon
 				} else {
-					logger.warn("gave up waiting for query reply from device {}", m_address);
+					logger.debug("gave up waiting for query reply from device {}", m_address);
 				}
 			}
 			QEntry qe = m_requestQueue.poll(); // take it off the queue!

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
@@ -395,7 +395,7 @@
 	<command-handler command="OnOffType">PowerMeterCommandHandler</command-handler>
 	<poll-handler ext="0" cmd1="0x82" cmd2="0x00" >FlexPollHandler</poll-handler>
 </feature>
-<feature name="X10Dimmer">
+<feature name="X10Dimmer" timeout="0">
 	<message-dispatcher>X10Dispatcher</message-dispatcher>
 	<message-handler cmd="0x02">X10OnHandler</message-handler>
 	<message-handler cmd="0x03">X10OffHandler</message-handler>
@@ -407,7 +407,7 @@
 	<command-handler command="IncreaseDecreaseType">X10IncreaseDecreaseCommandHandler</command-handler>
 	<poll-handler>NoPollHandler</poll-handler>
 </feature>
-<feature name="X10Switch">
+<feature name="X10Switch" timeout="0">
 	<message-dispatcher>X10Dispatcher</message-dispatcher>
 	<message-handler cmd="0x02">X10OnHandler</message-handler>
 	<message-handler cmd="0x03">X10OffHandler</message-handler>


### PR DESCRIPTION
InsteonPLM binding bug fix: no wait for reply when sending X10 messages. This fixes the 10sec delay when sending X10 commands.

Here is a compiled jar file with the fix. Should be drop-in for OH 1.7 and 1.8:

https://drive.google.com/open?id=0B8OtzwATWQSWN0RTdG1Wb0Q5VUk