### PR TITLE
MPD Binding extension to play a specific song

### DIFF
--- a/bundles/binding/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/MpdGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/MpdGenericBindingProvider.java
@@ -17,6 +17,7 @@ import org.openhab.binding.mpd.MpdBindingProvider;
 import org.openhab.core.binding.BindingConfig;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.DimmerItem;
+import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.items.StringItem;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.model.item.binding.AbstractGenericBindingProvider;
@@ -55,7 +56,7 @@ public class MpdGenericBindingProvider extends AbstractGenericBindingProvider im
 	 */
 	@Override
 	public void validateItemType(Item item, String bindingConfig) throws BindingConfigParseException {
-		if (!(item instanceof SwitchItem || item instanceof DimmerItem || item instanceof StringItem)) {
+		if (!(item instanceof SwitchItem || item instanceof DimmerItem || item instanceof StringItem || item instanceof NumberItem)) {
 			throw new BindingConfigParseException("item '" + item.getName()
 					+ "' is of type '" + item.getClass().getSimpleName()
 					+ "', only Switch- and DimmerItems are allowed - please check your *.items configuration");
@@ -104,7 +105,7 @@ public class MpdGenericBindingProvider extends AbstractGenericBindingProvider im
 		if (StringUtils.isNotBlank(bindingConfigTail)) {
 			parseBindingConfig(bindingConfigTail, config);
 		}
-				
+
 		config.put(command, playerId + ":" + playerCommand);
 	}
 	

--- a/bundles/binding/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/PlayerCommandTypeMapping.java
+++ b/bundles/binding/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/PlayerCommandTypeMapping.java
@@ -29,6 +29,13 @@ public enum PlayerCommandTypeMapping {
 		}
 	},
 	
+	PLAYSONG {
+		{
+			command = "playsong";
+			type = OnOffType.ON;
+		}
+	},
+	
 	PLAY {
 		{
 			command = "play";


### PR DESCRIPTION
I´ve added a command to the binding, so you can select a song that will be played.

```
Switch Radio_Station_1 {mpd="ON:<MPD_HOST>:playsong=<song_name>"}
```

I use this on my installation to start streaming internet radio. I´ve also changed binding provider to allow a numeric type.

Items:
```
Number Radio_Select {mpd="0:<MPD_HOST>:playsong=1Live, 1:<MPD_HOST>:playsong=WDR2"}
```

Sitemap:
```
Selection item=Radio_Select label="Choose a Radio Station" mappings=[0="1 Live", 1="WDR 2"]
```

I´ve tested this stuff with OH 1.7, 1.7.1 and 1.8 with forked-daapd as mpd server.

This is my first pull request so I really hope I did everything right.

Patrick