### PR TITLE
Add logging output when authentication with hue bridge

### DIFF
--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBridge.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBridge.java
@@ -107,6 +107,7 @@ public class HueBridge {
 			}
 
 			String output = response.getEntity(String.class);
+			logger.debug("Received pairing response: {}", output);
 
 			if (output.contains("success")) {
 				logger.info("Hue bridge successfully paired!");


### PR DESCRIPTION
Added logging output when openHAB tries to authenticate with the hue bridge. Should make it easier to analyse some recently reported issues (e.g. comments in pull request #3259)