### PR TITLE
Added job key to JSR223 timer trigger so reschedule works correctly.

### DIFF
--- a/bundles/core/org.openhab.core.jsr223/src/main/java/org/openhab/core/jsr223/internal/actions/Timer.java
+++ b/bundles/core/org.openhab.core.jsr223/src/main/java/org/openhab/core/jsr223/internal/actions/Timer.java
@@ -71,7 +71,10 @@ public class Timer {
 
 	public boolean reschedule(AbstractInstant newTime) {
 		try {
-			Trigger trigger = newTrigger().startAt(newTime.toDate()).build();
+			Trigger trigger = newTrigger()
+				.forJob(jobKey) // default group
+				.startAt(newTime.toDate())
+				.build();
 			scheduler.rescheduleJob(triggerKey, trigger);
 			this.triggerKey = trigger.getKey();
 			this.cancelled = false;


### PR DESCRIPTION
The JSR223 Quartz-based timer reschedule function was not setting the job key for the new trigger. This caused the Quartz reschedule to fail and the original timer timed out at the originally schedule time. Furthermore, no future reschedules worked so that after the original timeout there were no more callbacks.

From the Quartz docs...

 > Remove (delete) the Trigger with the given key, and store the new given one - which 
> must be associated with the same job (_the new trigger must have the job name & group specified_).

I observed the behavior while debugging a motion-triggered light rule that was not working correctly. With this change, the reschedule appears to work correctly.