### PR TITLE
Updated CommandEventTrigger to support both wildcarded and specific c…

### DIFF
--- a/bundles/core/org.openhab.core.jsr223/src/main/java/org/openhab/core/jsr223/internal/engine/RuleTriggerManager.java
+++ b/bundles/core/org.openhab.core.jsr223/src/main/java/org/openhab/core/jsr223/internal/engine/RuleTriggerManager.java
@@ -183,13 +183,24 @@ public class RuleTriggerManager {
 			return timerEventTriggeredRules;
 		case UPDATE:
 		case CHANGE:
-		case COMMAND:
 			if (newType instanceof State) {
 				for (Rule rule : rules) {
 					for (EventTrigger t : rule.getEventTrigger()) {
 						if (t.evaluate(item, (State) oldType, (State) newType, null, triggerType)) {
 							result.add(rule);
 							break; // break from eventTrigger iteration
+						}
+					}
+				}
+			}
+			break;
+		case COMMAND:
+			if (newType instanceof Command) {
+				for (Rule rule : rules) {
+					for (EventTrigger t : rule.getEventTrigger()) {
+						if (t.evaluate(item, null, null, (Command) newType, triggerType)) {
+							result.add(rule);
+							break;
 						}
 					}
 				}

--- a/bundles/core/org.openhab.core.jsr223/src/main/java/org/openhab/core/jsr223/internal/shared/CommandEventTrigger.java
+++ b/bundles/core/org.openhab.core.jsr223/src/main/java/org/openhab/core/jsr223/internal/shared/CommandEventTrigger.java
@@ -29,7 +29,8 @@ public class CommandEventTrigger implements EventTrigger {
 
 	@Override
 	public boolean evaluate(Item item, State oldState, State newState, Command command, TriggerType type) {
-		return (type == TriggerType.COMMAND && this.itemName.equals(item.getName()) && command == this.command);
+		return (type == TriggerType.COMMAND && this.itemName.equals(item.getName()) && 
+				(this.command == null || command.equals(this.command)));
 	}
 
 	@Override


### PR DESCRIPTION
…ommand values.

Updated RuleTriggerManager to pass command value to CommEventTrigger evaluations.
Updated RuleTriggerManager to not stop on first rule trigger for Change/Update/Command rules.

The UPDATE/CHANGE/COMMAND switch cases were previously combined and a null command was being passed to the CommandEventTrigger evaluator. I updated the code to pass the command value for the COMMAND trigger type. I also changed the CommandEventTrigger to match on a command value or to match any command on the item if the trigger command is null.

The purpose of the previous breaks in the rule evaluation code were not clear to me and I removed them. Wouldn't we want all triggered rules to execute based on a given trigger?