### PR TITLE
Add serial transport for benqprojector binding

### DIFF
--- a/bundles/binding/org.openhab.binding.benqprojector/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.benqprojector/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Bundle-Activator: org.openhab.binding.benqprojector.internal.BenqProjectorActiva
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the BenqProjector binding of the open Home Aut
  omation Bus (openHAB)
-Import-Package: org.apache.commons.lang,
+Import-Package: gnu.io,
+ org.apache.commons.lang,
  org.openhab.core.binding,
  org.openhab.core.events,
  org.openhab.core.items,

--- a/bundles/binding/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorBinding.java
+++ b/bundles/binding/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorBinding.java
@@ -12,6 +12,7 @@ import java.util.Dictionary;
 
 import org.openhab.binding.benqprojector.BenqProjectorBindingProvider;
 import org.openhab.binding.benqprojector.internal.transport.BenqProjectorNetworkTransport;
+import org.openhab.binding.benqprojector.internal.transport.BenqProjectorSerialTransport;
 import org.openhab.binding.benqprojector.internal.transport.BenqProjectorTransport;
 
 import org.apache.commons.lang.StringUtils;
@@ -150,7 +151,7 @@ public class BenqProjectorBinding extends
 			String modeString = (String) config.get("mode");
 			if (StringUtils.isNotBlank(modeString)) {
 				if (modeString.equalsIgnoreCase("serial")) {
-					// TODO assign serial transport when implemented
+					transport = new BenqProjectorSerialTransport();
 				} else {
 					/* default to network */
 					transport = new BenqProjectorNetworkTransport();

--- a/bundles/binding/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/transport/BenqProjectorSerialTransport.java
+++ b/bundles/binding/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/transport/BenqProjectorSerialTransport.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.benqprojector.internal.transport;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+
+import gnu.io.NRSerialPort;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Implement the serial based transport for communicating with a Benq projector
+ * 
+ * @author Kristian Larsson (kll)
+ * @since 1.8.0
+ */
+public class BenqProjectorSerialTransport implements BenqProjectorTransport {
+
+	private static final Logger logger = LoggerFactory
+			.getLogger(BenqProjectorSerialTransport.class);
+
+	/**
+	 * Serial device to use
+	 */
+	private String serialDevice = "";
+	// TODO: what should default be?
+	private int serialSpeed = 57600;
+
+	private NRSerialPort serialPort = null;
+	private PrintWriter projectorWriter = null;
+	private BufferedReader projectorReader = null;
+	private boolean retryAttempt = false;
+
+	private boolean serialConnect() {
+		logger.debug("Running connection setup");
+		try {
+			logger.debug("Setting up socket connection to " + this.serialDevice);
+			this.serialPort = new NRSerialPort(this.serialDevice, this.serialSpeed);
+			this.serialPort.connect();
+
+			this.projectorReader = new BufferedReader(new InputStreamReader(this.serialPort.getInputStream()));
+			this.projectorWriter = new PrintWriter(
+					this.serialPort.getOutputStream(), true);
+
+			logger.debug("Serial connection setup successfully!");
+			return true;
+		} catch (Exception e) {
+			logger.error("Unable to connect to device: " + this.serialDevice, e);
+		}
+		return false;
+	}
+
+	@Override
+	public boolean setupConnection(String connectionParams) {
+		boolean setupOK = false;
+		if (this.serialPort == null) {
+			/* parse connection paramters in the format device:speed */
+			String[] deviceIdParts = connectionParams.split(":");
+			if (deviceIdParts.length == 1) {
+				logger.debug("Using default speed: " + this.serialSpeed);
+				this.serialDevice = deviceIdParts[0];
+			} else if (deviceIdParts.length == 2) {
+				this.serialDevice = deviceIdParts[0];
+				this.serialSpeed = Integer.parseInt(deviceIdParts[1]);
+			} else {
+				return false;
+			}
+
+			setupOK = this.serialConnect();
+		} else {
+			logger.debug("Port is already setup");
+		}
+		return setupOK;
+	}
+
+	@Override
+	public void closeConnection() {
+		try {
+			this.serialPort.disconnect();
+		} catch (Exception e) {
+			logger.error("Trying to close socket resulted in IO exception: "
+					+ e.getMessage());
+		}
+		this.serialPort = null;
+	}
+
+	@Override
+	public String sendCommandExpectResponse(String cmd) {
+		String respStr = "";
+		String tmp;
+		if (this.projectorWriter != null) {
+			this.projectorWriter.printf("%s", cmd);
+			logger.debug("Sent command '" + cmd.replace("\r", "") + "'");
+			try {
+				tmp = this.projectorReader.readLine();
+				while (tmp != null) {
+					if (tmp.startsWith("*") == true && tmp.endsWith("#")) {
+						/* got response */
+						logger.debug("Response: '" + tmp + "'");
+						respStr = tmp;
+						break;
+					}
+					tmp = this.projectorReader.readLine();
+				}
+			} catch (Exception e) {
+				logger.error("IO Exception while reading response from projector: "
+						+ e.getMessage());
+				if (retryAttempt == false) {
+					this.closeConnection();
+					if (this.serialConnect()) {
+						logger.debug("Reconnect successful - retrying transmission");
+						/* set flag to stop us ending up here again and so avoid infinite recursion */
+						retryAttempt = true;
+						sendCommandExpectResponse(cmd);						
+					} else {
+						logger.error("Attempt to reconnect after IOException failed: "
+								+ e.getMessage());
+					}
+					/* reset flag */
+					retryAttempt = false;
+				}
+			} 
+		} else {
+			logger.debug("Not sending command to projector as connection is not setup yet.");
+		}
+
+		return respStr;
+	}
+
+}


### PR DESCRIPTION
This adds a serial transport for the benqprojector binding. Verified working with my Benq W1070 projector!

It is largely copied from the network transport but uses NRSerial to communicate directly over a serial port. The NRSerial library is already included in OpenHAB and used by other modules so I figured it was a no-brainer to rely on it over other modules (I actually thought of jssc before realising that something was included).

This is my first contribution to OpenHAB so apologies if I've missed to follow some contribution guidelines or similar.