### PR TITLE
InsteonPLM: fixed bug with handling of thermostat temperature status messages

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
@@ -518,7 +518,7 @@
 	<!-- handles direct extended message after query -->
 	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x02" match_d1="0x01" low_byte="userData10" high_byte="userData9" factor="0.1">NumberMsgHandler</message-handler>
 	<!-- handles out-of band status messages -->
-	<message-handler cmd="0x6e" ext="0" match_cmd1="0x6e" low_byte="command2" factor="0.5">NumberMsgHandler</message-handler>
+	<message-handler cmd="0x6e" ext="0" match_cmd1="0x6e" low_byte="command2" offset="-17.7777778" factor="0.2777778">NumberMsgHandler</message-handler>
 	<message-handler default="true">NoOpMsgHandler</message-handler>
 	<command-handler default="true">NoOpCommandHandler</command-handler>
 	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData2Group -->
@@ -528,7 +528,7 @@
 	<!-- handles direct extended message after query -->
 	<message-handler cmd="0x2e" ext="1" match_cmd1="0x2e" match_cmd2="0x02" match_d1="0x01" low_byte="userData10" high_byte="userData9" offset="32" factor="0.18">NumberMsgHandler</message-handler>
 	<!-- handles out-of band status messages -->
-	<message-handler cmd="0x6e" ext="0" match_cmd1="0x6e" low_byte="command2" offset="32" factor="0.9">NumberMsgHandler</message-handler>
+	<message-handler cmd="0x6e" ext="0" match_cmd1="0x6e" low_byte="command2" offset="0" factor="0.5">NumberMsgHandler</message-handler>
 	<message-handler default="true">NoOpMsgHandler</message-handler>
 	<command-handler default="true">NoOpCommandHandler</command-handler>
 	<poll-handler>NoPollHandler</poll-handler> <!-- polled by ThermostatData2Group -->


### PR DESCRIPTION
This pull request fixes a bug that causes outliers in thermostat temperature data due to incorrect parsing of status messages (0x6E).

I have tested the fix with my thermostat and the temperature status messages are now parsed correctly.
