### PR TITLE
Tinkerforge binding: add I2CMode setting to the BrickletTemperature configuration

### DIFF
--- a/bundles/binding/org.openhab.binding.tinkerforge/model/tinkerforge.xcore
+++ b/bundles/binding/org.openhab.binding.tinkerforge/model/tinkerforge.xcore
@@ -595,10 +595,11 @@ class PTCConnected extends PTCDevice, MSensor<DigitalValue> {
 }
 
 class MBrickletTemperature extends MDevice<MTinkerBrickletTemperature>, 
-		MSensor<MDecimalValue>, MTFConfigConsumer<TFBaseConfiguration>, 
+		MSensor<MDecimalValue>, MTFConfigConsumer<TFTemperatureConfiguration>, 
 		CallbackListener {
 	readonly String deviceType = "bricklet_temperature"
 	BigDecimal threshold = "0.1"
+	boolean slowI2C = "false"
 	op void init(){}
 }
 
@@ -775,6 +776,9 @@ class TFBaseConfiguration extends TFConfig {
 	int callbackPeriod
 }
 
+class TFTemperatureConfiguration extends TFBaseConfiguration {
+	boolean slowI2C
+}
 class TFObjectTemperatureConfiguration extends TFBaseConfiguration {
     int emissivity
 }

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/config/ConfigurationHandler.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/config/ConfigurationHandler.java
@@ -68,6 +68,7 @@ import org.openhab.binding.tinkerforge.internal.model.TFMoistureBrickletConfigur
 import org.openhab.binding.tinkerforge.internal.model.TFObjectTemperatureConfiguration;
 import org.openhab.binding.tinkerforge.internal.model.TFPTCBrickletConfiguration;
 import org.openhab.binding.tinkerforge.internal.model.TFServoConfiguration;
+import org.openhab.binding.tinkerforge.internal.model.TFTemperatureConfiguration;
 import org.openhab.binding.tinkerforge.internal.model.TFVoltageCurrentConfiguration;
 import org.openhab.binding.tinkerforge.internal.model.TemperatureIRSubIds;
 import org.openhab.binding.tinkerforge.internal.model.VoltageCurrentSubIds;
@@ -232,7 +233,6 @@ public class ConfigurationHandler {
       fillupConfig(ohtfDevice, deviceConfig);
     } else if (deviceType.equals(TypeKey.bricklet_distance_ir.name())
         || deviceType.equals(TypeKey.bricklet_humidity.name())
-        || deviceType.equals(TypeKey.bricklet_temperature.name())
         || deviceType.equals(TypeKey.bricklet_barometer.name())
         || deviceType.equals(TypeKey.bricklet_ambient_light.name())
         || deviceType.equals(TypeKey.ambient_temperature.name())
@@ -524,6 +524,12 @@ public class ConfigurationHandler {
       logger.trace("{} deviceType {}", LoggerConstants.CONFIG, deviceType);
       OHTFDevice<?, IndustrialDigitalOutSubIDs> ohtfDevice = modelFactory.createOHTFDevice();
       ohtfDevice.getSubDeviceIds().addAll(Arrays.asList(IndustrialDigitalOutSubIDs.values()));
+      fillupConfig(ohtfDevice, deviceConfig);
+    } else if (deviceType.equals(TypeKey.bricklet_temperature.name())) {
+      TFTemperatureConfiguration configuration = modelFactory.createTFTemperatureConfiguration();
+      OHTFDevice<TFTemperatureConfiguration, NoSubIds> ohtfDevice = modelFactory.createOHTFDevice();
+      ohtfDevice.getSubDeviceIds().addAll(Arrays.asList(NoSubIds.values()));
+      ohtfDevice.setTfConfig(configuration);
       fillupConfig(ohtfDevice, deviceConfig);
     } else {
       logger.debug("{} setting no tfConfig device_type {}", LoggerConstants.CONFIG, deviceType);

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/MBrickletTemperature.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/MBrickletTemperature.java
@@ -28,14 +28,15 @@ import org.openhab.binding.tinkerforge.internal.types.DecimalValue;
  * <ul>
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.MBrickletTemperature#getDeviceType <em>Device Type</em>}</li>
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.MBrickletTemperature#getThreshold <em>Threshold</em>}</li>
+ *   <li>{@link org.openhab.binding.tinkerforge.internal.model.MBrickletTemperature#isSlowI2C <em>Slow I2C</em>}</li>
  * </ul>
  * </p>
  *
  * @see org.openhab.binding.tinkerforge.internal.model.ModelPackage#getMBrickletTemperature()
- * @model superTypes="org.openhab.binding.tinkerforge.internal.model.MDevice<org.openhab.binding.tinkerforge.internal.model.MTinkerBrickletTemperature> org.openhab.binding.tinkerforge.internal.model.MSensor<org.openhab.binding.tinkerforge.internal.model.MDecimalValue> org.openhab.binding.tinkerforge.internal.model.MTFConfigConsumer<org.openhab.binding.tinkerforge.internal.model.TFBaseConfiguration> org.openhab.binding.tinkerforge.internal.model.CallbackListener"
+ * @model superTypes="org.openhab.binding.tinkerforge.internal.model.MDevice<org.openhab.binding.tinkerforge.internal.model.MTinkerBrickletTemperature> org.openhab.binding.tinkerforge.internal.model.MSensor<org.openhab.binding.tinkerforge.internal.model.MDecimalValue> org.openhab.binding.tinkerforge.internal.model.MTFConfigConsumer<org.openhab.binding.tinkerforge.internal.model.TFTemperatureConfiguration> org.openhab.binding.tinkerforge.internal.model.CallbackListener"
  * @generated
  */
-public interface MBrickletTemperature extends MDevice<BrickletTemperature>, MSensor<DecimalValue>, MTFConfigConsumer<TFBaseConfiguration>, CallbackListener
+public interface MBrickletTemperature extends MDevice<BrickletTemperature>, MSensor<DecimalValue>, MTFConfigConsumer<TFTemperatureConfiguration>, CallbackListener
 {
   /**
    * Returns the value of the '<em><b>Device Type</b></em>' attribute.
@@ -79,6 +80,33 @@ public interface MBrickletTemperature extends MDevice<BrickletTemperature>, MSen
    * @generated
    */
   void setThreshold(BigDecimal value);
+
+  /**
+   * Returns the value of the '<em><b>Slow I2C</b></em>' attribute.
+   * The default value is <code>"false"</code>.
+   * <!-- begin-user-doc -->
+   * <p>
+   * If the meaning of the '<em>Slow I2C</em>' attribute isn't clear,
+   * there really should be more of a description here...
+   * </p>
+   * <!-- end-user-doc -->
+   * @return the value of the '<em>Slow I2C</em>' attribute.
+   * @see #setSlowI2C(boolean)
+   * @see org.openhab.binding.tinkerforge.internal.model.ModelPackage#getMBrickletTemperature_SlowI2C()
+   * @model default="false" unique="false"
+   * @generated
+   */
+  boolean isSlowI2C();
+
+  /**
+   * Sets the value of the '{@link org.openhab.binding.tinkerforge.internal.model.MBrickletTemperature#isSlowI2C <em>Slow I2C</em>}' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @param value the new value of the '<em>Slow I2C</em>' attribute.
+   * @see #isSlowI2C()
+   * @generated
+   */
+  void setSlowI2C(boolean value);
 
   /**
    * <!-- begin-user-doc -->

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/ModelFactory.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/ModelFactory.java
@@ -764,6 +764,15 @@ public interface ModelFactory extends EFactory
   TFBaseConfiguration createTFBaseConfiguration();
 
   /**
+   * Returns a new object of class '<em>TF Temperature Configuration</em>'.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @return a new object of class '<em>TF Temperature Configuration</em>'.
+   * @generated
+   */
+  TFTemperatureConfiguration createTFTemperatureConfiguration();
+
+  /**
    * Returns a new object of class '<em>TF Object Temperature Configuration</em>'.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/ModelPackage.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/ModelPackage.java
@@ -188,7 +188,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTFBrickDCConfiguration()
    * @generated
    */
-  int TF_BRICK_DC_CONFIGURATION = 112;
+  int TF_BRICK_DC_CONFIGURATION = 113;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.MDualRelayBrickletImpl <em>MDual Relay Bricklet</em>}' class.
@@ -298,7 +298,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTFIOActorConfiguration()
    * @generated
    */
-  int TFIO_ACTOR_CONFIGURATION = 113;
+  int TFIO_ACTOR_CONFIGURATION = 114;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.MBrickletIO16Impl <em>MBricklet IO16</em>}' class.
@@ -338,7 +338,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTFInterruptListenerConfiguration()
    * @generated
    */
-  int TF_INTERRUPT_LISTENER_CONFIGURATION = 114;
+  int TF_INTERRUPT_LISTENER_CONFIGURATION = 115;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.TFIOSensorConfigurationImpl <em>TFIO Sensor Configuration</em>}' class.
@@ -348,7 +348,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTFIOSensorConfiguration()
    * @generated
    */
-  int TFIO_SENSOR_CONFIGURATION = 115;
+  int TFIO_SENSOR_CONFIGURATION = 116;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.MDualRelayImpl <em>MDual Relay</em>}' class.
@@ -378,7 +378,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTFServoConfiguration()
    * @generated
    */
-  int TF_SERVO_CONFIGURATION = 116;
+  int TF_SERVO_CONFIGURATION = 117;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.MServoImpl <em>MServo</em>}' class.
@@ -11570,13 +11570,22 @@ public interface ModelPackage extends EPackage
   int MBRICKLET_TEMPERATURE__THRESHOLD = MDEVICE_FEATURE_COUNT + 4;
 
   /**
+   * The feature id for the '<em><b>Slow I2C</b></em>' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int MBRICKLET_TEMPERATURE__SLOW_I2C = MDEVICE_FEATURE_COUNT + 5;
+
+  /**
    * The number of structural features of the '<em>MBricklet Temperature</em>' class.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
    * @generated
    * @ordered
    */
-  int MBRICKLET_TEMPERATURE_FEATURE_COUNT = MDEVICE_FEATURE_COUNT + 5;
+  int MBRICKLET_TEMPERATURE_FEATURE_COUNT = MDEVICE_FEATURE_COUNT + 6;
 
   /**
    * The operation id for the '<em>Enable</em>' operation.
@@ -15395,6 +15404,61 @@ public interface ModelPackage extends EPackage
   int TF_BASE_CONFIGURATION_OPERATION_COUNT = TF_CONFIG_OPERATION_COUNT + 0;
 
   /**
+   * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.TFTemperatureConfigurationImpl <em>TF Temperature Configuration</em>}' class.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see org.openhab.binding.tinkerforge.internal.model.impl.TFTemperatureConfigurationImpl
+   * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTFTemperatureConfiguration()
+   * @generated
+   */
+  int TF_TEMPERATURE_CONFIGURATION = 108;
+
+  /**
+   * The feature id for the '<em><b>Threshold</b></em>' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int TF_TEMPERATURE_CONFIGURATION__THRESHOLD = TF_BASE_CONFIGURATION__THRESHOLD;
+
+  /**
+   * The feature id for the '<em><b>Callback Period</b></em>' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int TF_TEMPERATURE_CONFIGURATION__CALLBACK_PERIOD = TF_BASE_CONFIGURATION__CALLBACK_PERIOD;
+
+  /**
+   * The feature id for the '<em><b>Slow I2C</b></em>' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int TF_TEMPERATURE_CONFIGURATION__SLOW_I2C = TF_BASE_CONFIGURATION_FEATURE_COUNT + 0;
+
+  /**
+   * The number of structural features of the '<em>TF Temperature Configuration</em>' class.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int TF_TEMPERATURE_CONFIGURATION_FEATURE_COUNT = TF_BASE_CONFIGURATION_FEATURE_COUNT + 1;
+
+  /**
+   * The number of operations of the '<em>TF Temperature Configuration</em>' class.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int TF_TEMPERATURE_CONFIGURATION_OPERATION_COUNT = TF_BASE_CONFIGURATION_OPERATION_COUNT + 0;
+
+  /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.TFObjectTemperatureConfigurationImpl <em>TF Object Temperature Configuration</em>}' class.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
@@ -15402,7 +15466,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTFObjectTemperatureConfiguration()
    * @generated
    */
-  int TF_OBJECT_TEMPERATURE_CONFIGURATION = 108;
+  int TF_OBJECT_TEMPERATURE_CONFIGURATION = 109;
 
   /**
    * The feature id for the '<em><b>Threshold</b></em>' attribute.
@@ -15457,7 +15521,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTFMoistureBrickletConfiguration()
    * @generated
    */
-  int TF_MOISTURE_BRICKLET_CONFIGURATION = 109;
+  int TF_MOISTURE_BRICKLET_CONFIGURATION = 110;
 
   /**
    * The feature id for the '<em><b>Threshold</b></em>' attribute.
@@ -15512,7 +15576,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTFDistanceUSBrickletConfiguration()
    * @generated
    */
-  int TF_DISTANCE_US_BRICKLET_CONFIGURATION = 110;
+  int TF_DISTANCE_US_BRICKLET_CONFIGURATION = 111;
 
   /**
    * The feature id for the '<em><b>Threshold</b></em>' attribute.
@@ -15567,7 +15631,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTFVoltageCurrentConfiguration()
    * @generated
    */
-  int TF_VOLTAGE_CURRENT_CONFIGURATION = 111;
+  int TF_VOLTAGE_CURRENT_CONFIGURATION = 112;
 
   /**
    * The feature id for the '<em><b>Averaging</b></em>' attribute.
@@ -15622,7 +15686,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getBrickletRemoteSwitchConfiguration()
    * @generated
    */
-  int BRICKLET_REMOTE_SWITCH_CONFIGURATION = 117;
+  int BRICKLET_REMOTE_SWITCH_CONFIGURATION = 118;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.RemoteSwitchAConfigurationImpl <em>Remote Switch AConfiguration</em>}' class.
@@ -15632,7 +15696,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getRemoteSwitchAConfiguration()
    * @generated
    */
-  int REMOTE_SWITCH_ACONFIGURATION = 118;
+  int REMOTE_SWITCH_ACONFIGURATION = 119;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.RemoteSwitchBConfigurationImpl <em>Remote Switch BConfiguration</em>}' class.
@@ -15642,7 +15706,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getRemoteSwitchBConfiguration()
    * @generated
    */
-  int REMOTE_SWITCH_BCONFIGURATION = 119;
+  int REMOTE_SWITCH_BCONFIGURATION = 120;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.RemoteSwitchCConfigurationImpl <em>Remote Switch CConfiguration</em>}' class.
@@ -15652,7 +15716,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getRemoteSwitchCConfiguration()
    * @generated
    */
-  int REMOTE_SWITCH_CCONFIGURATION = 120;
+  int REMOTE_SWITCH_CCONFIGURATION = 121;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.MultiTouchDeviceConfigurationImpl <em>Multi Touch Device Configuration</em>}' class.
@@ -15662,7 +15726,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMultiTouchDeviceConfiguration()
    * @generated
    */
-  int MULTI_TOUCH_DEVICE_CONFIGURATION = 121;
+  int MULTI_TOUCH_DEVICE_CONFIGURATION = 122;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.BrickletMultiTouchConfigurationImpl <em>Bricklet Multi Touch Configuration</em>}' class.
@@ -15672,7 +15736,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getBrickletMultiTouchConfiguration()
    * @generated
    */
-  int BRICKLET_MULTI_TOUCH_CONFIGURATION = 122;
+  int BRICKLET_MULTI_TOUCH_CONFIGURATION = 123;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.DimmableConfigurationImpl <em>Dimmable Configuration</em>}' class.
@@ -15682,7 +15746,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDimmableConfiguration()
    * @generated
    */
-  int DIMMABLE_CONFIGURATION = 123;
+  int DIMMABLE_CONFIGURATION = 124;
 
   /**
    * The feature id for the '<em><b>Min Value</b></em>' attribute.
@@ -16268,7 +16332,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getButtonConfiguration()
    * @generated
    */
-  int BUTTON_CONFIGURATION = 124;
+  int BUTTON_CONFIGURATION = 125;
 
   /**
    * The feature id for the '<em><b>Tactile</b></em>' attribute.
@@ -16305,7 +16369,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDualButtonLEDConfiguration()
    * @generated
    */
-  int DUAL_BUTTON_LED_CONFIGURATION = 125;
+  int DUAL_BUTTON_LED_CONFIGURATION = 126;
 
   /**
    * The feature id for the '<em><b>Autotoggle</b></em>' attribute.
@@ -16342,7 +16406,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getLEDStripConfiguration()
    * @generated
    */
-  int LED_STRIP_CONFIGURATION = 126;
+  int LED_STRIP_CONFIGURATION = 127;
 
   /**
    * The feature id for the '<em><b>Chiptype</b></em>' attribute.
@@ -16415,7 +16479,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getLEDGroupConfiguration()
    * @generated
    */
-  int LED_GROUP_CONFIGURATION = 127;
+  int LED_GROUP_CONFIGURATION = 128;
 
   /**
    * The feature id for the '<em><b>Leds</b></em>' attribute.
@@ -16452,7 +16516,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getSwitchState()
    * @generated
    */
-  int SWITCH_STATE = 164;
+  int SWITCH_STATE = 165;
 
   /**
    * The meta object id for the '<em>Digital Value</em>' data type.
@@ -16462,7 +16526,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDigitalValue()
    * @generated
    */
-  int DIGITAL_VALUE = 165;
+  int DIGITAL_VALUE = 166;
 
   /**
    * The meta object id for the '<em>HSB Value</em>' data type.
@@ -16472,7 +16536,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getHSBValue()
    * @generated
    */
-  int HSB_VALUE = 166;
+  int HSB_VALUE = 167;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet IO16</em>' data type.
@@ -16482,7 +16546,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletIO16()
    * @generated
    */
-  int TINKER_BRICKLET_IO16 = 167;
+  int TINKER_BRICKLET_IO16 = 168;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.DCDriveMode <em>DC Drive Mode</em>}' enum.
@@ -16492,7 +16556,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDCDriveMode()
    * @generated
    */
-  int DC_DRIVE_MODE = 146;
+  int DC_DRIVE_MODE = 147;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.ConfigOptsServo <em>Config Opts Servo</em>}' enum.
@@ -16502,7 +16566,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getConfigOptsServo()
    * @generated
    */
-  int CONFIG_OPTS_SERVO = 147;
+  int CONFIG_OPTS_SERVO = 148;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.DualButtonDevicePosition <em>Dual Button Device Position</em>}' enum.
@@ -16512,7 +16576,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDualButtonDevicePosition()
    * @generated
    */
-  int DUAL_BUTTON_DEVICE_POSITION = 148;
+  int DUAL_BUTTON_DEVICE_POSITION = 149;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.DualButtonLedSubIds <em>Dual Button Led Sub Ids</em>}' enum.
@@ -16522,7 +16586,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDualButtonLedSubIds()
    * @generated
    */
-  int DUAL_BUTTON_LED_SUB_IDS = 149;
+  int DUAL_BUTTON_LED_SUB_IDS = 150;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.DualButtonButtonSubIds <em>Dual Button Button Sub Ids</em>}' enum.
@@ -16532,7 +16596,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDualButtonButtonSubIds()
    * @generated
    */
-  int DUAL_BUTTON_BUTTON_SUB_IDS = 150;
+  int DUAL_BUTTON_BUTTON_SUB_IDS = 151;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.JoystickSubIds <em>Joystick Sub Ids</em>}' enum.
@@ -16542,7 +16606,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getJoystickSubIds()
    * @generated
    */
-  int JOYSTICK_SUB_IDS = 151;
+  int JOYSTICK_SUB_IDS = 152;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.PTCSubIds <em>PTC Sub Ids</em>}' enum.
@@ -16552,7 +16616,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getPTCSubIds()
    * @generated
    */
-  int PTC_SUB_IDS = 152;
+  int PTC_SUB_IDS = 153;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.IndustrialDual020mASubIds <em>Industrial Dual020m ASub Ids</em>}' enum.
@@ -16562,7 +16626,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getIndustrialDual020mASubIds()
    * @generated
    */
-  int INDUSTRIAL_DUAL020M_ASUB_IDS = 153;
+  int INDUSTRIAL_DUAL020M_ASUB_IDS = 154;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.NoSubIds <em>No Sub Ids</em>}' enum.
@@ -16572,7 +16636,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getNoSubIds()
    * @generated
    */
-  int NO_SUB_IDS = 128;
+  int NO_SUB_IDS = 129;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.IndustrialDigitalInSubIDs <em>Industrial Digital In Sub IDs</em>}' enum.
@@ -16582,7 +16646,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getIndustrialDigitalInSubIDs()
    * @generated
    */
-  int INDUSTRIAL_DIGITAL_IN_SUB_IDS = 129;
+  int INDUSTRIAL_DIGITAL_IN_SUB_IDS = 130;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.IndustrialDigitalOutSubIDs <em>Industrial Digital Out Sub IDs</em>}' enum.
@@ -16592,7 +16656,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getIndustrialDigitalOutSubIDs()
    * @generated
    */
-  int INDUSTRIAL_DIGITAL_OUT_SUB_IDS = 130;
+  int INDUSTRIAL_DIGITAL_OUT_SUB_IDS = 131;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.IndustrialQuadRelayIDs <em>Industrial Quad Relay IDs</em>}' enum.
@@ -16602,7 +16666,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getIndustrialQuadRelayIDs()
    * @generated
    */
-  int INDUSTRIAL_QUAD_RELAY_IDS = 131;
+  int INDUSTRIAL_QUAD_RELAY_IDS = 132;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.ServoSubIDs <em>Servo Sub IDs</em>}' enum.
@@ -16612,7 +16676,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getServoSubIDs()
    * @generated
    */
-  int SERVO_SUB_IDS = 132;
+  int SERVO_SUB_IDS = 133;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.BarometerSubIDs <em>Barometer Sub IDs</em>}' enum.
@@ -16622,7 +16686,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getBarometerSubIDs()
    * @generated
    */
-  int BAROMETER_SUB_IDS = 133;
+  int BAROMETER_SUB_IDS = 134;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.IO16SubIds <em>IO16 Sub Ids</em>}' enum.
@@ -16632,7 +16696,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getIO16SubIds()
    * @generated
    */
-  int IO16_SUB_IDS = 134;
+  int IO16_SUB_IDS = 135;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.IO4SubIds <em>IO4 Sub Ids</em>}' enum.
@@ -16642,7 +16706,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getIO4SubIds()
    * @generated
    */
-  int IO4_SUB_IDS = 135;
+  int IO4_SUB_IDS = 136;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.DualRelaySubIds <em>Dual Relay Sub Ids</em>}' enum.
@@ -16652,7 +16716,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDualRelaySubIds()
    * @generated
    */
-  int DUAL_RELAY_SUB_IDS = 136;
+  int DUAL_RELAY_SUB_IDS = 137;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.LCDButtonSubIds <em>LCD Button Sub Ids</em>}' enum.
@@ -16662,7 +16726,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getLCDButtonSubIds()
    * @generated
    */
-  int LCD_BUTTON_SUB_IDS = 137;
+  int LCD_BUTTON_SUB_IDS = 138;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.LCDBacklightSubIds <em>LCD Backlight Sub Ids</em>}' enum.
@@ -16672,7 +16736,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getLCDBacklightSubIds()
    * @generated
    */
-  int LCD_BACKLIGHT_SUB_IDS = 138;
+  int LCD_BACKLIGHT_SUB_IDS = 139;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.MultiTouchSubIds <em>Multi Touch Sub Ids</em>}' enum.
@@ -16682,7 +16746,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMultiTouchSubIds()
    * @generated
    */
-  int MULTI_TOUCH_SUB_IDS = 139;
+  int MULTI_TOUCH_SUB_IDS = 140;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.TemperatureIRSubIds <em>Temperature IR Sub Ids</em>}' enum.
@@ -16692,7 +16756,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTemperatureIRSubIds()
    * @generated
    */
-  int TEMPERATURE_IR_SUB_IDS = 140;
+  int TEMPERATURE_IR_SUB_IDS = 141;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.VoltageCurrentSubIds <em>Voltage Current Sub Ids</em>}' enum.
@@ -16702,7 +16766,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getVoltageCurrentSubIds()
    * @generated
    */
-  int VOLTAGE_CURRENT_SUB_IDS = 141;
+  int VOLTAGE_CURRENT_SUB_IDS = 142;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.ConfigOptsMove <em>Config Opts Move</em>}' enum.
@@ -16712,7 +16776,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getConfigOptsMove()
    * @generated
    */
-  int CONFIG_OPTS_MOVE = 142;
+  int CONFIG_OPTS_MOVE = 143;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.ConfigOptsDimmable <em>Config Opts Dimmable</em>}' enum.
@@ -16722,7 +16786,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getConfigOptsDimmable()
    * @generated
    */
-  int CONFIG_OPTS_DIMMABLE = 143;
+  int CONFIG_OPTS_DIMMABLE = 144;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.ConfigOptsSetPoint <em>Config Opts Set Point</em>}' enum.
@@ -16732,7 +16796,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getConfigOptsSetPoint()
    * @generated
    */
-  int CONFIG_OPTS_SET_POINT = 144;
+  int CONFIG_OPTS_SET_POINT = 145;
 
   /**
    * The meta object id for the '{@link org.openhab.binding.tinkerforge.internal.model.ConfigOptsSwitchSpeed <em>Config Opts Switch Speed</em>}' enum.
@@ -16742,7 +16806,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getConfigOptsSwitchSpeed()
    * @generated
    */
-  int CONFIG_OPTS_SWITCH_SPEED = 145;
+  int CONFIG_OPTS_SWITCH_SPEED = 146;
 
   /**
    * The meta object id for the '<em>MIP Connection</em>' data type.
@@ -16752,7 +16816,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMIPConnection()
    * @generated
    */
-  int MIP_CONNECTION = 154;
+  int MIP_CONNECTION = 155;
 
   /**
    * The meta object id for the '<em>MTinker Device</em>' data type.
@@ -16762,7 +16826,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerDevice()
    * @generated
    */
-  int MTINKER_DEVICE = 155;
+  int MTINKER_DEVICE = 156;
 
   /**
    * The meta object id for the '<em>MLogger</em>' data type.
@@ -16772,7 +16836,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMLogger()
    * @generated
    */
-  int MLOGGER = 156;
+  int MLOGGER = 157;
 
 
   /**
@@ -16783,7 +16847,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMAtomicBoolean()
    * @generated
    */
-  int MATOMIC_BOOLEAN = 157;
+  int MATOMIC_BOOLEAN = 158;
 
   /**
    * The meta object id for the '<em>MTinkerforge Device</em>' data type.
@@ -16793,7 +16857,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerforgeDevice()
    * @generated
    */
-  int MTINKERFORGE_DEVICE = 158;
+  int MTINKERFORGE_DEVICE = 159;
 
   /**
    * The meta object id for the '<em>MTinker Brick DC</em>' data type.
@@ -16803,7 +16867,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickDC()
    * @generated
    */
-  int MTINKER_BRICK_DC = 159;
+  int MTINKER_BRICK_DC = 160;
 
   /**
    * The meta object id for the '<em>MTinker Brick Servo</em>' data type.
@@ -16813,7 +16877,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickServo()
    * @generated
    */
-  int MTINKER_BRICK_SERVO = 168;
+  int MTINKER_BRICK_SERVO = 169;
 
 
   /**
@@ -16824,7 +16888,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerforgeValue()
    * @generated
    */
-  int MTINKERFORGE_VALUE = 169;
+  int MTINKERFORGE_VALUE = 170;
 
   /**
    * The meta object id for the '<em>MDecimal Value</em>' data type.
@@ -16834,7 +16898,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMDecimalValue()
    * @generated
    */
-  int MDECIMAL_VALUE = 170;
+  int MDECIMAL_VALUE = 171;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet Humidity</em>' data type.
@@ -16844,7 +16908,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletHumidity()
    * @generated
    */
-  int MTINKER_BRICKLET_HUMIDITY = 171;
+  int MTINKER_BRICKLET_HUMIDITY = 172;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet Distance IR</em>' data type.
@@ -16854,7 +16918,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletDistanceIR()
    * @generated
    */
-  int MTINKER_BRICKLET_DISTANCE_IR = 172;
+  int MTINKER_BRICKLET_DISTANCE_IR = 173;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet Temperature</em>' data type.
@@ -16864,7 +16928,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletTemperature()
    * @generated
    */
-  int MTINKER_BRICKLET_TEMPERATURE = 173;
+  int MTINKER_BRICKLET_TEMPERATURE = 174;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet Barometer</em>' data type.
@@ -16874,7 +16938,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletBarometer()
    * @generated
    */
-  int MTINKER_BRICKLET_BAROMETER = 174;
+  int MTINKER_BRICKLET_BAROMETER = 175;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet Ambient Light</em>' data type.
@@ -16884,7 +16948,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletAmbientLight()
    * @generated
    */
-  int MTINKER_BRICKLET_AMBIENT_LIGHT = 175;
+  int MTINKER_BRICKLET_AMBIENT_LIGHT = 176;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet LCD2 0x4</em>' data type.
@@ -16894,7 +16958,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletLCD20x4()
    * @generated
    */
-  int MTINKER_BRICKLET_LCD2_0X4 = 176;
+  int MTINKER_BRICKLET_LCD2_0X4 = 177;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Remote Switch</em>' data type.
@@ -16904,7 +16968,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletRemoteSwitch()
    * @generated
    */
-  int TINKER_BRICKLET_REMOTE_SWITCH = 177;
+  int TINKER_BRICKLET_REMOTE_SWITCH = 178;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Motion Detector</em>' data type.
@@ -16914,7 +16978,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletMotionDetector()
    * @generated
    */
-  int TINKER_BRICKLET_MOTION_DETECTOR = 178;
+  int TINKER_BRICKLET_MOTION_DETECTOR = 179;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Multi Touch</em>' data type.
@@ -16924,7 +16988,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletMultiTouch()
    * @generated
    */
-  int TINKER_BRICKLET_MULTI_TOUCH = 179;
+  int TINKER_BRICKLET_MULTI_TOUCH = 180;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Temperature IR</em>' data type.
@@ -16934,7 +16998,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletTemperatureIR()
    * @generated
    */
-  int TINKER_BRICKLET_TEMPERATURE_IR = 180;
+  int TINKER_BRICKLET_TEMPERATURE_IR = 181;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Sound Intensity</em>' data type.
@@ -16944,7 +17008,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletSoundIntensity()
    * @generated
    */
-  int TINKER_BRICKLET_SOUND_INTENSITY = 181;
+  int TINKER_BRICKLET_SOUND_INTENSITY = 182;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Moisture</em>' data type.
@@ -16954,7 +17018,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletMoisture()
    * @generated
    */
-  int TINKER_BRICKLET_MOISTURE = 182;
+  int TINKER_BRICKLET_MOISTURE = 183;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Distance US</em>' data type.
@@ -16964,7 +17028,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletDistanceUS()
    * @generated
    */
-  int TINKER_BRICKLET_DISTANCE_US = 183;
+  int TINKER_BRICKLET_DISTANCE_US = 184;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Voltage Current</em>' data type.
@@ -16974,7 +17038,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletVoltageCurrent()
    * @generated
    */
-  int TINKER_BRICKLET_VOLTAGE_CURRENT = 184;
+  int TINKER_BRICKLET_VOLTAGE_CURRENT = 185;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Tilt</em>' data type.
@@ -16984,7 +17048,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletTilt()
    * @generated
    */
-  int TINKER_BRICKLET_TILT = 185;
+  int TINKER_BRICKLET_TILT = 186;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet IO4</em>' data type.
@@ -16994,7 +17058,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletIO4()
    * @generated
    */
-  int TINKER_BRICKLET_IO4 = 186;
+  int TINKER_BRICKLET_IO4 = 187;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Hall Effect</em>' data type.
@@ -17004,7 +17068,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletHallEffect()
    * @generated
    */
-  int TINKER_BRICKLET_HALL_EFFECT = 187;
+  int TINKER_BRICKLET_HALL_EFFECT = 188;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Segment Display4x7</em>' data type.
@@ -17014,7 +17078,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletSegmentDisplay4x7()
    * @generated
    */
-  int TINKER_BRICKLET_SEGMENT_DISPLAY4X7 = 188;
+  int TINKER_BRICKLET_SEGMENT_DISPLAY4X7 = 189;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet LED Strip</em>' data type.
@@ -17024,7 +17088,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletLEDStrip()
    * @generated
    */
-  int TINKER_BRICKLET_LED_STRIP = 189;
+  int TINKER_BRICKLET_LED_STRIP = 190;
 
   /**
    * The meta object id for the '<em>Bricklet Joystick</em>' data type.
@@ -17034,7 +17098,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getBrickletJoystick()
    * @generated
    */
-  int BRICKLET_JOYSTICK = 190;
+  int BRICKLET_JOYSTICK = 191;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Linear Poti</em>' data type.
@@ -17044,7 +17108,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletLinearPoti()
    * @generated
    */
-  int TINKER_BRICKLET_LINEAR_POTI = 191;
+  int TINKER_BRICKLET_LINEAR_POTI = 192;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Dual Button</em>' data type.
@@ -17054,7 +17118,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletDualButton()
    * @generated
    */
-  int TINKER_BRICKLET_DUAL_BUTTON = 192;
+  int TINKER_BRICKLET_DUAL_BUTTON = 193;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet PTC</em>' data type.
@@ -17064,7 +17128,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletPTC()
    * @generated
    */
-  int TINKER_BRICKLET_PTC = 193;
+  int TINKER_BRICKLET_PTC = 194;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Industrial Dual020m A</em>' data type.
@@ -17074,7 +17138,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletIndustrialDual020mA()
    * @generated
    */
-  int TINKER_BRICKLET_INDUSTRIAL_DUAL020M_A = 194;
+  int TINKER_BRICKLET_INDUSTRIAL_DUAL020M_A = 195;
 
   /**
    * The meta object id for the '<em>Tinker Bricklet Solid State Relay</em>' data type.
@@ -17084,7 +17148,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTinkerBrickletSolidStateRelay()
    * @generated
    */
-  int TINKER_BRICKLET_SOLID_STATE_RELAY = 195;
+  int TINKER_BRICKLET_SOLID_STATE_RELAY = 196;
 
   /**
    * The meta object id for the '<em>HSB Type</em>' data type.
@@ -17094,7 +17158,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getHSBType()
    * @generated
    */
-  int HSB_TYPE = 196;
+  int HSB_TYPE = 197;
 
   /**
    * The meta object id for the '<em>Up Down Type</em>' data type.
@@ -17104,7 +17168,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getUpDownType()
    * @generated
    */
-  int UP_DOWN_TYPE = 197;
+  int UP_DOWN_TYPE = 198;
 
   /**
    * The meta object id for the '<em>Percent Value</em>' data type.
@@ -17114,7 +17178,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getPercentValue()
    * @generated
    */
-  int PERCENT_VALUE = 198;
+  int PERCENT_VALUE = 199;
 
   /**
    * The meta object id for the '<em>Device Options</em>' data type.
@@ -17124,7 +17188,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDeviceOptions()
    * @generated
    */
-  int DEVICE_OPTIONS = 199;
+  int DEVICE_OPTIONS = 200;
 
   /**
    * The meta object id for the '<em>Percent Type</em>' data type.
@@ -17134,7 +17198,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getPercentType()
    * @generated
    */
-  int PERCENT_TYPE = 200;
+  int PERCENT_TYPE = 201;
 
   /**
    * The meta object id for the '<em>Increase Decrease Type</em>' data type.
@@ -17144,7 +17208,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getIncreaseDecreaseType()
    * @generated
    */
-  int INCREASE_DECREASE_TYPE = 201;
+  int INCREASE_DECREASE_TYPE = 202;
 
   /**
    * The meta object id for the '<em>Direction Value</em>' data type.
@@ -17154,7 +17218,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getDirectionValue()
    * @generated
    */
-  int DIRECTION_VALUE = 202;
+  int DIRECTION_VALUE = 203;
 
   /**
    * The meta object id for the '<em>Enum</em>' data type.
@@ -17164,7 +17228,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getEnum()
    * @generated
    */
-  int ENUM = 203;
+  int ENUM = 204;
 
   /**
    * Returns the meta object for class '{@link org.openhab.binding.tinkerforge.internal.model.TFConfig <em>TF Config</em>}'.
@@ -17331,7 +17395,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletDualRelay()
    * @generated
    */
-  int MTINKER_BRICKLET_DUAL_RELAY = 160;
+  int MTINKER_BRICKLET_DUAL_RELAY = 161;
 
 
   /**
@@ -17342,7 +17406,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletIndustrialQuadRelay()
    * @generated
    */
-  int MTINKER_BRICKLET_INDUSTRIAL_QUAD_RELAY = 161;
+  int MTINKER_BRICKLET_INDUSTRIAL_QUAD_RELAY = 162;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet Industrial Digital In4</em>' data type.
@@ -17352,7 +17416,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletIndustrialDigitalIn4()
    * @generated
    */
-  int MTINKER_BRICKLET_INDUSTRIAL_DIGITAL_IN4 = 162;
+  int MTINKER_BRICKLET_INDUSTRIAL_DIGITAL_IN4 = 163;
 
   /**
    * The meta object id for the '<em>MTinker Bricklet Industrial Digital Out4</em>' data type.
@@ -17362,7 +17426,7 @@ public interface ModelPackage extends EPackage
    * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getMTinkerBrickletIndustrialDigitalOut4()
    * @generated
    */
-  int MTINKER_BRICKLET_INDUSTRIAL_DIGITAL_OUT4 = 163;
+  int MTINKER_BRICKLET_INDUSTRIAL_DIGITAL_OUT4 = 164;
 
   /**
    * Returns the meta object for class '{@link org.openhab.binding.tinkerforge.internal.model.Ecosystem <em>Ecosystem</em>}'.
@@ -20853,6 +20917,17 @@ public interface ModelPackage extends EPackage
   EAttribute getMBrickletTemperature_Threshold();
 
   /**
+   * Returns the meta object for the attribute '{@link org.openhab.binding.tinkerforge.internal.model.MBrickletTemperature#isSlowI2C <em>Slow I2C</em>}'.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @return the meta object for the attribute '<em>Slow I2C</em>'.
+   * @see org.openhab.binding.tinkerforge.internal.model.MBrickletTemperature#isSlowI2C()
+   * @see #getMBrickletTemperature()
+   * @generated
+   */
+  EAttribute getMBrickletTemperature_SlowI2C();
+
+  /**
    * Returns the meta object for the '{@link org.openhab.binding.tinkerforge.internal.model.MBrickletTemperature#init() <em>Init</em>}' operation.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
@@ -21169,6 +21244,27 @@ public interface ModelPackage extends EPackage
    * @generated
    */
   EAttribute getTFBaseConfiguration_CallbackPeriod();
+
+  /**
+   * Returns the meta object for class '{@link org.openhab.binding.tinkerforge.internal.model.TFTemperatureConfiguration <em>TF Temperature Configuration</em>}'.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @return the meta object for class '<em>TF Temperature Configuration</em>'.
+   * @see org.openhab.binding.tinkerforge.internal.model.TFTemperatureConfiguration
+   * @generated
+   */
+  EClass getTFTemperatureConfiguration();
+
+  /**
+   * Returns the meta object for the attribute '{@link org.openhab.binding.tinkerforge.internal.model.TFTemperatureConfiguration#isSlowI2C <em>Slow I2C</em>}'.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @return the meta object for the attribute '<em>Slow I2C</em>'.
+   * @see org.openhab.binding.tinkerforge.internal.model.TFTemperatureConfiguration#isSlowI2C()
+   * @see #getTFTemperatureConfiguration()
+   * @generated
+   */
+  EAttribute getTFTemperatureConfiguration_SlowI2C();
 
   /**
    * Returns the meta object for class '{@link org.openhab.binding.tinkerforge.internal.model.TFObjectTemperatureConfiguration <em>TF Object Temperature Configuration</em>}'.
@@ -25507,6 +25603,14 @@ public interface ModelPackage extends EPackage
     EAttribute MBRICKLET_TEMPERATURE__THRESHOLD = eINSTANCE.getMBrickletTemperature_Threshold();
 
     /**
+     * The meta object literal for the '<em><b>Slow I2C</b></em>' attribute feature.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    EAttribute MBRICKLET_TEMPERATURE__SLOW_I2C = eINSTANCE.getMBrickletTemperature_SlowI2C();
+
+    /**
      * The meta object literal for the '<em><b>Init</b></em>' operation.
      * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
@@ -25767,6 +25871,24 @@ public interface ModelPackage extends EPackage
      * @generated
      */
     EAttribute TF_BASE_CONFIGURATION__CALLBACK_PERIOD = eINSTANCE.getTFBaseConfiguration_CallbackPeriod();
+
+    /**
+     * The meta object literal for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.TFTemperatureConfigurationImpl <em>TF Temperature Configuration</em>}' class.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @see org.openhab.binding.tinkerforge.internal.model.impl.TFTemperatureConfigurationImpl
+     * @see org.openhab.binding.tinkerforge.internal.model.impl.ModelPackageImpl#getTFTemperatureConfiguration()
+     * @generated
+     */
+    EClass TF_TEMPERATURE_CONFIGURATION = eINSTANCE.getTFTemperatureConfiguration();
+
+    /**
+     * The meta object literal for the '<em><b>Slow I2C</b></em>' attribute feature.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    EAttribute TF_TEMPERATURE_CONFIGURATION__SLOW_I2C = eINSTANCE.getTFTemperatureConfiguration_SlowI2C();
 
     /**
      * The meta object literal for the '{@link org.openhab.binding.tinkerforge.internal.model.impl.TFObjectTemperatureConfigurationImpl <em>TF Object Temperature Configuration</em>}' class.

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/TFTemperatureConfiguration.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/TFTemperatureConfiguration.java
@@ -1,0 +1,50 @@
+/**
+ */
+package org.openhab.binding.tinkerforge.internal.model;
+
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>TF Temperature Configuration</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * <p>
+ * The following features are supported:
+ * <ul>
+ *   <li>{@link org.openhab.binding.tinkerforge.internal.model.TFTemperatureConfiguration#isSlowI2C <em>Slow I2C</em>}</li>
+ * </ul>
+ * </p>
+ *
+ * @see org.openhab.binding.tinkerforge.internal.model.ModelPackage#getTFTemperatureConfiguration()
+ * @model
+ * @generated
+ */
+public interface TFTemperatureConfiguration extends TFBaseConfiguration
+{
+  /**
+   * Returns the value of the '<em><b>Slow I2C</b></em>' attribute.
+   * <!-- begin-user-doc -->
+   * <p>
+   * If the meaning of the '<em>Slow I2C</em>' attribute isn't clear,
+   * there really should be more of a description here...
+   * </p>
+   * <!-- end-user-doc -->
+   * @return the value of the '<em>Slow I2C</em>' attribute.
+   * @see #setSlowI2C(boolean)
+   * @see org.openhab.binding.tinkerforge.internal.model.ModelPackage#getTFTemperatureConfiguration_SlowI2C()
+   * @model unique="false"
+   * @generated
+   */
+  boolean isSlowI2C();
+
+  /**
+   * Sets the value of the '{@link org.openhab.binding.tinkerforge.internal.model.TFTemperatureConfiguration#isSlowI2C <em>Slow I2C</em>}' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @param value the new value of the '<em>Slow I2C</em>' attribute.
+   * @see #isSlowI2C()
+   * @generated
+   */
+  void setSlowI2C(boolean value);
+
+} // TFTemperatureConfiguration

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/MBrickletTemperatureImpl.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/MBrickletTemperatureImpl.java
@@ -30,7 +30,7 @@ import org.openhab.binding.tinkerforge.internal.model.MBrickletTemperature;
 import org.openhab.binding.tinkerforge.internal.model.MSensor;
 import org.openhab.binding.tinkerforge.internal.model.MTFConfigConsumer;
 import org.openhab.binding.tinkerforge.internal.model.ModelPackage;
-import org.openhab.binding.tinkerforge.internal.model.TFBaseConfiguration;
+import org.openhab.binding.tinkerforge.internal.model.TFTemperatureConfiguration;
 import org.openhab.binding.tinkerforge.internal.tools.Tools;
 import org.openhab.binding.tinkerforge.internal.types.DecimalValue;
 import org.slf4j.Logger;
@@ -67,6 +67,7 @@ import com.tinkerforge.TimeoutException;
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.MBrickletTemperatureImpl#getCallbackPeriod <em>Callback Period</em>}</li>
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.MBrickletTemperatureImpl#getDeviceType <em>Device Type</em>}</li>
  *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.MBrickletTemperatureImpl#getThreshold <em>Threshold</em>}</li>
+ *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.MBrickletTemperatureImpl#isSlowI2C <em>Slow I2C</em>}</li>
  * </ul>
  * </p>
  *
@@ -282,7 +283,7 @@ public class MBrickletTemperatureImpl extends MinimalEObjectImpl.Container imple
    * @generated
    * @ordered
    */
-  protected TFBaseConfiguration tfConfig;
+  protected TFTemperatureConfiguration tfConfig;
 
   /**
    * The default value of the '{@link #getCallbackPeriod() <em>Callback Period</em>}' attribute.
@@ -343,6 +344,26 @@ public class MBrickletTemperatureImpl extends MinimalEObjectImpl.Container imple
    * @ordered
    */
   protected BigDecimal threshold = THRESHOLD_EDEFAULT;
+
+  /**
+   * The default value of the '{@link #isSlowI2C() <em>Slow I2C</em>}' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #isSlowI2C()
+   * @generated
+   * @ordered
+   */
+  protected static final boolean SLOW_I2C_EDEFAULT = false;
+
+  /**
+   * The cached value of the '{@link #isSlowI2C() <em>Slow I2C</em>}' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #isSlowI2C()
+   * @generated
+   * @ordered
+   */
+  protected boolean slowI2C = SLOW_I2C_EDEFAULT;
 
   private TemperatureListener listener;
 
@@ -693,7 +714,7 @@ public class MBrickletTemperatureImpl extends MinimalEObjectImpl.Container imple
    * <!-- end-user-doc -->
    * @generated
    */
-  public TFBaseConfiguration getTfConfig()
+  public TFTemperatureConfiguration getTfConfig()
   {
     return tfConfig;
   }
@@ -703,9 +724,9 @@ public class MBrickletTemperatureImpl extends MinimalEObjectImpl.Container imple
    * <!-- end-user-doc -->
    * @generated
    */
-  public NotificationChain basicSetTfConfig(TFBaseConfiguration newTfConfig, NotificationChain msgs)
+  public NotificationChain basicSetTfConfig(TFTemperatureConfiguration newTfConfig, NotificationChain msgs)
   {
-    TFBaseConfiguration oldTfConfig = tfConfig;
+    TFTemperatureConfiguration oldTfConfig = tfConfig;
     tfConfig = newTfConfig;
     if (eNotificationRequired())
     {
@@ -720,7 +741,7 @@ public class MBrickletTemperatureImpl extends MinimalEObjectImpl.Container imple
    * <!-- end-user-doc -->
    * @generated
    */
-  public void setTfConfig(TFBaseConfiguration newTfConfig)
+  public void setTfConfig(TFTemperatureConfiguration newTfConfig)
   {
     if (newTfConfig != tfConfig)
     {
@@ -772,6 +793,29 @@ public class MBrickletTemperatureImpl extends MinimalEObjectImpl.Container imple
   /**
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
+   * @generated
+   */
+  public boolean isSlowI2C()
+  {
+    return slowI2C;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public void setSlowI2C(boolean newSlowI2C)
+  {
+    boolean oldSlowI2C = slowI2C;
+    slowI2C = newSlowI2C;
+    if (eNotificationRequired())
+      eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.MBRICKLET_TEMPERATURE__SLOW_I2C, oldSlowI2C, slowI2C));
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
    * @generated NOT
    */
   public void init() {
@@ -813,9 +857,18 @@ public class MBrickletTemperatureImpl extends MinimalEObjectImpl.Container imple
       if (tfConfig.eIsSet(tfConfig.eClass().getEStructuralFeature("callbackPeriod"))) {
         setCallbackPeriod(tfConfig.getCallbackPeriod());
       }
+      if (tfConfig.eIsSet(tfConfig.eClass().getEStructuralFeature("slowI2C"))) {
+        setSlowI2C(true);
+      }
     }
     try {
       tinkerforgeDevice = new BrickletTemperature(uid, getIpConnection());
+      if (isSlowI2C()) {
+        logger.debug("setting I2C slow mode");
+        tinkerforgeDevice.setI2CMode(BrickletTemperature.I2C_MODE_SLOW);
+      } else {
+        logger.debug("working with I2C fast mode");
+      }
       tinkerforgeDevice.setResponseExpected(
           BrickletTemperature.FUNCTION_SET_TEMPERATURE_CALLBACK_PERIOD, false);
       tinkerforgeDevice.setTemperatureCallbackPeriod(callbackPeriod);
@@ -958,6 +1011,8 @@ public class MBrickletTemperatureImpl extends MinimalEObjectImpl.Container imple
         return getDeviceType();
       case ModelPackage.MBRICKLET_TEMPERATURE__THRESHOLD:
         return getThreshold();
+      case ModelPackage.MBRICKLET_TEMPERATURE__SLOW_I2C:
+        return isSlowI2C();
     }
     return super.eGet(featureID, resolve, coreType);
   }
@@ -1009,13 +1064,16 @@ public class MBrickletTemperatureImpl extends MinimalEObjectImpl.Container imple
         setSensorValue((DecimalValue)newValue);
         return;
       case ModelPackage.MBRICKLET_TEMPERATURE__TF_CONFIG:
-        setTfConfig((TFBaseConfiguration)newValue);
+        setTfConfig((TFTemperatureConfiguration)newValue);
         return;
       case ModelPackage.MBRICKLET_TEMPERATURE__CALLBACK_PERIOD:
         setCallbackPeriod((Long)newValue);
         return;
       case ModelPackage.MBRICKLET_TEMPERATURE__THRESHOLD:
         setThreshold((BigDecimal)newValue);
+        return;
+      case ModelPackage.MBRICKLET_TEMPERATURE__SLOW_I2C:
+        setSlowI2C((Boolean)newValue);
         return;
     }
     super.eSet(featureID, newValue);
@@ -1068,13 +1126,16 @@ public class MBrickletTemperatureImpl extends MinimalEObjectImpl.Container imple
         setSensorValue((DecimalValue)null);
         return;
       case ModelPackage.MBRICKLET_TEMPERATURE__TF_CONFIG:
-        setTfConfig((TFBaseConfiguration)null);
+        setTfConfig((TFTemperatureConfiguration)null);
         return;
       case ModelPackage.MBRICKLET_TEMPERATURE__CALLBACK_PERIOD:
         setCallbackPeriod(CALLBACK_PERIOD_EDEFAULT);
         return;
       case ModelPackage.MBRICKLET_TEMPERATURE__THRESHOLD:
         setThreshold(THRESHOLD_EDEFAULT);
+        return;
+      case ModelPackage.MBRICKLET_TEMPERATURE__SLOW_I2C:
+        setSlowI2C(SLOW_I2C_EDEFAULT);
         return;
     }
     super.eUnset(featureID);
@@ -1122,6 +1183,8 @@ public class MBrickletTemperatureImpl extends MinimalEObjectImpl.Container imple
         return DEVICE_TYPE_EDEFAULT == null ? deviceType != null : !DEVICE_TYPE_EDEFAULT.equals(deviceType);
       case ModelPackage.MBRICKLET_TEMPERATURE__THRESHOLD:
         return THRESHOLD_EDEFAULT == null ? threshold != null : !THRESHOLD_EDEFAULT.equals(threshold);
+      case ModelPackage.MBRICKLET_TEMPERATURE__SLOW_I2C:
+        return slowI2C != SLOW_I2C_EDEFAULT;
     }
     return super.eIsSet(featureID);
   }
@@ -1294,6 +1357,8 @@ public class MBrickletTemperatureImpl extends MinimalEObjectImpl.Container imple
     result.append(deviceType);
     result.append(", threshold: ");
     result.append(threshold);
+    result.append(", slowI2C: ");
+    result.append(slowI2C);
     result.append(')');
     return result.toString();
   }

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/ModelFactoryImpl.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/ModelFactoryImpl.java
@@ -194,6 +194,7 @@ public class ModelFactoryImpl extends EFactoryImpl implements ModelFactory
       case ModelPackage.TFPTC_BRICKLET_CONFIGURATION: return createTFPTCBrickletConfiguration();
       case ModelPackage.TF_INDUSTRIAL_DUAL020M_ACONFIGURATION: return createTFIndustrialDual020mAConfiguration();
       case ModelPackage.TF_BASE_CONFIGURATION: return createTFBaseConfiguration();
+      case ModelPackage.TF_TEMPERATURE_CONFIGURATION: return createTFTemperatureConfiguration();
       case ModelPackage.TF_OBJECT_TEMPERATURE_CONFIGURATION: return createTFObjectTemperatureConfiguration();
       case ModelPackage.TF_MOISTURE_BRICKLET_CONFIGURATION: return createTFMoistureBrickletConfiguration();
       case ModelPackage.TF_DISTANCE_US_BRICKLET_CONFIGURATION: return createTFDistanceUSBrickletConfiguration();
@@ -1443,6 +1444,17 @@ public class ModelFactoryImpl extends EFactoryImpl implements ModelFactory
   {
     TFBaseConfigurationImpl tfBaseConfiguration = new TFBaseConfigurationImpl();
     return tfBaseConfiguration;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public TFTemperatureConfiguration createTFTemperatureConfiguration()
+  {
+    TFTemperatureConfigurationImpl tfTemperatureConfiguration = new TFTemperatureConfigurationImpl();
+    return tfTemperatureConfiguration;
   }
 
   /**

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/ModelPackageImpl.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/ModelPackageImpl.java
@@ -24,164 +24,6 @@ import org.eclipse.emf.ecore.ETypeParameter;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.impl.EPackageImpl;
 import org.openhab.binding.tinkerforge.internal.config.DeviceOptions;
-import org.openhab.binding.tinkerforge.internal.model.AmbientTemperature;
-import org.openhab.binding.tinkerforge.internal.model.BarometerSubIDs;
-import org.openhab.binding.tinkerforge.internal.model.BrickletMultiTouchConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.BrickletRemoteSwitchConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.ButtonConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.CallbackListener;
-import org.openhab.binding.tinkerforge.internal.model.ColorActor;
-import org.openhab.binding.tinkerforge.internal.model.ConfigOptsDimmable;
-import org.openhab.binding.tinkerforge.internal.model.ConfigOptsMove;
-import org.openhab.binding.tinkerforge.internal.model.ConfigOptsServo;
-import org.openhab.binding.tinkerforge.internal.model.ConfigOptsSetPoint;
-import org.openhab.binding.tinkerforge.internal.model.ConfigOptsSwitchSpeed;
-import org.openhab.binding.tinkerforge.internal.model.DCDriveMode;
-import org.openhab.binding.tinkerforge.internal.model.DigitalActor;
-import org.openhab.binding.tinkerforge.internal.model.DigitalActorDigitalOut4;
-import org.openhab.binding.tinkerforge.internal.model.DigitalActorIO16;
-import org.openhab.binding.tinkerforge.internal.model.DigitalActorIO4;
-import org.openhab.binding.tinkerforge.internal.model.DigitalSensor;
-import org.openhab.binding.tinkerforge.internal.model.DigitalSensorIO4;
-import org.openhab.binding.tinkerforge.internal.model.DimmableActor;
-import org.openhab.binding.tinkerforge.internal.model.DimmableConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.Dual020mADevice;
-import org.openhab.binding.tinkerforge.internal.model.DualButtonButton;
-import org.openhab.binding.tinkerforge.internal.model.DualButtonButtonSubIds;
-import org.openhab.binding.tinkerforge.internal.model.DualButtonDevice;
-import org.openhab.binding.tinkerforge.internal.model.DualButtonDevicePosition;
-import org.openhab.binding.tinkerforge.internal.model.DualButtonLEDConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.DualButtonLed;
-import org.openhab.binding.tinkerforge.internal.model.DualButtonLedSubIds;
-import org.openhab.binding.tinkerforge.internal.model.DualRelaySubIds;
-import org.openhab.binding.tinkerforge.internal.model.Ecosystem;
-import org.openhab.binding.tinkerforge.internal.model.Electrode;
-import org.openhab.binding.tinkerforge.internal.model.GenericDevice;
-import org.openhab.binding.tinkerforge.internal.model.IO16SubIds;
-import org.openhab.binding.tinkerforge.internal.model.IO4Device;
-import org.openhab.binding.tinkerforge.internal.model.IO4SubIds;
-import org.openhab.binding.tinkerforge.internal.model.IODevice;
-import org.openhab.binding.tinkerforge.internal.model.IndustrialDigitalInSubIDs;
-import org.openhab.binding.tinkerforge.internal.model.IndustrialDigitalOutSubIDs;
-import org.openhab.binding.tinkerforge.internal.model.IndustrialDual020mASubIds;
-import org.openhab.binding.tinkerforge.internal.model.IndustrialQuadRelayIDs;
-import org.openhab.binding.tinkerforge.internal.model.InterruptListener;
-import org.openhab.binding.tinkerforge.internal.model.JoystickButton;
-import org.openhab.binding.tinkerforge.internal.model.JoystickDevice;
-import org.openhab.binding.tinkerforge.internal.model.JoystickSubIds;
-import org.openhab.binding.tinkerforge.internal.model.JoystickXPosition;
-import org.openhab.binding.tinkerforge.internal.model.JoystickYPosition;
-import org.openhab.binding.tinkerforge.internal.model.LCDBacklightSubIds;
-import org.openhab.binding.tinkerforge.internal.model.LCDButtonSubIds;
-import org.openhab.binding.tinkerforge.internal.model.LEDGroup;
-import org.openhab.binding.tinkerforge.internal.model.LEDGroupConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.LEDStripConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.MActor;
-import org.openhab.binding.tinkerforge.internal.model.MBarometerTemperature;
-import org.openhab.binding.tinkerforge.internal.model.MBaseDevice;
-import org.openhab.binding.tinkerforge.internal.model.MBrickDC;
-import org.openhab.binding.tinkerforge.internal.model.MBrickServo;
-import org.openhab.binding.tinkerforge.internal.model.MBrickd;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletAmbientLight;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletBarometer;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletDistanceIR;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletDistanceUS;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletDualButton;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletHallEffect;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletHumidity;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletIO16;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletIO4;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletIndustrialDigitalIn4;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletIndustrialDigitalOut4;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletIndustrialDual020mA;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletJoystick;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletLCD20x4;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletLEDStrip;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletLinearPoti;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletMoisture;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletMotionDetector;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletMultiTouch;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletPTC;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletRemoteSwitch;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletSegmentDisplay4x7;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletSolidStateRelay;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletSoundIntensity;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletTemperature;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletTemperatureIR;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletTilt;
-import org.openhab.binding.tinkerforge.internal.model.MBrickletVoltageCurrent;
-import org.openhab.binding.tinkerforge.internal.model.MDevice;
-import org.openhab.binding.tinkerforge.internal.model.MDualRelay;
-import org.openhab.binding.tinkerforge.internal.model.MDualRelayBricklet;
-import org.openhab.binding.tinkerforge.internal.model.MInSwitchActor;
-import org.openhab.binding.tinkerforge.internal.model.MIndustrialDigitalIn;
-import org.openhab.binding.tinkerforge.internal.model.MIndustrialQuadRelay;
-import org.openhab.binding.tinkerforge.internal.model.MIndustrialQuadRelayBricklet;
-import org.openhab.binding.tinkerforge.internal.model.MLCD20x4Backlight;
-import org.openhab.binding.tinkerforge.internal.model.MLCD20x4Button;
-import org.openhab.binding.tinkerforge.internal.model.MLCDSubDevice;
-import org.openhab.binding.tinkerforge.internal.model.MSensor;
-import org.openhab.binding.tinkerforge.internal.model.MServo;
-import org.openhab.binding.tinkerforge.internal.model.MSubDevice;
-import org.openhab.binding.tinkerforge.internal.model.MSubDeviceHolder;
-import org.openhab.binding.tinkerforge.internal.model.MSwitchActor;
-import org.openhab.binding.tinkerforge.internal.model.MTFConfigConsumer;
-import org.openhab.binding.tinkerforge.internal.model.MTemperatureIRDevice;
-import org.openhab.binding.tinkerforge.internal.model.MTextActor;
-import org.openhab.binding.tinkerforge.internal.model.ModelFactory;
-import org.openhab.binding.tinkerforge.internal.model.ModelPackage;
-import org.openhab.binding.tinkerforge.internal.model.MoveActor;
-import org.openhab.binding.tinkerforge.internal.model.MultiTouchDevice;
-import org.openhab.binding.tinkerforge.internal.model.MultiTouchDeviceConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.MultiTouchSubIds;
-import org.openhab.binding.tinkerforge.internal.model.NoSubIds;
-import org.openhab.binding.tinkerforge.internal.model.NumberActor;
-import org.openhab.binding.tinkerforge.internal.model.OHConfig;
-import org.openhab.binding.tinkerforge.internal.model.OHTFDevice;
-import org.openhab.binding.tinkerforge.internal.model.OHTFSubDeviceAdminDevice;
-import org.openhab.binding.tinkerforge.internal.model.ObjectTemperature;
-import org.openhab.binding.tinkerforge.internal.model.PTCConnected;
-import org.openhab.binding.tinkerforge.internal.model.PTCDevice;
-import org.openhab.binding.tinkerforge.internal.model.PTCNoiseRejectionFilter;
-import org.openhab.binding.tinkerforge.internal.model.PTCResistance;
-import org.openhab.binding.tinkerforge.internal.model.PTCSubIds;
-import org.openhab.binding.tinkerforge.internal.model.PTCTemperature;
-import org.openhab.binding.tinkerforge.internal.model.PTCWireMode;
-import org.openhab.binding.tinkerforge.internal.model.ProgrammableColorActor;
-import org.openhab.binding.tinkerforge.internal.model.ProgrammableSwitchActor;
-import org.openhab.binding.tinkerforge.internal.model.Proximity;
-import org.openhab.binding.tinkerforge.internal.model.RemoteSwitch;
-import org.openhab.binding.tinkerforge.internal.model.RemoteSwitchA;
-import org.openhab.binding.tinkerforge.internal.model.RemoteSwitchAConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.RemoteSwitchB;
-import org.openhab.binding.tinkerforge.internal.model.RemoteSwitchBConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.RemoteSwitchC;
-import org.openhab.binding.tinkerforge.internal.model.RemoteSwitchCConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.ServoSubIDs;
-import org.openhab.binding.tinkerforge.internal.model.SetPointActor;
-import org.openhab.binding.tinkerforge.internal.model.SimpleColorActor;
-import org.openhab.binding.tinkerforge.internal.model.SubDeviceAdmin;
-import org.openhab.binding.tinkerforge.internal.model.SwitchSensor;
-import org.openhab.binding.tinkerforge.internal.model.TFBaseConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.TFBrickDCConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.TFConfig;
-import org.openhab.binding.tinkerforge.internal.model.TFDistanceUSBrickletConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.TFIOActorConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.TFIOSensorConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.TFIndustrialDual020mAConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.TFInterruptListenerConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.TFMoistureBrickletConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.TFNullConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.TFObjectTemperatureConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.TFPTCBrickletConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.TFServoConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.TFVoltageCurrentConfiguration;
-import org.openhab.binding.tinkerforge.internal.model.TemperatureIRSubIds;
-import org.openhab.binding.tinkerforge.internal.model.VCDeviceCurrent;
-import org.openhab.binding.tinkerforge.internal.model.VCDevicePower;
-import org.openhab.binding.tinkerforge.internal.model.VCDeviceVoltage;
-import org.openhab.binding.tinkerforge.internal.model.VoltageCurrentDevice;
-import org.openhab.binding.tinkerforge.internal.model.VoltageCurrentSubIds;
 import org.openhab.binding.tinkerforge.internal.model.*;
 import org.openhab.binding.tinkerforge.internal.types.DecimalValue;
 import org.openhab.binding.tinkerforge.internal.types.DirectionValue;
@@ -1029,6 +871,13 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
    * @generated
    */
   private EClass tfBaseConfigurationEClass = null;
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  private EClass tfTemperatureConfigurationEClass = null;
 
   /**
    * <!-- begin-user-doc -->
@@ -5188,6 +5037,16 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
    * <!-- end-user-doc -->
    * @generated
    */
+  public EAttribute getMBrickletTemperature_SlowI2C()
+  {
+    return (EAttribute)mBrickletTemperatureEClass.getEStructuralFeatures().get(2);
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
   public EOperation getMBrickletTemperature__Init()
   {
     return mBrickletTemperatureEClass.getEOperations().get(0);
@@ -5481,6 +5340,26 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
   public EAttribute getTFBaseConfiguration_CallbackPeriod()
   {
     return (EAttribute)tfBaseConfigurationEClass.getEStructuralFeatures().get(1);
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public EClass getTFTemperatureConfiguration()
+  {
+    return tfTemperatureConfigurationEClass;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public EAttribute getTFTemperatureConfiguration_SlowI2C()
+  {
+    return (EAttribute)tfTemperatureConfigurationEClass.getEStructuralFeatures().get(0);
   }
 
   /**
@@ -7134,6 +7013,7 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
     mBrickletTemperatureEClass = createEClass(MBRICKLET_TEMPERATURE);
     createEAttribute(mBrickletTemperatureEClass, MBRICKLET_TEMPERATURE__DEVICE_TYPE);
     createEAttribute(mBrickletTemperatureEClass, MBRICKLET_TEMPERATURE__THRESHOLD);
+    createEAttribute(mBrickletTemperatureEClass, MBRICKLET_TEMPERATURE__SLOW_I2C);
     createEOperation(mBrickletTemperatureEClass, MBRICKLET_TEMPERATURE___INIT);
 
     mBrickletTemperatureIREClass = createEClass(MBRICKLET_TEMPERATURE_IR);
@@ -7250,6 +7130,9 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
     tfBaseConfigurationEClass = createEClass(TF_BASE_CONFIGURATION);
     createEAttribute(tfBaseConfigurationEClass, TF_BASE_CONFIGURATION__THRESHOLD);
     createEAttribute(tfBaseConfigurationEClass, TF_BASE_CONFIGURATION__CALLBACK_PERIOD);
+
+    tfTemperatureConfigurationEClass = createEClass(TF_TEMPERATURE_CONFIGURATION);
+    createEAttribute(tfTemperatureConfigurationEClass, TF_TEMPERATURE_CONFIGURATION__SLOW_I2C);
 
     tfObjectTemperatureConfigurationEClass = createEClass(TF_OBJECT_TEMPERATURE_CONFIGURATION);
     createEAttribute(tfObjectTemperatureConfigurationEClass, TF_OBJECT_TEMPERATURE_CONFIGURATION__EMISSIVITY);
@@ -8007,7 +7890,7 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
     g1.getETypeArguments().add(g2);
     mBrickletTemperatureEClass.getEGenericSuperTypes().add(g1);
     g1 = createEGenericType(this.getMTFConfigConsumer());
-    g2 = createEGenericType(this.getTFBaseConfiguration());
+    g2 = createEGenericType(this.getTFTemperatureConfiguration());
     g1.getETypeArguments().add(g2);
     mBrickletTemperatureEClass.getEGenericSuperTypes().add(g1);
     g1 = createEGenericType(this.getCallbackListener());
@@ -8193,6 +8076,7 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
     tfptcBrickletConfigurationEClass.getESuperTypes().add(this.getTFConfig());
     tfIndustrialDual020mAConfigurationEClass.getESuperTypes().add(this.getTFConfig());
     tfBaseConfigurationEClass.getESuperTypes().add(this.getTFConfig());
+    tfTemperatureConfigurationEClass.getESuperTypes().add(this.getTFBaseConfiguration());
     tfObjectTemperatureConfigurationEClass.getESuperTypes().add(this.getTFBaseConfiguration());
     tfMoistureBrickletConfigurationEClass.getESuperTypes().add(this.getTFBaseConfiguration());
     tfDistanceUSBrickletConfigurationEClass.getESuperTypes().add(this.getTFBaseConfiguration());
@@ -8657,6 +8541,7 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
     initEClass(mBrickletTemperatureEClass, MBrickletTemperature.class, "MBrickletTemperature", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
     initEAttribute(getMBrickletTemperature_DeviceType(), theEcorePackage.getEString(), "deviceType", "bricklet_temperature", 0, 1, MBrickletTemperature.class, !IS_TRANSIENT, !IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
     initEAttribute(getMBrickletTemperature_Threshold(), theEcorePackage.getEBigDecimal(), "threshold", "0.1", 0, 1, MBrickletTemperature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+    initEAttribute(getMBrickletTemperature_SlowI2C(), theEcorePackage.getEBoolean(), "slowI2C", "false", 0, 1, MBrickletTemperature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEOperation(getMBrickletTemperature__Init(), null, "init", 0, 1, !IS_UNIQUE, IS_ORDERED);
 
@@ -8810,6 +8695,9 @@ public class ModelPackageImpl extends EPackageImpl implements ModelPackage
     initEClass(tfBaseConfigurationEClass, TFBaseConfiguration.class, "TFBaseConfiguration", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
     initEAttribute(getTFBaseConfiguration_Threshold(), theEcorePackage.getEBigDecimal(), "threshold", null, 0, 1, TFBaseConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
     initEAttribute(getTFBaseConfiguration_CallbackPeriod(), theEcorePackage.getEInt(), "callbackPeriod", null, 0, 1, TFBaseConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+    initEClass(tfTemperatureConfigurationEClass, TFTemperatureConfiguration.class, "TFTemperatureConfiguration", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+    initEAttribute(getTFTemperatureConfiguration_SlowI2C(), theEcorePackage.getEBoolean(), "slowI2C", null, 0, 1, TFTemperatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(tfObjectTemperatureConfigurationEClass, TFObjectTemperatureConfiguration.class, "TFObjectTemperatureConfiguration", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
     initEAttribute(getTFObjectTemperatureConfiguration_Emissivity(), theEcorePackage.getEInt(), "emissivity", null, 0, 1, TFObjectTemperatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);

--- a/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/TFTemperatureConfigurationImpl.java
+++ b/bundles/binding/org.openhab.binding.tinkerforge/src/main/java/org/openhab/binding/tinkerforge/internal/model/impl/TFTemperatureConfigurationImpl.java
@@ -1,0 +1,176 @@
+/**
+ */
+package org.openhab.binding.tinkerforge.internal.model.impl;
+
+import org.eclipse.emf.common.notify.Notification;
+
+import org.eclipse.emf.ecore.EClass;
+
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+
+import org.openhab.binding.tinkerforge.internal.model.ModelPackage;
+import org.openhab.binding.tinkerforge.internal.model.TFTemperatureConfiguration;
+
+/**
+ * <!-- begin-user-doc -->
+ * An implementation of the model object '<em><b>TF Temperature Configuration</b></em>'.
+ * <!-- end-user-doc -->
+ * <p>
+ * The following features are implemented:
+ * <ul>
+ *   <li>{@link org.openhab.binding.tinkerforge.internal.model.impl.TFTemperatureConfigurationImpl#isSlowI2C <em>Slow I2C</em>}</li>
+ * </ul>
+ * </p>
+ *
+ * @generated
+ */
+public class TFTemperatureConfigurationImpl extends TFBaseConfigurationImpl implements TFTemperatureConfiguration
+{
+  /**
+   * The default value of the '{@link #isSlowI2C() <em>Slow I2C</em>}' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #isSlowI2C()
+   * @generated
+   * @ordered
+   */
+  protected static final boolean SLOW_I2C_EDEFAULT = false;
+
+  /**
+   * The cached value of the '{@link #isSlowI2C() <em>Slow I2C</em>}' attribute.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #isSlowI2C()
+   * @generated
+   * @ordered
+   */
+  protected boolean slowI2C = SLOW_I2C_EDEFAULT;
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  protected TFTemperatureConfigurationImpl()
+  {
+    super();
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  @Override
+  protected EClass eStaticClass()
+  {
+    return ModelPackage.Literals.TF_TEMPERATURE_CONFIGURATION;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public boolean isSlowI2C()
+  {
+    return slowI2C;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public void setSlowI2C(boolean newSlowI2C)
+  {
+    boolean oldSlowI2C = slowI2C;
+    slowI2C = newSlowI2C;
+    if (eNotificationRequired())
+      eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.TF_TEMPERATURE_CONFIGURATION__SLOW_I2C, oldSlowI2C, slowI2C));
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  @Override
+  public Object eGet(int featureID, boolean resolve, boolean coreType)
+  {
+    switch (featureID)
+    {
+      case ModelPackage.TF_TEMPERATURE_CONFIGURATION__SLOW_I2C:
+        return isSlowI2C();
+    }
+    return super.eGet(featureID, resolve, coreType);
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  @Override
+  public void eSet(int featureID, Object newValue)
+  {
+    switch (featureID)
+    {
+      case ModelPackage.TF_TEMPERATURE_CONFIGURATION__SLOW_I2C:
+        setSlowI2C((Boolean)newValue);
+        return;
+    }
+    super.eSet(featureID, newValue);
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  @Override
+  public void eUnset(int featureID)
+  {
+    switch (featureID)
+    {
+      case ModelPackage.TF_TEMPERATURE_CONFIGURATION__SLOW_I2C:
+        setSlowI2C(SLOW_I2C_EDEFAULT);
+        return;
+    }
+    super.eUnset(featureID);
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  @Override
+  public boolean eIsSet(int featureID)
+  {
+    switch (featureID)
+    {
+      case ModelPackage.TF_TEMPERATURE_CONFIGURATION__SLOW_I2C:
+        return slowI2C != SLOW_I2C_EDEFAULT;
+    }
+    return super.eIsSet(featureID);
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  @Override
+  public String toString()
+  {
+    if (eIsProxy()) return super.toString();
+
+    StringBuffer result = new StringBuffer(super.toString());
+    result.append(" (slowI2C: ");
+    result.append(slowI2C);
+    result.append(')');
+    return result.toString();
+  }
+
+} //TFTemperatureConfigurationImpl


### PR DESCRIPTION
This change was requested on the TinkerForge forum:
http://www.tinkerunity.org/forum/index.php?topic=3349.new
I'm awaiting feedback from there.
