### PR TITLE
Add filename to email attachment

### DIFF
--- a/bundles/action/org.openhab.action.mail/src/main/java/org/openhab/action/mail/internal/Mail.java
+++ b/bundles/action/org.openhab.action.mail/src/main/java/org/openhab/action/mail/internal/Mail.java
@@ -90,7 +90,10 @@ import org.slf4j.LoggerFactory;
 					  EmailAttachment attachment = new EmailAttachment();
 					  attachment.setURL(new URL(attachmentUrl));
 					  attachment.setDisposition(EmailAttachment.ATTACHMENT);
-					  attachment.setName("Attachment");
+					  if( attachmentUrl.lastIndexOf("/") < 0 )
+					    attachment.setName("Attachment");
+					  else
+					    attachment.setName(attachmentUrl.substring(attachmentUrl.lastIndexOf("/")+1));
 					  ((MultiPartEmail) email).attach(attachment);
 				} catch (MalformedURLException e) {
 					logger.error("Invalid attachment url.", e);


### PR DESCRIPTION
Fix the mail sending action so that the correct filename of the attachment is used.

Fixes the attachment name issue discussed in #3338 