### PR TITLE
Added error checking for JSR223 timer reschedule.

### DIFF
--- a/bundles/core/org.openhab.core.jsr223/src/main/java/org/openhab/core/jsr223/internal/actions/Timer.java
+++ b/bundles/core/org.openhab.core.jsr223/src/main/java/org/openhab/core/jsr223/internal/actions/Timer.java
@@ -10,6 +10,7 @@ package org.openhab.core.jsr223.internal.actions;
 
 import static org.quartz.TriggerBuilder.newTrigger;
 
+import java.util.Date;
 import org.joda.time.DateTime;
 import org.joda.time.base.AbstractInstant;
 import org.quartz.JobExecutionContext;
@@ -72,15 +73,17 @@ public class Timer {
 	public boolean reschedule(AbstractInstant newTime) {
 		try {
 			Trigger trigger = newTrigger().startAt(newTime.toDate()).build();
-			scheduler.rescheduleJob(triggerKey, trigger);
-			this.triggerKey = trigger.getKey();
-			this.cancelled = false;
-			this.terminated = false;
-			return true;
+			Date nextTriggerTime = scheduler.rescheduleJob(triggerKey, trigger);
+			if (nextTriggerTime != null) {
+				this.triggerKey = trigger.getKey();
+				this.cancelled = false;
+				this.terminated = false;
+				return true;
+			}
 		} catch (SchedulerException e) {
 			logger.warn("An error occured while rescheduling the job '{}': {}", new String[] { jobKey.toString(), e.getMessage() });
-			return false;
 		}
+		return false;
 	}
 
 	public boolean isRunning() {


### PR DESCRIPTION
The JSR223 TImer management code was not checking the Quartz reschedule return value when returning openHAB status. This change adds the check. 

Quartz will not reschedule a trigger that has expired. Previously, the failed Quartz reschedule would not result in a failed status from openHAB.

Note, there is a similar issue with the Timer management code used by Xtext rules.