### PR TITLE
Added try/catch for rule exceptions in the JSR223 ScriptWatcher.

### DIFF
--- a/bundles/core/org.openhab.core.jsr223/src/main/java/org/openhab/core/jsr223/internal/engine/scriptmanager/ScriptUpdateWatcher.java
+++ b/bundles/core/org.openhab.core.jsr223/src/main/java/org/openhab/core/jsr223/internal/engine/scriptmanager/ScriptUpdateWatcher.java
@@ -101,7 +101,12 @@ public class ScriptUpdateWatcher implements Runnable {
 					}
 				}
 
-				scriptManager.scriptsChanged(addedScripts, removedScripts, modifiedScripts);
+				try {
+					scriptManager.scriptsChanged(addedScripts, removedScripts, modifiedScripts);
+				}
+				catch (Exception ex) {
+					logger.error("Error during script change processing", ex);
+				}
 
 				boolean valid = key.reset();
 				if (!valid) {


### PR DESCRIPTION
Otherwise, the script watcher thread dies. This causes rules to no no longer be reloaded automatically. Currently, the workaround is to restart the bundle.