### PR TITLE
Binding Enigma2: Downmix switch

### DIFF
--- a/bundles/binding/org.openhab.binding.enigma2/src/main/java/org/openhab/binding/enigma2/internal/Enigma2Binding.java
+++ b/bundles/binding/org.openhab.binding.enigma2/src/main/java/org/openhab/binding/enigma2/internal/Enigma2Binding.java
@@ -120,6 +120,8 @@ public class Enigma2Binding extends
 					case MUTE:
 						value = node.getMuteUnmute();
 						break;
+					case DOWNMIX:
+						value = node.getDownmix();
 					default:
 						break;
 					}
@@ -214,6 +216,9 @@ public class Enigma2Binding extends
 					break;
 				case POWERSTATE:
 					node.sendOnOff(command, Enigma2PowerState.STANDBY);
+					break;
+				case DOWNMIX:
+					node.setDownmix(command);
 					break;
 				default:
 					logger.error("Unknown cmdId \"{}\"",

--- a/bundles/binding/org.openhab.binding.enigma2/src/main/java/org/openhab/binding/enigma2/internal/Enigma2Command.java
+++ b/bundles/binding/org.openhab.binding.enigma2/src/main/java/org/openhab/binding/enigma2/internal/Enigma2Command.java
@@ -16,5 +16,5 @@ package org.openhab.binding.enigma2.internal;
  * 
  */
 public enum Enigma2Command {
-	VOLUME, CHANNEL, PAUSE, MUTE, REMOTECONTROL, POWERSTATE
+	VOLUME, CHANNEL, PAUSE, MUTE, REMOTECONTROL, POWERSTATE, DOWNMIX
 }

--- a/bundles/binding/org.openhab.binding.enigma2/src/main/java/org/openhab/binding/enigma2/internal/Enigma2Node.java
+++ b/bundles/binding/org.openhab.binding.enigma2/src/main/java/org/openhab/binding/enigma2/internal/Enigma2Node.java
@@ -50,6 +50,7 @@ public class Enigma2Node {
 	private static final String SUFFIX_VOLUME_SET = "?set=set";
 	private static final String SUFFIX_CHANNEL = "/web/subservices";
 	private static final String SUFFIX_POWERSTATE = "/web/powerstate";
+	private static final String SUFFIX_DOWNMIX = "/web/downmix";
 
 	private String hostName;
 	private String userName;
@@ -136,6 +137,21 @@ public class Enigma2Node {
 				: OnOffType.OFF.name();
 	}
 
+	/**
+	 * Requests, if downmix is active
+	 * 
+	 * @return <code>true</code>, if dowmix is active
+	 *         <code>false</code>
+	 */
+	public String getDownmix() {
+		String content = HttpUtil.executeUrl(GET,
+				createUserPasswordHostnamePrefix() + SUFFIX_DOWNMIX,
+				this.timeOut);
+		content = XmlUtils.getContentOfElement(content, "e2state");
+		return content.toLowerCase().equals("true") ? OnOffType.ON.name()
+				: OnOffType.OFF.name();
+	}
+
 	/*
 	 * Setter
 	 */
@@ -207,6 +223,24 @@ public class Enigma2Node {
 		if (command instanceof OnOffType) {
 			HttpUtil.executeUrl(GET, createUserPasswordHostnamePrefix()
 					+ SUFFIX_POWERSTATE + "?newstate=" + powerState.getValue(),
+					this.timeOut);
+		} else {
+			logger.error("Unsupported command type: {}", command.getClass()
+					.getName());
+		}
+	}
+
+	/*
+	 * Setter
+	 */
+	/**
+	 * Sets downmix
+	 */
+	public void setDownmix(Command command) {
+		if (command instanceof OnOffType) {
+			String enable = (OnOffType)command == OnOffType.ON ? "True" : "False";
+			HttpUtil.executeUrl(GET, createUserPasswordHostnamePrefix()
+					+ SUFFIX_DOWNMIX + "?enable=" + enable,
 					this.timeOut);
 		} else {
 			logger.error("Unsupported command type: {}", command.getClass()


### PR DESCRIPTION
I use my Dreambox in two separate rooms. One room with stereo and one with 5.1 speakers. I've added this setting to the binding to be able to fast switch between the two speaker configurations. Please merge this into the master branch.