### PR TITLE
InsteonPLM: improved error messages, longer timeouts for hub2

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/ModemDBBuilder.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/ModemDBBuilder.java
@@ -32,7 +32,7 @@ public class ModemDBBuilder implements MsgListener, Runnable {
 	private boolean	m_isComplete 	= false;
 	private Port	m_port 			= null;
 	private	Thread	m_writeThread	= null;
-	private int		m_timeoutMillis = 60000;
+	private int		m_timeoutMillis = 120000;
 
 	public ModemDBBuilder(Port port) {
 		m_port = port;

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/Driver.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/Driver.java
@@ -34,7 +34,7 @@ public class Driver {
 	private DriverListener m_listener = null; // single listener for notifications
 	private HashMap<InsteonAddress, ModemDBEntry> m_modemDBEntries = new HashMap<InsteonAddress, ModemDBEntry>();
 	private ReentrantLock m_modemDBEntriesLock = new ReentrantLock();
-	private int	m_modemDBRetryTimeout	= 30000;	// in milliseconds
+	private int	m_modemDBRetryTimeout	= 120000;	// in milliseconds
 
 	public void setDriverListener(DriverListener listener) {
 		m_listener = listener;

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/hub/HubIOStream.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/hub/HubIOStream.java
@@ -106,6 +106,9 @@ public class HubIOStream extends IOStream implements Runnable {
 		String[] parts = result.split("<BS>");
 		if (parts.length > 1) {
 			result = parts[1].split("</BS>")[0].trim();
+		} else if (result.startsWith("401 Unauthorized:")) {
+			logger.error("bad username or password. See bottom label of hub for correct login");
+			throw new IOException("login credentials incorrect");
 		} else {
 			logger.error("got invalid buffer status: {}", result);
 			throw new IOException("malformed bufferstatus.xml");

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1441,8 +1441,10 @@ tcp:refreshinterval=250
 # insteonplm:port_0=COM1	  (Windows, with serial/usb modem on COM1)
 
 #
-# to connect to an Insteon Hub2 (the 2014 version) on port 25105, with
-# a poll interval of 1000ms = 1sec:
+# to connect to an Insteon Hub2 (the 2014 version) on port 25105 with
+# a poll interval of 1000ms = 1sec, use the following line. Use the login
+# and password that is printed on the label on the bottom of the hub,
+# NOT the Insteon online login and password!
 #
 # insteonplm:port_0=/hub2/my_user_name:my_password@myinsteonhub.mydomain:25105,poll_time=1000
 
@@ -1451,31 +1453,37 @@ tcp:refreshinterval=250
 #
 # insteonplm:port_0=/hub/localhost:9761
 
+
 # Poll interval (optional, in milliseconds, defaults to 300000).
-# Poll too often and you will overload the insteon network,
-# leading to sluggish or no response when trying to send messages to devices.
+# Poll too often and you will overload the insteon network, leading to sluggish
+# or no response when trying to send messages to devices. Poll too rarely and it'll
+# take a long time to establish the correct state of all devices.
 # The default poll interval of 300s has been tested and found to be a good
 # compromise in a configuration of about 110 switches/dimmers.
 #
 #insteonplm:poll_interval=300000
 
-# Refresh value (optional, in milliseconds, defaults to 600000)
-# The refresh interval is not critical, since only device statistics are logged
-# upon refresh (the polling operates under different timers).
 #
-#insteonplm:refresh=600000
+# If the modem database download times out prematurely (while the download is
+# still making progress), bump this parameter. Timeout is in milliseconds, default is 120000.
+# You should not have to adjust this parameter. Please post on the openhab forum if you do
+# have to bump it.
+#
+# insteonplm:modem_db_retry_timeout=120000
+
+
 
 # optional file with additional device types. The syntax of
 # the file is identical to the device_types.xml file in the
 # source tree. Please remember to post successfully added
 # device types to the openhab group so the developers
 # can include them into the device_types.xml file!
-
+#
 #insteonplm:more_devices=/path_to_file/more_devices.xml
 
 # optional file with additional feature templates, like
 # in the device_features.xml file in the source tree.
-
+#
 #insteonplm:more_features=/path_to_file/more_features.xml
 
 


### PR DESCRIPTION
- improved documentation in openhab.cfg to make it clear which username/pwd to use for hub2
- better error message when providing incorrect password
- longer default timeout for modem database download

This addresses Issue #3327 