### PR TITLE
Try to avoid null items being added to contextMap items set.

### DIFF
--- a/bundles/model/org.openhab.model.item/src/org/openhab/model/item/binding/AbstractGenericBindingProvider.java
+++ b/bundles/model/org.openhab.model.item/src/org/openhab/model/item/binding/AbstractGenericBindingProvider.java
@@ -72,6 +72,10 @@ public abstract class AbstractGenericBindingProvider implements BindingConfigRea
 	 * {@inheritDoc}
 	 */
 	public void processBindingConfiguration(String context, Item item, String bindingConfig) throws BindingConfigParseException {
+		if( item == null ) {
+			throw new BindingConfigParseException("item is not permitted to be null");
+		}
+
 		if( context == null ) {
 			throw new BindingConfigParseException("context is not permitted to be null for item "+item);
 		}


### PR DESCRIPTION
This change is intended to stop what appears to be the adding of a `null` `Item` to the `contextMap` in AbstractGenericBindingProvider.  This appears to only happen on Raspberry Pi A/B/B+ and possibly other slow machines due to a race condition that shows itself there and not the much faster Raspberry Pi 2 or other faster machines.

See [this comment](https://github.com/openhab/openhab/pull/3016#issuecomment-152816629) to PR #3016 based on logs from @lolodomo.

Note that throwing the `BindingConfigParseException` if `null` was passed for `item` will stop the `null` from ending up in the set of items, but it will essentially move the issue closer to its cause.  The other possible PR was to carefully bypass any `null` `Item` in the `contextMap` sets to avoid the NPE of the longstanding bug, but that approach would keep us from ever understanding the original cause of the apparent race condition.

If you are OK with this approach, @teichsta, then hopefully @lolodomo can try a new build after the merge, and see if it helps us identify the problem at its source.