### PR TITLE
MiOS Binding: Issue #3317 Tracking last used pin on locks.

### DIFF
--- a/bundles/binding/org.openhab.binding.mios/examples/scripts/miosTransform.xslt
+++ b/bundles/binding/org.openhab.binding.mios/examples/scripts/miosTransform.xslt
@@ -197,7 +197,6 @@ String   <xsl:value-of select="$DeviceNameFixed"/>DeviceStatus "<xsl:value-of se
 <xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable = 'MinPinSize'"          >Integer</xsl:when>
 <xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable = 'MaxPinSize'"          >Integer</xsl:when>
 <xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable = 'sl_CodeChanged'"      >Integer</xsl:when>
-<xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable = 'sl_UserCode'"         >Integer</xsl:when>
 <xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable = 'sl_LockChanged'"      >Integer</xsl:when>
 <xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable = 'sl_LowBattery'"       >Integer</xsl:when>
 <xsl:when test="@service = 'urn:micasaverde-com:serviceId:DoorLock1'          and @variable = 'sl_LockButton'"       >Integer</xsl:when>
@@ -553,6 +552,9 @@ String   <xsl:value-of select="$DeviceNameFixed"/>DeviceStatus "<xsl:value-of se
 </xsl:choose>
 <xsl:value-of select="$ItemName"/> &quot;<xsl:value-of select="$ItemDescription"/>
 <xsl:value-of select="$ItemFormat"/>&quot; <xsl:value-of select="$ItemIcon"/><xsl:value-of select="$ItemGroups"/>{mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,device:<xsl:value-of select="../../@id"/>/service/<xsl:value-of select="$ServiceAlias"/>/<xsl:value-of select="@variable"/>"}
+<xsl:if test="@variable = 'sl_UserCode' and @service = 'urn:micasaverde-com:serviceId:DoorLock1'">Number   <xsl:value-of select="$ItemName"/>_userid &quot;<xsl:value-of select="$ItemDescription"/> (ID) [%d]&quot; <xsl:value-of select="$ItemGroups"/>{mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,device:<xsl:value-of select="../../@id"/>/service/<xsl:value-of select="$ServiceAlias"/>/<xsl:value-of select="@variable"/>,in:REGEX(UserID=\&quot;(.+)\&quot; UserName=\&quot;.*\&quot;)"}
+String   <xsl:value-of select="$ItemName"/>_username &quot;<xsl:value-of select="$ItemDescription"/> (Name) [%s]&quot; <xsl:value-of select="$ItemGroups"/>{mios="unit:<xsl:value-of select="$MIOS_UNIT"/>,device:<xsl:value-of select="../../@id"/>/service/<xsl:value-of select="$ServiceAlias"/>/<xsl:value-of select="@variable"/>,in:REGEX(UserID=\&quot;.+\&quot; UserName=\&quot;(.*)\&quot;)"}
+</xsl:if>
 </xsl:if>
 </xsl:template>
 

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosBinding.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosBinding.java
@@ -451,8 +451,6 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 						if (newValue != value) {
 							logger.trace("internalPropertyUpdate: transformation performed, from '{}' to '{}'", value,
 									newValue);
-
-							value = newValue;
 						}
 
 						//
@@ -469,25 +467,25 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider> implements
 						//
 						if (incremental) {
 							logger.debug("internalPropertyUpdate: BOUND (Incr) Updating '{} {mios=\"{}\"}' to '{}'",
-									itemName, property, value);
+									itemName, property, newValue);
 
-							eventPublisher.postUpdate(itemName, value);
+							eventPublisher.postUpdate(itemName, newValue);
 						} else {
 							ItemRegistry reg = miosProvider.getItemRegistry();
 							State oldValue = reg.getItem(itemName).getState();
 
-							if ((oldValue == null && value != null)
-									|| (UnDefType.UNDEF.equals(oldValue) && !UnDefType.UNDEF.equals(value))
-									|| !oldValue.equals(value)) {
+							if ((oldValue == null && newValue != null)
+									|| (UnDefType.UNDEF.equals(oldValue) && !UnDefType.UNDEF.equals(newValue))
+									|| !oldValue.equals(newValue)) {
 								logger.debug(
 										"internalPropertyUpdate: BOUND (Full) Updating '{} {mios=\"{}\"}' to '{}', was '{}'",
-										new Object[] { itemName, property, value, oldValue });
+										new Object[] { itemName, property, newValue, oldValue });
 
-								eventPublisher.postUpdate(itemName, value);
+								eventPublisher.postUpdate(itemName, newValue);
 							} else {
 								logger.trace(
 										"internalPropertyUpdate: BOUND (Full) Ignoring '{} {mios=\"{}\"}' to '{}', was '{}'",
-										new Object[] { itemName, property, value, oldValue });
+										new Object[] { itemName, property, newValue, oldValue });
 							}
 						}
 						bound++;

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/MiosBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/MiosBindingConfig.java
@@ -72,7 +72,7 @@ import org.slf4j.LoggerFactory;
  * @since 1.6.0
  */
 public abstract class MiosBindingConfig implements BindingConfig {
-	private static Pattern TRANSFORM_PATTERN = Pattern.compile("(?<transform>.+)[(]{1}?(?<param>.*)[)]{1}");
+	private static Pattern TRANSFORM_PATTERN = Pattern.compile("(?<transform>[a-zA-Z]+)[(]{1}?(?<param>.*)[)]{1}");
 
 	protected static final Logger logger = LoggerFactory.getLogger(MiosBindingConfig.class);
 


### PR DESCRIPTION
Bugfix for Issue #3317 Tracking last used pin on locks.

MiOS Item Generator (XSLT) incorrectly generated the `sl_UserCode` UPnP attribute as `Number` type instead of `String` type.

Fix involves:
a) Emitting original value as `String` type, which is of the form:

        "UserID=".+" UserName=".*"

b) Emitting new Item declaration `*UserCode_userid` representing the _UserID_ value encoded in the original value (`Number`).

c) Emitting new Item declaration `*UserCode_username` representing the _UserName_ value encoded in the original value (`String`).

d) When transforming multiply-bound source values, avoid destroying the original/untransformed value.

e) Tighten the parse logic to work better with Transformations (like `REGEX`) that have complex parameters.


Note: Online docs will be updated once the PR is in the codebase.  The fix isn't isolated to the MiOS Item Generator code, but it helped me find an issue found in the MiOS Binding, which needed to be fixed for it all to work together cleanly


Signed-off-by: Mark Clark <mr.guessed@gmail.com>