### PR TITLE
InsteonPlm: Added support for leak sensor heartbeat messages.

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
@@ -726,24 +726,36 @@ public abstract class MessageHandler {
 		@Override
 		public void handleMessage(int group, byte cmd1, Msg msg,
 				DeviceFeature f, String fromPort) {
-			if (cmd1 != 0x11) return;
 			try {
 				byte cmd2 = msg.getByte("command2");
-				switch (cmd2) {
-				case 0x02:
-					m_feature.publish(OpenClosedType.CLOSED, StateChangeType.CHANGED);
+				switch (cmd1) {
+				case 0x11:
+					switch (cmd2) {
+					case 0x02:
+						m_feature.publish(OpenClosedType.CLOSED, StateChangeType.CHANGED);
+						break;
+					case 0x01:
+					case 0x04:
+						m_feature.publish(OpenClosedType.OPEN, StateChangeType.CHANGED);
+						break;
+					default: // do nothing
+						break;
+					}
 					break;
-				case 0x01:
-					m_feature.publish(OpenClosedType.OPEN, StateChangeType.CHANGED);
-					break;
-				default: // do nothing
+				case 0x13:
+					switch (cmd2) {
+					case 0x04:
+						m_feature.publish(OpenClosedType.CLOSED, StateChangeType.CHANGED);
+						break;
+					default: // do nothing
+						break;
+					}
 					break;
 				}
 			} catch (FieldException e) {
 				logger.debug("{} no cmd2 found, dropping msg {}", nm(), msg);
 				return;
 			}
-
 		}
 	}
 

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
@@ -379,6 +379,7 @@
 	<message-dispatcher>DefaultDispatcher</message-dispatcher>
 	<message-handler cmd="0x03">NoOpMsgHandler</message-handler>
 	<message-handler cmd="0x11">OpenedOrClosedContactHandler</message-handler>
+	<message-handler cmd="0x13">OpenedOrClosedContactHandler</message-handler>
 	<command-handler command="OnOffType">NoOpCommandHandler</command-handler>
 	<poll-handler>NoPollHandler</poll-handler>
 </feature>


### PR DESCRIPTION
I've tested this over the last several days (only one heartbeat/day). The item status is being updated (based on events.log) and the lastheardfrom timestamps are being updated correctly. This feature is useful for the leak sensor because there is no battery life indicator and it sends very few messages unless there is a status change. Thanks to @berndpfrommer for his help.