### PR TITLE
AlarmDecoder binding: port speed now configurable , new default of 115200

### DIFF
--- a/bundles/binding/org.openhab.binding.alarmdecoder/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Description: This is the alarmdecoder backend for openHAB
 Import-Package: gnu.io,
+ org.apache.commons.lang,
  org.openhab.core.autoupdate,
  org.openhab.core.binding,
  org.openhab.core.events,

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1552,18 +1552,19 @@ tcp:refreshinterval=250
 
 ############################## alarmdecoder binding ###################################
 #
-# how to connect to the alarmdecoder: either via serial port or tcp connection
-
+# use this line to reach an IP-enabled alarmdecoder (ad2pi) via tcp:
 #alarmdecoder:connect=tcp:ad2pihostname.mydomain.com:port
+
+# for serial port access use a line like this:
 #alarmdecoder:connect=serial:/dev/ttyUSB0
+# or this to override the default speed:
+#alarmdecoder:connect=serial@9600:/dev/ttyUSB0
 
 # time (in milliseconds) between attempts to reconnect to the alarmdecoder
 # in case the connection goes down
-
 #alarmdecoder:reconnect=10000
 
 # set this to true if you want to send commands to the alarm panel as well
-
 #alarmdecoder:send_commands_and_compromise_security=false
 
 ################################# Davis Binding #######################################


### PR DESCRIPTION
This PR allows users of the alarmdecoder binding to configure the port speed, and changes the default speed to 115200.

Related to this:

https://community.openhab.org/t/ad2usb-not-sending-messages-to-openhab/4086

For testing, here is a pre-build jar file that should work for OH 1.8 and 1.7:

https://drive.google.com/file/d/0B8OtzwATWQSWUUZfZEFyZUdoRlU/view?usp=sharing
