### PR TITLE
[TCP-Binding] correctly parse postamble and preamble strings

### DIFF
--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/TCPBinding.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/TCPBinding.java
@@ -14,6 +14,8 @@ import java.util.Dictionary;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.tcp.AbstractSocketChannelBinding;
 import org.openhab.binding.tcp.Direction;
@@ -180,28 +182,18 @@ public class TCPBinding extends AbstractSocketChannelBinding<TCPBindingProvider>
 
 			String preambleString = (String) config.get("preamble");
 			if (StringUtils.isNotBlank(preambleString)) {
-				try {
-					preAmble = preambleString.replaceAll("\\\\", "\\");
-				}
-				catch(Exception e) {
-					preAmble = preambleString;
-				}
+				preAmble = StringEscapeUtils.unescapeJava(preambleString);
 			} else {
-				logger.info("The preamble for all write operations will be set to the default vaulue of {}",preAmble);
+				logger.info("The preamble for all write operations will be set to the default vaulue of \"{}\"",preAmble);
 			}
 
 			String postambleString = (String) config.get("postamble");
 			if (StringUtils.isNotBlank(postambleString)) {
-				try {
-					postAmble = postambleString.replaceAll("\\\\", "\\");
-				}
-				catch(Exception e) {
-					postAmble = postambleString;
-				}
+				postAmble = StringEscapeUtils.unescapeJava(postambleString);
 			} else {
-				logger.info("The postamble for all write operations will be set to the default vaulue of {}",postAmble);
+				logger.info("The postamble for all write operations will be set to the default vaulue of \"{}\"",postAmble);
 			}
-			
+
 			String updatewithresponseString = (String) config.get("updatewithresponse");
 			if (StringUtils.isNotBlank(updatewithresponseString)) {
 				updateWithResponse = Boolean.parseBoolean((updatewithresponseString));


### PR DESCRIPTION
Use Apache `StringEscapeUtils.unescapeJava` to correctly parse the preamble and postamble config strings.  To address issue #3201.