### PR TITLE
Fixes for PointType; added distanceFrom(otherPoint)

### DIFF
--- a/bundles/core/org.openhab.core.library.test/src/test/java/org/openhab/core/library/types/LocationItemTest.java
+++ b/bundles/core/org.openhab.core.library.test/src/test/java/org/openhab/core/library/types/LocationItemTest.java
@@ -34,10 +34,10 @@ public class LocationItemTest {
 		LocationItem locationBerlin = new LocationItem("berlin");
 		locationBerlin.setState(pointBerlin);
 		
-		DecimalType distance = locationParis.distanceFrom(pointParis);
+		DecimalType distance = locationParis.distanceFrom(locationParis);
 		assertEquals(distance.intValue(),0);
 		
-		double parisBerlin = locationParis.distanceFrom(pointBerlin).doubleValue();
+		double parisBerlin = locationParis.distanceFrom(locationBerlin).doubleValue();
 		assertEquals(parisBerlin,878400,50);	
 		
 		double gravParis = pointParis.getGravity().doubleValue();

--- a/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/items/LocationItem.java
+++ b/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/items/LocationItem.java
@@ -48,27 +48,16 @@ public class LocationItem extends GenericItem {
 	}
 	
 	/**
-	 * Compute the distance with another Point type,
-	 * http://stackoverflow.com/questions/837872/calculate-distance-in-meters-when-you-know-longitude-and-latitude-in-java
+	 * Return the distance from another LocationItem.
 	 * @return distance between the two points in meters
 	 */
-	public DecimalType distanceFrom(PointType away){
-			
-		double dist = -1;
-		
-		if ((away != null) && (this.state instanceof PointType)) {
-			
-			PointType me = (PointType) this.state;
-			
-			double dLat = Math.pow(Math.sin(Math.toRadians(away.getLatitude().doubleValue() - me.getLatitude().doubleValue()) / 2),2);
-			double dLng = Math.pow(Math.sin(Math.toRadians(away.getLongitude().doubleValue() - me.getLongitude().doubleValue()) / 2),2);
-			double a = dLat + Math.cos(Math.toRadians(me.getLatitude().doubleValue()))  
-							* Math.cos(Math.toRadians(away.getLatitude().doubleValue())) * dLng;
-			
-			dist = PointType.WGS84_a * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+	public DecimalType distanceFrom(LocationItem awayItem) {
+		if (awayItem != null && awayItem.state instanceof PointType && this.state instanceof PointType) {
+			PointType thisPoint = (PointType)this.state;
+			PointType awayPoint = (PointType)awayItem.state;
+			return thisPoint.distanceFrom(awayPoint);
 		}
-		
-		return new DecimalType(dist);
+		return new DecimalType(-1);
 	}
 	
 }


### PR DESCRIPTION
Addition:
* `distanceFrom(PointType otherPoint)` returns distance in meters from this point to another point.  Useful for geofencing and for other purposes in rules.

Fixes:
* `toString()` method would return nicely formatted string version of `PointType`, but the formatted version was useless from the REST API, and therefore unusable by clients.  Now returns 3 decimal numbers separated by commas without rounding or other formatting.  @clinique, is this OK with you?
* The `String` constructor would take any non-empty string and construct the object regardless of the string contents if it had no commas in the string.  Following the example of the `HSBType` `ComplexType`, the string is now sanity checked in the constructor, and `IllegalArgumentException`s are thrown if the string is not in the valid "lat,long[,alt]" format. 
* The `valueOf` method must be static, since it's expected to be called in [`org.openhab.core.types.TypeParser`](https://github.com/openhab/openhab/blob/master/bundles/core/org.openhab.core/src/main/java/org/openhab/core/types/TypeParser.java#L39) using reflection.  (There is still an issue with actually using `TypeParser`, since it uses a list of Types and the first successful call to `XXXType.valueOf` determines the type returned.  For example, if `PointType` appeared before `StringType` in the list (which it would have to be), then any string that happened to be of an acceptable format to `PointType` would "win", even if a `StringType` was preferred.)
