### PR TITLE
Base64 support and error comparing classes

### DIFF
--- a/bundles/binding/org.openhab.binding.serial/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.serial/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-Version: 1.8.0.qualifier
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Import-Package: gnu.io,
+ org.apache.commons.codec.binary,
  org.apache.commons.io,
  org.openhab.core.events,
  org.openhab.core.items,

--- a/bundles/binding/org.openhab.binding.serial/src/main/java/org/openhab/binding/serial/internal/SerialBinding.java
+++ b/bundles/binding/org.openhab.binding.serial/src/main/java/org/openhab/binding/serial/internal/SerialBinding.java
@@ -130,6 +130,7 @@ public class SerialBinding extends AbstractEventSubscriber implements BindingCon
 		int indexOf = bindingConfig.indexOf(',');
 		String serialPart = bindingConfig;
 		String pattern = null;
+		boolean base64 = false;
 
 		if(indexOf != -1) {
 			String substring = bindingConfig.substring(indexOf+1);
@@ -137,6 +138,10 @@ public class SerialBinding extends AbstractEventSubscriber implements BindingCon
 
 			if(substring.startsWith("REGEX(")) {
 				pattern = substring.substring(6, substring.length()-1);
+			}
+
+			if(substring.equals("BASE64")) {
+				base64 = true;
 			}
 		}
 
@@ -172,7 +177,7 @@ public class SerialBinding extends AbstractEventSubscriber implements BindingCon
 			serialDevices.put(port, serialDevice);
 		}
 
-		serialDevice.addRegEx(item.getName(), item.getClass(), pattern);
+		serialDevice.addConfig(item.getName(), item.getClass(), pattern, base64);
 		
 		Set<String> itemNames = contextMap.get(context);
 		if (itemNames == null) {
@@ -196,7 +201,7 @@ public class SerialBinding extends AbstractEventSubscriber implements BindingCon
 					continue;
 				}
 
-				serialDevice.removeRegEx(itemName);
+				serialDevice.removeConfig(itemName);
 				
 				// if there is no binding left, dispose this device
 				if(serialDevice.isEmpty()) {

--- a/bundles/binding/org.openhab.binding.serial/src/main/java/org/openhab/binding/serial/internal/SerialDevice.java
+++ b/bundles/binding/org.openhab.binding.serial/src/main/java/org/openhab/binding/serial/internal/SerialDevice.java
@@ -26,6 +26,7 @@ import java.util.TooManyListenersException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.library.items.NumberItem;
@@ -64,31 +65,33 @@ public class SerialDevice implements SerialPortEventListener {
 
 	private OutputStream outputStream;
 
-	private Map<String, ItemType> patternMap;
+	private Map<String, ItemType> configMap;
 
 	class ItemType {
 		String pattern;
+		boolean base64;
 		Class<?> type;
 	}
 	
 	public boolean isEmpty() {
-		return patternMap.isEmpty();
+		return configMap.isEmpty();
 	}
 	
-	public void addRegEx(String itemName, Class<?> type, String pattern) {
-		if(patternMap == null)
-			patternMap = new HashMap<String, ItemType>();
+	public void addConfig(String itemName, Class<?> type, String pattern, boolean base64) {
+		if(configMap == null)
+			configMap = new HashMap<String, ItemType>();
 		
 		ItemType typeItem = new ItemType();
 		typeItem.pattern = pattern;
+		typeItem.base64 = base64;
 		typeItem.type = type;
 		
-		patternMap.put(itemName, typeItem);
+		configMap.put(itemName, typeItem);
 	}
 	
-	public void removeRegEx(String itemName) {
-		if(patternMap != null) {
-			patternMap.remove(itemName);
+	public void removeConfig(String itemName) {
+		if(configMap != null) {
+			configMap.remove(itemName);
 		}
 	}
 
@@ -222,8 +225,8 @@ public class SerialDevice implements SerialPortEventListener {
 				logger.debug("Received message '{}' on serial port {}", new String[] { result, port });
 
 				if (eventPublisher != null) {
-					if(patternMap != null && !patternMap.isEmpty()) {
-						for (Entry<String, ItemType> entry : patternMap.entrySet()) {
+					if(configMap != null && !configMap.isEmpty()) {
+						for (Entry<String, ItemType> entry : configMap.entrySet()) {
 
 							// use pattern
 							if(entry.getValue().pattern != null) {
@@ -249,10 +252,12 @@ public class SerialDevice implements SerialPortEventListener {
 									}
 								}
 								
-							} else if(entry.getValue().type.isInstance(StringItem.class)) {
+							} else if(entry.getValue().type == StringItem.class) {
+								if (entry.getValue().base64)
+									result = Base64.encodeBase64String(result.getBytes());
 								eventPublisher.postUpdate(entry.getKey(), new StringType(result));
 								
-							} else if(entry.getValue().type.isInstance(SwitchItem.class) && result.trim().isEmpty()) {
+							} else if(entry.getValue().type == SwitchItem.class && result.trim().isEmpty()) {
 								eventPublisher.postUpdate(entry.getKey(), OnOffType.ON);
 								eventPublisher.postUpdate(entry.getKey(), OnOffType.OFF);
 							}
@@ -277,7 +282,11 @@ public class SerialDevice implements SerialPortEventListener {
 		logger.debug("Writing '{}' to serial port {}", new String[] { msg, port });
 		try {
 			// write string to serial port
-			outputStream.write(msg.getBytes());
+			if (msg.startsWith("BASE64:"))
+				outputStream.write(Base64.decodeBase64(msg.substring(7, msg.length())));
+			else
+				outputStream.write(msg.getBytes());
+
 			outputStream.flush();
 		} catch (IOException e) {
 			logger.error("Error writing '{}' to serial port {}: {}", new String[] { msg, port, e.getMessage() });


### PR DESCRIPTION
I’ve added support for Base64 communication because some bytes from
serial devices are causing problems in the rest api: (see
https://community.openhab.org/t/error-in-rest-service-when-serial-port-s
ends-stx-ack-eot-bytes/3932/2)

I also fixed an error when no regex is used.
(entry.getValue().type.isInstance(SwitchItem.class) was never true)