### PR TITLE
benq: Allow minimum source number 0

### DIFF
--- a/bundles/binding/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorSourceMapping.java
+++ b/bundles/binding/org.openhab.binding.benqprojector/src/main/java/org/openhab/binding/benqprojector/internal/BenqProjectorSourceMapping.java
@@ -51,7 +51,7 @@ public enum BenqProjectorSourceMapping {
 	 * @return String representation of source
 	 */
 	public static String getStringFromMapping(int idx) {
-		if (idx > 0 && idx < BenqProjectorSourceMapping.values().length)
+		if (idx >= 0 && idx < BenqProjectorSourceMapping.values().length)
 			return BenqProjectorSourceMapping.values()[idx].commandString;
 		else
 			return "";


### PR DESCRIPTION
The first valid number is actually 0 so we have to be inclusive when
checking the range of valid numbers. The code would previously consider
1 to be first lowest valid number.

It's possible to set the source either referring to its numeric index or using a string and while using a string has worked, the code to map index into a string was broken as it would consider 1 to be the lowest valid number when it in fact should be 0.