### PR TITLE
MapDB Persistence: PercentType restore needs to allow Decimal values (Issue #3437)

### DIFF
--- a/bundles/persistence/org.openhab.persistence.mapdb/src/main/java/org/openhab/persistence/mapdb/internal/MapDBitemSerializer.java
+++ b/bundles/persistence/org.openhab.persistence.mapdb/src/main/java/org/openhab/persistence/mapdb/internal/MapDBitemSerializer.java
@@ -26,10 +26,10 @@ import org.openhab.core.types.State;
 
 /**
  * Serializer to serialize items to and from Mapdb format
- * 
+ *
  * @author Jens Viebig
  * @since 1.7.0
- * 
+ *
  */
 public class MapDBitemSerializer implements Serializer<MapDBItem>, Serializable {
 
@@ -58,11 +58,11 @@ public class MapDBitemSerializer implements Serializer<MapDBItem>, Serializable 
 		State state = null;
 
 		if ("DecimalType".equals(stateType)) {
-			state = new DecimalType(Double.parseDouble(stateStr));
+			state = DecimalType.valueOf(stateStr);
 		} else if ("HSBType".equals(stateType)) {
-			state = new HSBType(stateStr);
+			state = HSBType.valueOf(stateStr);
 		} else if ("PercentType".equals(stateType)) {
-			state = new PercentType(Integer.parseInt(stateStr));
+			state = PercentType.valueOf(stateStr);
 		} else if ("OnOffType".equals(stateType)) {
 			state = OnOffType.valueOf(stateStr);
 		} else if ("OpenClosedType".equals(stateType)) {
@@ -70,7 +70,7 @@ public class MapDBitemSerializer implements Serializer<MapDBItem>, Serializable 
 		} else if ("DateTimeType".equals(stateType)) {
 			state = DateTimeType.valueOf(stateStr);
 		} else
-			state = new StringType(stateStr);
+			state = StringType.valueOf(stateStr);
 
 		item.setState(state);
 		item.setTimestamp(new Date(in.readLong()));


### PR DESCRIPTION
openHAB Issue #3437

In openHAB, `PercentType` is derived from `DecimalType`.  The
MapDB Persistence is pre-parsing the value, assuming it's an `Integer`,
and failing when it wasn't an Integer.

In some cases, this would cause the openHAB startup process to enter a never ending loop, since the Persistence-Restore functionality was failing.

With this change, we simply hand the String value to `PercentType.valueOf()` and let it perform any necessary conversions.

Signed-off-by: Mark Clark <mr.guessed@gmail.com>