### PR TITLE
Fix for #3432

### DIFF
--- a/bundles/core/org.openhab.core.transform/META-INF/MANIFEST.MF
+++ b/bundles/core/org.openhab.core.transform/META-INF/MANIFEST.MF
@@ -43,3 +43,4 @@ Bundle-ClassPath: .,
  lib/json-smart-1.2.jar
 Export-Package: org.openhab.core.transform,org.openhab.core.transform.
  actions
+Bundle-ActivationPolicy: lazy

--- a/bundles/core/org.openhab.core.transform/src/main/java/org/openhab/core/transform/actions/Transformation.java
+++ b/bundles/core/org.openhab.core.transform/src/main/java/org/openhab/core/transform/actions/Transformation.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.core.transform.actions;
 
+import org.openhab.core.scriptengine.action.ActionDoc;
+import org.openhab.core.scriptengine.action.ParamDoc;
 import org.openhab.core.transform.TransformationException;
 import org.openhab.core.transform.TransformationHelper;
 import org.openhab.core.transform.TransformationService;
@@ -37,7 +39,11 @@ public class Transformation {
 	 * 		the transformed value or the original one, if there was no service registered for the
 	 * 		given type or a transformation exception occurred.
 	 */
-	public static String transform(String type, String function, String value) {
+	@ActionDoc(text = "Applies a transformation of a given type with some function to a value.")
+	public static String transform(
+			@ParamDoc(name = "type", text = "the transformation type, e.g. REGEX or MAP") String type,
+			@ParamDoc(name = "function", text = "the function to call, this value depends on the transformation type") String function,
+			@ParamDoc(name = "value", text = "the value to apply the transformation to") String value) {
 		String result;
 		TransformationService service = TransformationHelper.getTransformationService(TransformationActivator.getContext(), type);
 		if(service!=null) {


### PR DESCRIPTION
The `transform` action was not being recognized in the Designer.  This PR adds 
`Bundle-ActivationPolicy: lazy` to bundles/core/org.openhab.core.transform/META-INF/MANIFEST.MF, and adds ActionDoc and ParamDoc annotations to the `transform` static method.

Tested on Designer on Mac.  Not tested in runtime or on Windows.