### PR TITLE
allow lower chart scale values

### DIFF
--- a/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/chart/ChartServlet.java
+++ b/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/chart/ChartServlet.java
@@ -309,7 +309,7 @@ public class ChartServlet extends HttpServlet implements ManagedService {
 		}
 		if(properties.get("scale") != null) {
 			scale = Double.parseDouble((String)properties.get("scale"));
-			if(scale < 0.5)
+			if(scale < 0.1)
 				scale = 1.0;
 		}
 	}

--- a/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/chart/ChartServlet.java
+++ b/bundles/ui/org.openhab.ui/src/main/java/org/openhab/ui/internal/chart/ChartServlet.java
@@ -309,8 +309,10 @@ public class ChartServlet extends HttpServlet implements ManagedService {
 		}
 		if(properties.get("scale") != null) {
 			scale = Double.parseDouble((String)properties.get("scale"));
-			if(scale < 0.1)
+			// Set scale to normal if the custom value is unrealisticly low
+			if(scale < 0.1) {
 				scale = 1.0;
+			}
 		}
 	}
 


### PR DESCRIPTION
I just realized the scale factor for the chart servlet is restrictet from 0.5 to 1.0.
Is there a particular reason for that?

I am using a Sasmung Galaxy S6 with a 575 dpi display.
I can use a scale of 0.5, but it would be more readable with a value of ~0.3 - 0.4.

The next generation of smartphones will be having evan higher resolution display (e.g. Sony Z5 Premium)