### PR TITLE
Fix for #3390. Refreshes NTP-bound items when binding changes (items reloaded).

### DIFF
--- a/bundles/binding/org.openhab.binding.ntp/src/main/java/org/openhab/binding/ntp/internal/NtpBinding.java
+++ b/bundles/binding/org.openhab.binding.ntp/src/main/java/org/openhab/binding/ntp/internal/NtpBinding.java
@@ -24,6 +24,7 @@ import org.apache.commons.net.ntp.NTPUDPClient;
 import org.apache.commons.net.ntp.TimeInfo;
 import org.openhab.binding.ntp.NtpBindingProvider;
 import org.openhab.core.binding.AbstractActiveBinding;
+import org.openhab.core.binding.BindingProvider;
 import org.openhab.core.library.types.DateTimeType;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
@@ -83,18 +84,22 @@ public class NtpBinding extends AbstractActiveBinding<NtpBindingProvider> implem
 		logger.debug("Got time from {}: {}", hostname, SDF.format(new Date(networkTimeInMillis)));
 				
 		for (NtpBindingProvider provider : providers) {
-			for (String itemName : provider.getItemNames()) {
-				
-				TimeZone timeZone = provider.getTimeZone(itemName);				
-				Locale locale = provider.getLocale(itemName);
-				
-				Calendar calendar = Calendar.getInstance(timeZone, locale);
-				calendar.setTimeInMillis(networkTimeInMillis);
-
-				eventPublisher.postUpdate(itemName, new DateTimeType(calendar));
+			for (String itemName : provider.getItemNames()) {			
+				updateTime(provider, itemName, networkTimeInMillis);
 			}
 		}
 		
+	}
+
+	private void updateTime(NtpBindingProvider provider, String itemName,
+			long networkTimeInMillis) {
+		TimeZone timeZone = provider.getTimeZone(itemName);
+		Locale locale = provider.getLocale(itemName);
+		
+		Calendar calendar = Calendar.getInstance(timeZone, locale);
+		calendar.setTimeInMillis(networkTimeInMillis);
+
+		eventPublisher.postUpdate(itemName, new DateTimeType(calendar));
 	}
 	
 	/**
@@ -148,4 +153,18 @@ public class NtpBinding extends AbstractActiveBinding<NtpBindingProvider> implem
 
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void bindingChanged(BindingProvider provider, String itemName) {
+		NtpGenericBindingProvider ntpBindingProvider = (NtpGenericBindingProvider)provider;
+		if (ntpBindingProvider.providesBindingFor(itemName))
+		{
+			long networkTimeInMillis = getTime(hostname);
+			updateTime(ntpBindingProvider, itemName, networkTimeInMillis);
+		}
+		super.bindingChanged(provider, itemName);
+	}
+
 }


### PR DESCRIPTION
I extracted part of the execute method and called it from the bindingChanged callback. I manually tested it by updating my items file and verifying the NTP-bound item was updated immediately after the items file was reloaded rather than waiting for the next timer callback. Re: #3390 