### PR TITLE
apt installation: openhab user as owner of /etc/openhab/configurations directory

### DIFF
--- a/distribution/src/deb/bin/setpermissions.sh
+++ b/distribution/src/deb/bin/setpermissions.sh
@@ -27,7 +27,7 @@ setPerm () {
 	chmod $spmode "${spfile}"
 }
 
-for ohdir in "${OPENHAB_HOME_DIR}" "${OPENHAB_LOG_DIR}"; do
+for ohdir in "${OPENHAB_HOME_DIR}" "${OPENHAB_LOG_DIR}" "${OPENHAB_CONFIGURATIONS_DIR}"; do
 	setPermRecursive "${ohdir}"
 done
 


### PR DESCRIPTION
This PR is related to https://github.com/openhab/openhab/issues/3451

With this change the openhab user will be the owner of the /etc/openhab/configurations directory and all files below. Thus bindings will be able to change the openhab configuration. It means somewhat lesser security, but better usability.
