### PR TITLE
sapp binding: added signed intepretation for words and bytes

### DIFF
--- a/bundles/binding/org.openhab.binding.sapp/src/main/java/org/openhab/binding/sapp/SappUpdatePendingRequestsProvider.java
+++ b/bundles/binding/org.openhab.binding.sapp/src/main/java/org/openhab/binding/sapp/SappUpdatePendingRequestsProvider.java
@@ -20,15 +20,17 @@ public interface SappUpdatePendingRequestsProvider {
 
 	/**
 	 * adds itemName to the items list to be refreshed
-	 *  
-	 * @param itemName name of item 
+	 * 
+	 * @param itemName
+	 *            name of item
 	 */
 	public void addPendingUpdateRequest(String itemName);
 
 	/**
 	 * clears all pending requests and adds itemName to the items list to be refreshed. Must be implemented atomically
-	 *  
-	 * @param itemName name of item 
+	 * 
+	 * @param itemName
+	 *            name of item
 	 */
 	public void replaceAllPendingUpdateRequests(String itemName);
 

--- a/bundles/binding/org.openhab.binding.sapp/src/main/java/org/openhab/binding/sapp/internal/SappBinding.java
+++ b/bundles/binding/org.openhab.binding.sapp/src/main/java/org/openhab/binding/sapp/internal/SappBinding.java
@@ -706,7 +706,7 @@ public class SappBinding extends AbstractActiveBinding<SappBindingProvider> impl
 					if (address.getAddressType() == sappAddressType && address.getPnmasId().equals(pnmasId) && addressToUpdate == address.getAddress()) {
 						logger.debug("found binding to update {}", sappBindingConfigNumberItem);
 						int result = SappBindingConfigUtils.maskWithSubAddress(address.getSubAddress(), newState);
-						eventPublisher.postUpdate(itemName, new DecimalType(address.scaledValue(result)));
+						eventPublisher.postUpdate(itemName, new DecimalType(address.scaledValue(result, address.getSubAddress())));
 					}
 				} else if (item instanceof RollershutterItem) {
 					SappBindingConfigRollershutterItem sappBindingConfigRollershutterItem = (SappBindingConfigRollershutterItem) provider.getBindingConfig(itemName);
@@ -721,7 +721,7 @@ public class SappBinding extends AbstractActiveBinding<SappBindingProvider> impl
 					SappAddressDimmer statusAddress = sappBindingConfigDimmerItem.getStatus();
 					if (statusAddress.getAddressType() == sappAddressType && statusAddress.getPnmasId().equals(pnmasId) && addressToUpdate == statusAddress.getAddress()) {
 						logger.debug("found binding to update {}", sappBindingConfigDimmerItem);
-						int result = (int) statusAddress.scaledValue(SappBindingConfigUtils.maskWithSubAddress(statusAddress.getSubAddress(), newState));
+						int result = (int) statusAddress.scaledValue(SappBindingConfigUtils.maskWithSubAddress(statusAddress.getSubAddress(), newState), statusAddress.getSubAddress());
 						if (result <= PercentType.ZERO.intValue()) {
 							eventPublisher.postUpdate(itemName, PercentType.ZERO);
 						} else if (result >= PercentType.HUNDRED.intValue()) {
@@ -847,7 +847,7 @@ public class SappBinding extends AbstractActiveBinding<SappBindingProvider> impl
 		case VIRTUAL:
 			try {
 				int result = SappBindingConfigUtils.maskWithSubAddress(address.getSubAddress(), getVirtualValue(provider, address.getPnmasId(), address.getAddress(), address.getSubAddress(), true));
-				eventPublisher.postUpdate(itemName, new DecimalType(address.scaledValue(result)));
+				eventPublisher.postUpdate(itemName, new DecimalType(address.scaledValue(result, address.getSubAddress())));
 			} catch (SappException e) {
 				logger.error("could not run sappcommand", e);
 			}
@@ -856,7 +856,7 @@ public class SappBinding extends AbstractActiveBinding<SappBindingProvider> impl
 		case INPUT:
 			try {
 				int result = SappBindingConfigUtils.maskWithSubAddress(address.getSubAddress(), getInputValue(provider, address.getPnmasId(), address.getAddress(), address.getSubAddress(), true));
-				eventPublisher.postUpdate(itemName, new DecimalType(address.scaledValue(result)));
+				eventPublisher.postUpdate(itemName, new DecimalType(address.scaledValue(result, address.getSubAddress())));
 			} catch (SappException e) {
 				logger.error("could not run sappcommand", e);
 			}
@@ -865,7 +865,7 @@ public class SappBinding extends AbstractActiveBinding<SappBindingProvider> impl
 		case OUTPUT:
 			try {
 				int result = SappBindingConfigUtils.maskWithSubAddress(address.getSubAddress(), getOutputValue(provider, address.getPnmasId(), address.getAddress(), address.getSubAddress(), true));
-				eventPublisher.postUpdate(itemName, new DecimalType(address.scaledValue(result)));
+				eventPublisher.postUpdate(itemName, new DecimalType(address.scaledValue(result, address.getSubAddress())));
 			} catch (SappException e) {
 				logger.error("could not run sappcommand: " + e.getMessage());
 			}
@@ -914,7 +914,7 @@ public class SappBinding extends AbstractActiveBinding<SappBindingProvider> impl
 		switch (statusAddress.getAddressType()) {
 		case VIRTUAL:
 			try {
-				int result = (int) statusAddress.scaledValue(SappBindingConfigUtils.maskWithSubAddress(statusAddress.getSubAddress(), getVirtualValue(provider, statusAddress.getPnmasId(), statusAddress.getAddress(), statusAddress.getSubAddress(), true)));
+				int result = (int) statusAddress.scaledValue(SappBindingConfigUtils.maskWithSubAddress(statusAddress.getSubAddress(), getVirtualValue(provider, statusAddress.getPnmasId(), statusAddress.getAddress(), statusAddress.getSubAddress(), true)), statusAddress.getSubAddress());
 				if (result <= PercentType.ZERO.intValue()) {
 					eventPublisher.postUpdate(itemName, PercentType.ZERO);
 				} else if (result >= PercentType.HUNDRED.intValue()) {

--- a/bundles/binding/org.openhab.binding.sapp/src/main/java/org/openhab/binding/sapp/internal/configs/SappBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.sapp/src/main/java/org/openhab/binding/sapp/internal/configs/SappBindingConfig.java
@@ -38,13 +38,16 @@ public abstract class SappBindingConfig implements BindingConfig {
 	protected static final String[] validSubAddresses;
 
 	static {
-		validSubAddresses = new String[19];
+		validSubAddresses = new String[22];
 		for (int i = 0; i < 16; i++) {
 			validSubAddresses[i] = String.valueOf(i + 1);
 		}
-		validSubAddresses[16] = "L";
-		validSubAddresses[17] = "H";
-		validSubAddresses[18] = "*";
+		validSubAddresses[16] = SappBindingConfigUtils.WORD_MASK_U;
+		validSubAddresses[17] = SappBindingConfigUtils.WORD_MASK_S;
+		validSubAddresses[18] = SappBindingConfigUtils.LOW_MASK_U;
+		validSubAddresses[19] = SappBindingConfigUtils.LOW_MASK_S;
+		validSubAddresses[20] = SappBindingConfigUtils.HIGH_MASK_U;
+		validSubAddresses[21] = SappBindingConfigUtils.HIGH_MASK_S;
 	}
 
 	private String itemName;

--- a/bundles/binding/org.openhab.binding.sapp/src/main/java/org/openhab/binding/sapp/internal/configs/SappBindingConfigUtils.java
+++ b/bundles/binding/org.openhab.binding.sapp/src/main/java/org/openhab/binding/sapp/internal/configs/SappBindingConfigUtils.java
@@ -17,6 +17,13 @@ package org.openhab.binding.sapp.internal.configs;
  */
 public class SappBindingConfigUtils {
 
+	public static final String WORD_MASK_U = "*";
+	public static final String WORD_MASK_S = "+";
+	public static final String LOW_MASK_U = "L";
+	public static final String LOW_MASK_S = "L+";
+	public static final String HIGH_MASK_U = "H";
+	public static final String HIGH_MASK_S = "H+";
+
 	/**
 	 * mask the value against the subAddress
 	 * 
@@ -27,11 +34,11 @@ public class SappBindingConfigUtils {
 	 */
 	public static int maskWithSubAddress(String subAddress, int value) {
 
-		if (subAddress.equals("*")) {
+		if (subAddress.equals(WORD_MASK_U) || subAddress.equals(WORD_MASK_S)) {
 			return value & 0xFFFF;
-		} else if (subAddress.equals("L")) {
+		} else if (subAddress.equals(LOW_MASK_U) || subAddress.equals(LOW_MASK_S)) {
 			return (value & 0x00FF);
-		} else if (subAddress.equals("H")) {
+		} else if (subAddress.equals(HIGH_MASK_U) || subAddress.equals(HIGH_MASK_S)) {
 			return ((value >> 8) & 0x00FF);
 		} else {
 			int shift = Integer.parseInt(subAddress);
@@ -51,11 +58,11 @@ public class SappBindingConfigUtils {
 	 */
 	public static int maskWithSubAddressAndSet(String subAddress, int newValue, int previousValue) {
 
-		if (subAddress.equals("*")) {
+		if (subAddress.equals(WORD_MASK_U) || subAddress.equals(WORD_MASK_S)) {
 			return newValue & 0xFFFF;
-		} else if (subAddress.equals("L")) {
+		} else if (subAddress.equals(LOW_MASK_U) || subAddress.equals(LOW_MASK_S)) {
 			return (newValue & 0x00FF) | (previousValue & 0xFF00);
-		} else if (subAddress.equals("H")) {
+		} else if (subAddress.equals(HIGH_MASK_U) || subAddress.equals(HIGH_MASK_S)) {
 			return ((newValue << 8) & 0xFF00) | (previousValue & 0x00FF);
 		} else {
 			int shift = Integer.parseInt(subAddress);

--- a/bundles/binding/org.openhab.binding.sapp/src/main/java/org/openhab/binding/sapp/internal/model/SappAddressDecimal.java
+++ b/bundles/binding/org.openhab.binding.sapp/src/main/java/org/openhab/binding/sapp/internal/model/SappAddressDecimal.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.sapp.internal.model;
 
+import org.openhab.binding.sapp.internal.configs.SappBindingConfigUtils;
+
 /**
  * Decimal Address model
  * 
@@ -79,13 +81,13 @@ public class SappAddressDecimal extends SappAddress {
 
 	private void setOriginalScale(String subAddress) {
 
-		if (subAddress.equals("*")) {
+		if (subAddress.equals(SappBindingConfigUtils.WORD_MASK_U) || subAddress.equals(SappBindingConfigUtils.WORD_MASK_S)) {
 			originalMinScale = 0;
 			originalMaxScale = 0xFFFF;
-		} else if (subAddress.equals("L")) {
+		} else if (subAddress.equals(SappBindingConfigUtils.LOW_MASK_U) || subAddress.equals(SappBindingConfigUtils.LOW_MASK_S)) {
 			originalMinScale = 0;
 			originalMaxScale = 0x00FF;
-		} else if (subAddress.equals("H")) {
+		} else if (subAddress.equals(SappBindingConfigUtils.HIGH_MASK_U) || subAddress.equals(SappBindingConfigUtils.HIGH_MASK_S)) {
 			originalMinScale = 0;
 			originalMaxScale = 0x00FF;
 		} else {
@@ -97,8 +99,20 @@ public class SappAddressDecimal extends SappAddress {
 	/**
 	 * returns the scaled value with respect to the original scale
 	 */
-	public double scaledValue(double value) {
-		return (((double) (value - originalMinScale)) * ((double) (maxScale - minScale)) / ((double) (originalMaxScale - originalMinScale))) + ((double) minScale);
+	public double scaledValue(int value, String subAddress) {
+		double toScaleValue;
+
+		if (subAddress.equals(SappBindingConfigUtils.WORD_MASK_S) && value > 0x7FFF) {
+			toScaleValue = value - 0xFFFF - 1;
+		} else if (subAddress.equals(SappBindingConfigUtils.LOW_MASK_S) && value > 0x7F) {
+			toScaleValue = value - 0xFF - 1;
+		} else if (subAddress.equals(SappBindingConfigUtils.HIGH_MASK_S) && value > 0x7F) {
+			toScaleValue = value - 0xFF - 1;
+		} else {
+			toScaleValue = value;
+		}
+
+		return (((double) (toScaleValue - originalMinScale)) * ((double) (maxScale - minScale)) / ((double) (originalMaxScale - originalMinScale))) + ((double) minScale);
 	}
 
 	/**


### PR DESCRIPTION
This version adds capability to interpret words and bytes as signed.

Existing unsigned bindings data types are:

* \* (unsigned word, 0 to 65535)
* H (unsigned high byte, 0 to 255)
* L (unsigned low byte, 0 to 255)

New signed correspondent data types bindings are:

* + (signed word, -32768 to 32767)
* H+ (unsigned high byte, -128 to 127)
* L+ (unsigned low byte, -128 to 127)
