### PR TITLE
Log execution failures in ExecUtil.

### DIFF
--- a/bundles/io/org.openhab.io.net/src/main/java/org/openhab/io/net/exec/ExecUtil.java
+++ b/bundles/io/org.openhab.io.net/src/main/java/org/openhab/io/net/exec/ExecUtil.java
@@ -137,7 +137,12 @@ public class ExecUtil {
 			resultHandler.waitFor();
 			int exitCode = resultHandler.getExitValue();
 			retval = StringUtils.chomp(stdout.toString());
-			logger.debug("exit code '{}', result '{}'", exitCode, retval);
+			if (resultHandler.getException() != null) {
+				logger.warn(resultHandler.getException().getMessage());
+			}
+			else {
+				logger.debug("exit code '{}', result '{}'", exitCode, retval);
+			}
 
 		} catch (InterruptedException e) {
 			logger.error("Timeout occured when executing commandLine '"


### PR DESCRIPTION
Currently, the ExecUtil silently ignores exceptions caught by the Apache Commons Exec utilities. The `executor.execute` does not throw an exception so the existing implementation doesn't log the error. The exception is returned in the result handler. The change in this PR looks for an exception in the result handler and logs a warning with the exception message. This will apply to both the Exec transformation service and the Exec action and will help users diagnose problems with the external programs.