### PR TITLE
Added support for regex substitutions to Regex transformation

### DIFF
--- a/bundles/core/org.openhab.core.transform.test/src/test/java/org/openhab/core/transform/internal/RegExTransformationServiceTest.java
+++ b/bundles/core/org.openhab.core.transform.test/src/test/java/org/openhab/core/transform/internal/RegExTransformationServiceTest.java
@@ -69,5 +69,21 @@ public class RegExTransformationServiceTest extends AbstractTransformationServic
 		Assert.assertEquals("8", transformedResponse);
 	}
 	
+	@Test
+	public void testTransformByRegex_substituteFirst() throws TransformationException {
+		// method under test
+		String transformedResponse = processor.transform("s/^OP:(.*?),ARG:(.*)$/$1($2)/", "OP:SetMode,ARG:42");
+		
+		// Asserts
+		Assert.assertEquals("SetMode(42)", transformedResponse);
+	}
 
+	@Test
+	public void testTransformByRegex_substituteAll() throws TransformationException {
+		// method under test
+		String transformedResponse = processor.transform("s/([A-Z]+)([0-9]+),*/var$1=$2 /g", "X12,Y54");
+		
+		// Asserts
+		Assert.assertEquals("varX=12 varY=54 ", transformedResponse);
+	}
 }

--- a/bundles/core/org.openhab.core.transform/src/main/java/org/openhab/core/transform/internal/service/RegExTransformationService.java
+++ b/bundles/core/org.openhab.core.transform/src/main/java/org/openhab/core/transform/internal/service/RegExTransformationService.java
@@ -29,7 +29,9 @@ import org.slf4j.LoggerFactory;
 public class RegExTransformationService implements TransformationService {
 
 	static final Logger logger = LoggerFactory.getLogger(RegExTransformationService.class);
-
+	
+	private static final Pattern substPattern = Pattern.compile("^s/(.*?[^\\\\])/(.*?[^\\\\])/(.*)$");
+	
 	/**
 	 * @{inheritDoc
 	 */
@@ -42,7 +44,24 @@ public class RegExTransformationService implements TransformationService {
 		logger.debug("about to transform '{}' by the function '{}'", source, regExpression);
 
 		String result = source;
-
+		
+		Matcher substMatcher = substPattern.matcher(regExpression);
+		if (substMatcher.matches()) {
+			logger.debug("Using substitution form of regex transformation");
+			String regex = substMatcher.group(1);
+			String substitution = substMatcher.group(2);
+			String options = substMatcher.group(3);
+			if (options.equals("g")) {
+				result = source.trim().replaceAll(regex, substitution);
+			}
+			else {
+				result = source.trim().replaceFirst(regex, substitution);
+			}
+			if (result != null) {
+				return result;
+			}
+		}
+		
 		Matcher matcher = Pattern.compile("^" + regExpression + "$", Pattern.DOTALL).matcher(source.trim());
 		if (!matcher.matches()) {
 			logger.debug("the given regex '^{}$' doesn't match the given content '{}' -> couldn't compute transformation", regExpression, source);


### PR DESCRIPTION
This modification allows the Regex transformation to do substitutions. A substitution pattern is specified using a syntax similar to sed, Python, Perl, etcetera. The substitution will be performed if the regex looks like "s/<pattern>/<substitution>/". The substitution can use capturing groups using the "$n" syntax supported by Java regular expressions. By default, the substitution is applied to the first match. If a "g" is appended to the regex (e.g., "s/([0-9]+)000/$1K/g"), then the substitution if applied to all matches in the source string.