### PR TITLE
[Sapp Binding] BigDecimal precision in scaling vs double

### DIFF
--- a/bundles/binding/org.openhab.binding.sapp/src/main/java/org/openhab/binding/sapp/internal/SappBinding.java
+++ b/bundles/binding/org.openhab.binding.sapp/src/main/java/org/openhab/binding/sapp/internal/SappBinding.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.binding.sapp.internal;
 
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -406,7 +408,7 @@ public class SappBinding extends AbstractActiveBinding<SappBindingProvider> impl
 
 							// mask bits on previous value
 							int previousValue = getVirtualValue(provider, address.getPnmasId(), address.getAddress(), address.getSubAddress(), false);
-							int newValue = SappBindingConfigUtils.maskWithSubAddressAndSet(address.getSubAddress(), address.backScaledValue(((DecimalType) command).doubleValue()), previousValue);
+							int newValue = SappBindingConfigUtils.maskWithSubAddressAndSet(address.getSubAddress(), address.backScaledValue(((DecimalType) command).toBigDecimal()), previousValue);
 
 							// update pnmas
 							SappPnmas pnmas = provider.getPnmasMap().get(address.getPnmasId());
@@ -544,7 +546,7 @@ public class SappBinding extends AbstractActiveBinding<SappBindingProvider> impl
 
 							// mask bits on previous value
 							int previousValue = getVirtualValue(provider, address.getPnmasId(), address.getAddress(), address.getSubAddress(), false);
-							int newValue = SappBindingConfigUtils.maskWithSubAddressAndSet(address.getSubAddress(), address.backScaledValue(((PercentType) command).doubleValue()), previousValue);
+							int newValue = SappBindingConfigUtils.maskWithSubAddressAndSet(address.getSubAddress(), address.backScaledValue(((PercentType) command).toBigDecimal()), previousValue);
 
 							// update pnmas
 							SappPnmas pnmas = provider.getPnmasMap().get(address.getPnmasId());
@@ -721,7 +723,7 @@ public class SappBinding extends AbstractActiveBinding<SappBindingProvider> impl
 					SappAddressDimmer statusAddress = sappBindingConfigDimmerItem.getStatus();
 					if (statusAddress.getAddressType() == sappAddressType && statusAddress.getPnmasId().equals(pnmasId) && addressToUpdate == statusAddress.getAddress()) {
 						logger.debug("found binding to update {}", sappBindingConfigDimmerItem);
-						int result = (int) statusAddress.scaledValue(SappBindingConfigUtils.maskWithSubAddress(statusAddress.getSubAddress(), newState), statusAddress.getSubAddress());
+						int result = statusAddress.scaledValue(SappBindingConfigUtils.maskWithSubAddress(statusAddress.getSubAddress(), newState), statusAddress.getSubAddress()).round(new MathContext(0, RoundingMode.HALF_EVEN)).intValue();
 						if (result <= PercentType.ZERO.intValue()) {
 							eventPublisher.postUpdate(itemName, PercentType.ZERO);
 						} else if (result >= PercentType.HUNDRED.intValue()) {
@@ -914,7 +916,7 @@ public class SappBinding extends AbstractActiveBinding<SappBindingProvider> impl
 		switch (statusAddress.getAddressType()) {
 		case VIRTUAL:
 			try {
-				int result = (int) statusAddress.scaledValue(SappBindingConfigUtils.maskWithSubAddress(statusAddress.getSubAddress(), getVirtualValue(provider, statusAddress.getPnmasId(), statusAddress.getAddress(), statusAddress.getSubAddress(), true)), statusAddress.getSubAddress());
+				int result = statusAddress.scaledValue(SappBindingConfigUtils.maskWithSubAddress(statusAddress.getSubAddress(), getVirtualValue(provider, statusAddress.getPnmasId(), statusAddress.getAddress(), statusAddress.getSubAddress(), true)), statusAddress.getSubAddress()).round(new MathContext(0, RoundingMode.HALF_EVEN)).intValue();
 				if (result <= PercentType.ZERO.intValue()) {
 					eventPublisher.postUpdate(itemName, PercentType.ZERO);
 				} else if (result >= PercentType.HUNDRED.intValue()) {


### PR DESCRIPTION
While scaling values to and from Pnmas hardware, double precision has been substituted by BigDecimal.

New DecimalType are allocated and posted directly with BigDecimal constructor instead of using double constructor.