### PR TITLE
Temporarily disable sqlite persistence to fix build

### DIFF
--- a/bundles/persistence/org.openhab.persistence.jdbc/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.jdbc/META-INF/MANIFEST.MF
@@ -27,8 +27,7 @@ Import-Package: com.mysql.jdbc;resolution:=optional,
  org.openhab.model.item.binding,
  org.osgi.framework,
  org.postgresql;resolution:=optional,
- org.slf4j,
- org.sqlite;resolution:=optional
+ org.slf4j
 Bundle-ClassPath: .,
  lib/HikariCP-2.4.1.jar,
  lib/commons-dbutils-1.6.jar,


### PR DESCRIPTION
This is in addition to #3248 and #3490 

I don't fully understand why the "optional" resolution of org.sqlite breaks the build, but to avoid breaking the nightly build, I have temporarily disabled it.

@lewie , could you please have a look at the sqlite stuff?