### PR TITLE
Fix D-Link DCH-Z110 product catalog entry

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -2945,8 +2945,8 @@
 				<Id>000e</Id>
 			</Reference>
 			<Model>DCH-Z110</Model>
-			<Label lang="en">Remote Control</Label>
-			<ConfigFile>nodon/crc3100.xml</ConfigFile>
+			<Label lang="en">Door &amp; Window Sensor</Label>
+			<ConfigFile>dlink/dch-z110.xml</ConfigFile>
 		</Product>
 	</Manufacturer>
 	<Manufacturer>


### PR DESCRIPTION
Looks like an copy/paste error was made when adding the sensor, the catalog.xml points to some completely unrelated controller instead. 