### PR TITLE
PointType needs hashCode and equals to be used in tests

### DIFF
--- a/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/PointType.java
+++ b/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/types/PointType.java
@@ -203,4 +203,37 @@ public class PointType implements ComplexType, Command, State {
 		longitude = longitude.subtract(flat);
 	}
 
+	@Override
+	public int hashCode() {
+		int tmp = 10000 * (getLatitude() == null ? 0 : getLatitude().hashCode());
+		tmp += 100 * (getLongitude() == null ? 0 : getLongitude().hashCode());
+		tmp += (getAltitude() == null ? 0 : getAltitude().hashCode());
+		return tmp;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (!(obj instanceof PointType))
+			return false;
+		PointType other = (PointType) obj;
+		if ((getLatitude() != null && other.getLatitude() == null)
+				|| (getLatitude() == null && other.getLatitude() != null)
+				|| (getLongitude() != null && other.getLongitude() == null)
+				|| (getLongitude() == null && other.getLongitude() != null)
+				|| (getAltitude() != null && other.getAltitude() == null)
+				|| (getAltitude() == null && other.getAltitude() != null)) {
+			return false;
+		}
+		if (!getLatitude().equals(other.getLatitude())
+				|| !getLongitude().equals(other.getLongitude())
+				|| !getAltitude().equals(other.getAltitude())) {
+			return false;
+		}
+		return true;
+	}
+
 }


### PR DESCRIPTION
On trying to use `PointType` in a unit test, I discovered that it doesn't implement equals, so `assertEquals` always fails.