### PR TITLE
Modbus binding to close connections on configuration refresh

### DIFF
--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ModbusASCIITransport.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ModbusASCIITransport.java
@@ -60,9 +60,14 @@ public class ModbusASCIITransport
   }//constructor
   
   public void close() throws IOException {
-    m_InputStream.close();
-    m_OutputStream.close();
-  }//close
+    if (m_InputStream != null) {
+      m_InputStream.close();
+    }
+    if (m_OutputStream != null) {
+      m_OutputStream.close();
+    }
+    super.close();
+}// close
 
   public void writeMessage(ModbusMessage msg)
       throws ModbusIOException {

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ModbusBINTransport.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ModbusBINTransport.java
@@ -58,8 +58,13 @@ public class ModbusBINTransport
   }//constructor
 
   public void close() throws IOException {
-    m_InputStream.close();
-    m_OutputStream.close();
+    if (m_InputStream != null) {
+      m_InputStream.close();
+    }
+    if (m_OutputStream != null) {
+      m_OutputStream.close();
+    }
+    super.close();
   }//close
 
   public void writeMessage(ModbusMessage msg)

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ModbusRTUTransport.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ModbusRTUTransport.java
@@ -189,8 +189,13 @@ public class ModbusRTUTransport
   } //prepareStreams
 
   public void close() throws IOException {
-    m_InputStream.close();
-    m_OutputStream.close();
+    if (m_InputStream != null) {
+          m_InputStream.close();
+    }
+    if (m_OutputStream != null) {
+      m_OutputStream.close();
+    }
+    super.close();
   }//close
 
   private void getResponse(int fn, BytesOutputStream out)

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ModbusSerialTransport.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ModbusSerialTransport.java
@@ -99,7 +99,11 @@ abstract public class ModbusSerialTransport
    *
    * @exception IOException if an error occurs
    */
-  abstract public void close() throws IOException;
+  public void close() throws IOException {
+    if (m_CommPort != null) {
+      m_CommPort.close();
+    }
+  }
   
   /**
    * <code>setCommPort</code> sets the comm port member and prepares the input
@@ -109,6 +113,8 @@ abstract public class ModbusSerialTransport
    * @throws IOException if an I/O related error occurs.
    */
   public void setCommPort(CommPort cp) throws IOException {
+    // Close existing port, if any
+    close();
     m_CommPort = cp;
     if (cp != null) {
       prepareStreams(cp.getInputStream(), cp.getOutputStream());

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ModbusTCPTransaction.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ModbusTCPTransaction.java
@@ -222,9 +222,6 @@ public class ModbusTCPTransaction
     } catch (InterruptedException ex) {
       throw new ModbusIOException("Thread acquiring lock was interrupted.");
     } finally {
-    	if (m_Connection != null && m_Connection.isConnected()) {
-        	m_Connection.close();
-    	}
       m_TransactionLock.release();
     }
   }//execute

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ModbusTCPTransport.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ModbusTCPTransport.java
@@ -51,6 +51,7 @@ public class ModbusTCPTransport
   private DataInputStream m_Input;	  //input stream
   private DataOutputStream m_Output;	 //output stream
   private BytesInputStream m_ByteIn;
+  private Socket m_Socket;
 
   /**
    * Constructs a new <tt>ModbusTransport</tt> instance,
@@ -78,12 +79,22 @@ public class ModbusTCPTransport
    * @throws IOException if an I/O related error occurs.
    */
   public void setSocket(Socket socket) throws IOException {
+    // Close existing socket and streams, if any
+    close();
+    m_Socket = socket;
     prepareStreams(socket);
   }//setSocket
 
   public void close() throws IOException {
-    m_Input.close();
-    m_Output.close();
+    if (m_Input != null) {
+      m_Input.close();
+    }
+    if (m_Output != null) {
+      m_Output.close();
+    }
+    if (m_Socket != null) {
+      m_Socket.close();
+    }
   }//close
 
   public void writeMessage(ModbusMessage msg)

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/net/SerialConnection.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/net/SerialConnection.java
@@ -239,16 +239,16 @@ public class SerialConnection
       return;
     }
 
-    // Check to make sure sPort has reference to avoid a NPE.
-    if (m_SerialPort != null) {
-      try {
-        m_Transport.close();
-        m_SerialIn.close();
-      } catch (IOException e) {
-        logger.error(e.getMessage());
-      }
-      // Close the port.
-      m_SerialPort.close();
+    try {
+      m_Transport.close();
+    } catch (IOException e) {
+      logger.error(e.getMessage());
+    }
+
+    try {
+      m_SerialIn.close();
+    } catch (IOException e) {
+      logger.error(e.getMessage());
     }
 
     m_Open = false;

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/net/TCPMasterConnection.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/net/TCPMasterConnection.java
@@ -62,12 +62,14 @@ public class TCPMasterConnection {
    *
    * @throws Exception if there is a network failure.
    */
-  public synchronized void connect()
-      throws Exception {
-    if(!m_Connected) {
+  public synchronized void connect() throws Exception {
+    if (!isConnected()) {
       logger.debug("connect()");
       m_Socket = new Socket(m_Address, m_Port);
       setTimeout(m_Timeout);
+      m_Socket.setReuseAddress(true);
+      m_Socket.setSoLinger(true, 1);
+      m_Socket.setKeepAlive(true);
       prepareTransport();
       m_Connected = true;
     }
@@ -183,6 +185,15 @@ public class TCPMasterConnection {
    * @return <tt>true</tt> if connected, <tt>false</tt> otherwise.
    */
   public boolean isConnected() {
+    // From j2mod originally. Sockets that are not fully open are closed.
+    if (m_Connected && m_Socket != null) {      
+      // Call close() if the connection is not fully "open"
+      if (!m_Socket.isConnected() || m_Socket.isClosed()
+          || m_Socket.isInputShutdown()
+          || m_Socket.isOutputShutdown()) {
+        close();
+      }
+    }
     return m_Connected;
   }//isConnected
 

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
@@ -232,11 +232,17 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider> 
 		}
 	}
 	
+	private void clearSlaves() {
+		for(ModbusSlave slave : modbusSlaves.values()){
+			slave.resetConnection();
+		}
+		modbusSlaves.clear();
+	}
 
 	@Override
 	public void updated(Dictionary<String, ?> config) throws ConfigurationException {
 		// remove all known items if configuration changed
-		modbusSlaves.clear();
+		clearSlaves();
 		if (config != null) {
 			Enumeration<String> keys = config.keys();
 			while (keys.hasMoreElements()) {

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusTcpSlave.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusTcpSlave.java
@@ -55,7 +55,7 @@ public class ModbusTcpSlave extends ModbusIPSlave {
 				connection = new TCPMasterConnection(InetAddress.getByName(getHost()));
 		} catch (UnknownHostException e) {
 			logger.debug("ModbusSlave: Error connecting to master: {}", e.getMessage());
-			connection = null;
+			resetConnection();
 			return false;
 		}
 		if (!connection.isConnected())
@@ -72,6 +72,9 @@ public class ModbusTcpSlave extends ModbusIPSlave {
 	}
 	
 	public void resetConnection() {
+		if (connection != null) {
+			connection.close();
+		}
 		connection = null;
 	}
 

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusUdpSlave.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusUdpSlave.java
@@ -47,7 +47,7 @@ public class ModbusUdpSlave extends ModbusIPSlave {
 				connection = new UDPMasterConnection(InetAddress.getByName(getHost()));
 		} catch (UnknownHostException e) {
 			logger.debug("ModbusSlave: Error connecting to master: {}", e.getMessage());
-			connection = null;
+			resetConnection();
 			return false;
 		}
 		if (!connection.isConnected())
@@ -63,6 +63,9 @@ public class ModbusUdpSlave extends ModbusIPSlave {
 	}
 	
 	public void resetConnection() {
+		if (connection != null) {
+			connection.close();
+		}
 		connection = null;
 	}
 }


### PR DESCRIPTION
The following closes the connections when configuration changes (updated method). In addition, all resetConnection methods now properly close the connection.

Previously changes in openhab.cfg left old connections unclosed.