### PR TITLE
InsteonPLM: Include known features when an item is configured with an unknown feature

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/InsteonPLMActiveBinding.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/InsteonPLMActiveBinding.java
@@ -9,7 +9,9 @@
 package org.openhab.binding.insteonplm;
 
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -498,8 +500,22 @@ public class InsteonPLMActiveBinding
 			return;
 		}
 		DeviceFeature f = aDev.getFeature(aConfig.getFeature());
-		if (f == null) {
-			logger.error("item {} references unknown feature: {}, item disabled!", aItemName, aConfig.getFeature());
+		if (f == null || f.isFeatureGroup()) {
+			StringBuffer buf = new StringBuffer();
+			ArrayList<String> names = new ArrayList<String>(aDev.getFeatures().keySet());
+			Collections.sort(names);
+			for (String name : names) {
+				DeviceFeature feature = aDev.getFeature(name);
+				if (!feature.isFeatureGroup()) {
+					if (buf.length() > 0) {
+						buf.append(", ");
+					}
+					buf.append(name);
+				}
+			}
+
+			logger.error("item {} references unknown feature: {}, item disabled! Known features for {} are: {}.",
+					aItemName, aConfig.getFeature(), aConfig.getProductKey(), buf.toString());
 			return;
 		}
 		DeviceFeatureListener fl = new DeviceFeatureListener(this, aItemName, eventPublisher);

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/DeviceFeature.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/DeviceFeature.java
@@ -105,6 +105,7 @@ public class DeviceFeature {
 	public String	 	getName()			{ return m_name; }
 	public synchronized QueryStatus	getQueryStatus()	{ return m_queryStatus; }
 	public InsteonDevice getDevice() 		{ return m_device; }
+	public boolean      isFeatureGroup()    { return !m_connectedFeatures.isEmpty(); }
 	public boolean		isStatusFeature()	{ return m_isStatus; }
 	public int			getDirectAckTimeout() { return m_directAckTimeout; }
 	public MessageHandler getDefaultMsgHandler() { return m_defaultMsgHandler; }


### PR DESCRIPTION
Improve error logging by logging the known features when an unknown feature is accidentally used. The previous error message was:

    item foo references unknown feature: dimmer, item disabled!

It now is:

    item foo references unknown feature: dimmer, item disabled! Known features for F00.00.15 are: fastonoff, keypadbuttonA, keypadbuttonB, keypadbuttonC, keypadbuttonD, lastheardfrom, loaddimmer, manualchange.

@berndpfrommer does this look OK?