### PR TITLE
[Telegram action] UTF-8 messages bug fix

### DIFF
--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
@@ -67,6 +67,7 @@ public class Telegram {
 		HttpClient client = new HttpClient();
 
 		PostMethod postMethod = new PostMethod(url);
+		postMethod.getParams().setContentCharset("UTF-8");
 		postMethod.getParams().setSoTimeout(HTTP_TIMEOUT);
 		postMethod.getParams().setParameter(HttpMethodParams.RETRY_HANDLER,
 				new DefaultHttpMethodRetryHandler(3, false));


### PR DESCRIPTION
sendTelegram crashes when extended characters are sent.
Character encoding changed from the default ISO-8859-1 to UTF-8

problem addressed here: https://community.openhab.org/t/new-telegram-action/4459/2