### PR TITLE
OneWireBinding - Support for iButtons

### DIFF
--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/connection/OneWireConnection.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/connection/OneWireConnection.java
@@ -221,8 +221,13 @@ public class OneWireConnection {
 					logger.info("there is no device for path {}, read attempt={}", new Object[] { lvDevicePropertyPath, lvAttempt });
 				}
 			} catch (OwfsException oe) {
-				logger.error("reading from path " + lvDevicePropertyPath + " attempt " + lvAttempt + " throws exception", oe);
-				reconnect();
+				String lvLogText = "reading from path " + lvDevicePropertyPath + " attempt " + lvAttempt + " throws exception";
+				if (pvBindingConfig.isIgnoreReadErrors()) {
+					logger.debug(lvLogText, oe);
+				} else {
+					logger.error(lvLogText, oe);
+					reconnect();
+				}
 			} catch (IOException ioe) {
 				logger.error("couldn't establish network connection while read attempt " + lvAttempt + " '" + lvDevicePropertyPath + "' ip:port=" + cvIp + ":" + cvPort, ioe);
 				reconnect();

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/AbstractOneWireDevicePropertyBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/AbstractOneWireDevicePropertyBindingConfig.java
@@ -20,32 +20,31 @@ import org.slf4j.LoggerFactory;
 /**
  * Abstract class which defines a 1-Wire Device Property which can be read
  * 
- * Basic Configuration for an OneWire Binding:
- * <code>
+ * Basic Configuration for an OneWire Binding: <code>
  * 	onewire="deviceId=<i>deviceId</i>;propertyName<i>propertyName</i>"
  * </code>
  * 
- * Optional:
- * <code>refreshinterval=<i>value in seconds</i></code>
- * Defaults to 60 seconds
+ * Optional: <code>refreshinterval=<i>value in seconds</i></code> Defaults to 60
+ * seconds
  * 
  * Ignore 85°C power on reset values (DS18B20)
- * <code>ignore85CPowerOnResetValues</code>
- * Defaults to false 
+ * <code>ignore85CPowerOnResetValues</code> Defaults to false
  * 
- * Example:
- * <code>
+ * Example: <code>
  * 	onewire="deviceId=28.67C6697351FF;propertyName=temperature;refreshinterval=10"
  * </code>
  * 
- * Type-Modifiers can be configured to the items. The documentation of these possible modifiers, look into the specialized classes
+ * Type-Modifiers can be configured to the items. The documentation of these
+ * possible modifiers, look into the specialized classes
  * 
  * @author Dennis Riegelbauer
  * @since 1.7.0
  */
-public abstract class AbstractOneWireDevicePropertyBindingConfig implements OneWireBindingConfig {
+public abstract class AbstractOneWireDevicePropertyBindingConfig implements
+		OneWireBindingConfig {
 
-	private static final Logger logger = LoggerFactory.getLogger(AbstractOneWireDevicePropertyBindingConfig.class);
+	private static final Logger logger = LoggerFactory
+			.getLogger(AbstractOneWireDevicePropertyBindingConfig.class);
 
 	/**
 	 * deviceId like <code>28.67C6697351FF</code>
@@ -53,15 +52,20 @@ public abstract class AbstractOneWireDevicePropertyBindingConfig implements OneW
 	private String ivDeviceId;
 
 	/**
-	 * property name like <code>temperature</code>  
+	 * property name like <code>temperature</code>
 	 */
 	private String ivPropertyName;
-	
+
 	/**
 	 * ignore 85°C power on reset values (DS18B20)
 	 */
 	private boolean ivIgnore85CPowerOnResetValues = false;
-	
+
+	/**
+	 * don't log read errors, for iButtons for exapmle
+	 */
+	private boolean ivIgnoreReadErrors = false;
+
 	/**
 	 * Default autofresh value in seconds, can be set for each defined Item
 	 */
@@ -70,12 +74,14 @@ public abstract class AbstractOneWireDevicePropertyBindingConfig implements OneW
 	/** maintains state of filters for eliminating outliers */
 	private ArrayList<InterfaceOneWireTypeModifier> ivTypeModifieryList = new ArrayList<InterfaceOneWireTypeModifier>();
 
-	public AbstractOneWireDevicePropertyBindingConfig(String pvBindingConfig) throws BindingConfigParseException {
+	public AbstractOneWireDevicePropertyBindingConfig(String pvBindingConfig)
+			throws BindingConfigParseException {
 		super();
 		parseBindingConfig(pvBindingConfig);
 	}
 
-	private void parseBindingConfig(String pvBindingConfig) throws BindingConfigParseException {
+	private void parseBindingConfig(String pvBindingConfig)
+			throws BindingConfigParseException {
 		String[] pvConfigParts = pvBindingConfig.trim().split(";");
 
 		for (String pvConfigPart : pvConfigParts) {
@@ -83,12 +89,16 @@ public abstract class AbstractOneWireDevicePropertyBindingConfig implements OneW
 			parsePropertyName(pvConfigPart);
 			parseRefreshInterval(pvConfigPart);
 			parseIgnore85CPowerOnResetValues(pvConfigPart);
+			parseIgnoreReadErrors(pvConfigPart);
 		}
 
 		// DeviceId and property must be filled
-		if (this.ivDeviceId == null || this.ivDeviceId.trim().equals("") || this.ivPropertyName == null || this.ivPropertyName.trim().equals("")) {
+		if (this.ivDeviceId == null || this.ivDeviceId.trim().equals("")
+				|| this.ivPropertyName == null
+				|| this.ivPropertyName.trim().equals("")) {
 			logger.error("deviceId and propertyName not set in config!");
-			throw new BindingConfigParseException("Onewire sensor configuration must contain at least the deviceId and the propertyName");
+			throw new BindingConfigParseException(
+					"Onewire sensor configuration must contain at least the deviceId and the propertyName");
 		}
 	}
 
@@ -97,7 +107,8 @@ public abstract class AbstractOneWireDevicePropertyBindingConfig implements OneW
 
 		lvConfigProperty = "deviceId=";
 		if (pvConfigPart.startsWith(lvConfigProperty)) {
-			String lvConfigValue = pvConfigPart.substring(lvConfigProperty.length());
+			String lvConfigValue = pvConfigPart.substring(lvConfigProperty
+					.length());
 			this.setDeviceId(lvConfigValue);
 		}
 	}
@@ -107,17 +118,27 @@ public abstract class AbstractOneWireDevicePropertyBindingConfig implements OneW
 
 		lvConfigProperty = "propertyName=";
 		if (pvConfigPart.startsWith(lvConfigProperty)) {
-			String lvConfigValue = pvConfigPart.substring(lvConfigProperty.length());
+			String lvConfigValue = pvConfigPart.substring(lvConfigProperty
+					.length());
 			this.setPropertyName(lvConfigValue);
 		}
 	}
-	
+
+	private void parseIgnoreReadErrors(String pvConfigPart) {
+		String lvConfigProperty = null;
+
+		lvConfigProperty = "ignoreReadErrors";
+		if (pvConfigPart.equals(lvConfigProperty)) {
+			ivIgnoreReadErrors = true;
+		}
+	}
+
 	private void parseIgnore85CPowerOnResetValues(String pvConfigPart) {
 		String lvConfigProperty = null;
 
 		lvConfigProperty = "ignore85CPowerOnResetValues";
 		if (pvConfigPart.equals(lvConfigProperty)) {
-			ivIgnore85CPowerOnResetValues=true;
+			ivIgnore85CPowerOnResetValues = true;
 		}
 	}
 
@@ -126,7 +147,8 @@ public abstract class AbstractOneWireDevicePropertyBindingConfig implements OneW
 
 		lvConfigProperty = "refreshinterval=";
 		if (pvConfigPart.startsWith(lvConfigProperty)) {
-			String lvConfigValue = pvConfigPart.substring(lvConfigProperty.length());
+			String lvConfigValue = pvConfigPart.substring(lvConfigProperty
+					.length());
 			this.setAutoRefreshInSecs(Integer.parseInt(lvConfigValue));
 		}
 	}
@@ -154,7 +176,7 @@ public abstract class AbstractOneWireDevicePropertyBindingConfig implements OneW
 	public void setAutoRefreshInSecs(int pvAutoRefreshInSecs) {
 		this.ivAutoRefreshInSecs = pvAutoRefreshInSecs;
 	}
-	
+
 	public boolean isIgnore85CPowerOnResetValues() {
 		return ivIgnore85CPowerOnResetValues;
 	}
@@ -164,15 +186,25 @@ public abstract class AbstractOneWireDevicePropertyBindingConfig implements OneW
 		this.ivIgnore85CPowerOnResetValues = pvIgnore85CPowerOnResetValues;
 	}
 
+	public boolean isIgnoreReadErrors() {
+		return ivIgnoreReadErrors;
+	}
+
+	public void setIgnoreReadErrors(boolean pvIgnoreReadErrors) {
+		this.ivIgnoreReadErrors = pvIgnoreReadErrors;
+	}
+
 	/**
 	 * @return deviceId + / + propertyName
 	 */
 	public String getDevicePropertyPath() {
-		return new StringBuffer().append(getDeviceId()).append("/").append(getPropertyName()).toString();
+		return new StringBuffer().append(getDeviceId()).append("/")
+				.append(getPropertyName()).toString();
 	}
 
 	/**
-	 * @return a list of configured modifiers for this 1-Wire property device binding 
+	 * @return a list of configured modifiers for this 1-Wire property device
+	 *         binding
 	 */
 	public ArrayList<InterfaceOneWireTypeModifier> getTypeModifieryList() {
 		return ivTypeModifieryList;
@@ -181,15 +213,20 @@ public abstract class AbstractOneWireDevicePropertyBindingConfig implements OneW
 	/**
 	 * 
 	 * @param pvReadValue
-	 * @return the modified and converted given readValue String as a openHab-Type 
+	 * @return the modified and converted given readValue String as a
+	 *         openHab-Type
 	 */
 	public Type convertReadValueToType(String pvReadValue) {
 		Type lvType = convertReadValueToUnmodifiedType(pvReadValue);
 
 		for (InterfaceOneWireTypeModifier lvTypeModifier : getTypeModifieryList()) {
-			logger.debug("type of " + getDevicePropertyPath() + " before modifier:" + lvTypeModifier.getModifierName() + "type=" + lvType.toString());
+			logger.debug("type of " + getDevicePropertyPath()
+					+ " before modifier:" + lvTypeModifier.getModifierName()
+					+ "type=" + lvType.toString());
 			lvType = lvTypeModifier.modify4Read(lvType);
-			logger.debug("type of " + getDevicePropertyPath() + " after modifier:" + lvTypeModifier.getModifierName() + "type=" + lvType.toString());
+			logger.debug("type of " + getDevicePropertyPath()
+					+ " after modifier:" + lvTypeModifier.getModifierName()
+					+ "type=" + lvType.toString());
 		}
 
 		return lvType;
@@ -206,7 +243,15 @@ public abstract class AbstractOneWireDevicePropertyBindingConfig implements OneW
 	@Override
 	public String toString() {
 		final int maxLen = 20;
-		return "AbstractOneWireDevicePropertyBindingConfig [deviceId=" + ivDeviceId + ", propertyName=" + ivPropertyName + ", autoRefreshInSecs=" + ivAutoRefreshInSecs + ", typeModifieryList="
-				+ (ivTypeModifieryList != null ? ivTypeModifieryList.subList(0, Math.min(ivTypeModifieryList.size(), maxLen)) : null) + "]";
+		return "AbstractOneWireDevicePropertyBindingConfig [deviceId="
+				+ ivDeviceId
+				+ ", propertyName="
+				+ ivPropertyName
+				+ ", autoRefreshInSecs="
+				+ ivAutoRefreshInSecs
+				+ ", typeModifieryList="
+				+ (ivTypeModifieryList != null ? ivTypeModifieryList.subList(0,
+						Math.min(ivTypeModifieryList.size(), maxLen)) : null)
+				+ "]";
 	}
 }


### PR DESCRIPTION
Added a new parameter "ignoreReadErrors" to supress read-error log entries, if an iButton
is not present.