### PR TITLE
[Telegram action] enhancement: added send photo capability

### DIFF
--- a/bundles/action/org.openhab.action.telegram/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.telegram/META-INF/MANIFEST.MF
@@ -12,6 +12,7 @@ Bundle-Description: This is the Telegram action of the open Home Automation Bus 
 Import-Package: org.apache.commons.httpclient,
  org.apache.commons.httpclient.auth,
  org.apache.commons.httpclient.methods,
+ org.apache.commons.httpclient.methods.multipart,
  org.apache.commons.httpclient.params,
  org.apache.commons.io,
  org.apache.commons.lang,

--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
@@ -8,12 +8,18 @@
  */
 package org.openhab.action.telegram.internal;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
 
 import org.apache.commons.httpclient.DefaultHttpMethodRetryHandler;
 import org.apache.commons.httpclient.Header;
@@ -22,7 +28,13 @@ import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.NameValuePair;
+import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.httpclient.methods.multipart.ByteArrayPartSource;
+import org.apache.commons.httpclient.methods.multipart.FilePart;
+import org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity;
+import org.apache.commons.httpclient.methods.multipart.Part;
+import org.apache.commons.httpclient.methods.multipart.StringPart;
 import org.apache.commons.httpclient.params.HttpMethodParams;
 import org.apache.commons.io.IOUtils;
 import org.openhab.core.scriptengine.action.ActionDoc;
@@ -44,7 +56,9 @@ public class Telegram {
 			.getLogger(Telegram.class);
 
 	private static final String TELEGRAM_URL = "https://api.telegram.org/bot%s/sendMessage";
+	private static final String TELEGRAM_PHOTO_URL = "https://api.telegram.org/bot%s/sendPhoto";
 	private static final int HTTP_TIMEOUT = 2000;
+	private static final int HTTP_PHOTO_TIMEOUT = 10000;
 
 	private static Map<String, TelegramBot> groupTokens = new HashMap<String, TelegramBot>();
 
@@ -129,5 +143,109 @@ public class Telegram {
 			@ParamDoc(name = "args") Object... args) {
 
 		return sendTelegram(group, String.format(format, args));
+	}
+
+	@ActionDoc(text = "Sends a Picture via Telegram REST API")
+	static public boolean sendTelegramPhoto(
+			@ParamDoc(name = "group") String group,
+			@ParamDoc(name = "photoURL") String photoURL,
+			@ParamDoc(name = "caption") String caption) {
+
+		if (groupTokens.get(group) == null) {
+			logger.error("Bot '{}' not defined, action skipped", group);
+			return false;
+		}
+
+		if (photoURL == null) {
+			logger.error("photoURL not defined, action skipped");
+			return false;
+		}
+
+		// load image from url
+		byte[] imageFromURL;
+
+		HttpClient getClient = new HttpClient();
+		GetMethod getMethod = new GetMethod(photoURL);
+		getMethod.getParams().setSoTimeout(HTTP_PHOTO_TIMEOUT);
+		getMethod.getParams().setParameter(HttpMethodParams.RETRY_HANDLER,
+				new DefaultHttpMethodRetryHandler(3, false));
+		try {
+			int statusCode = getClient.executeMethod(getMethod);
+			if (statusCode != HttpStatus.SC_OK) {
+				logger.error("Method failed: {}", getMethod.getStatusLine());
+				return false;
+			}
+
+			imageFromURL = getMethod.getResponseBody();
+		} catch (HttpException e) {
+			logger.error("Fatal protocol violation: {}", e.toString());
+			return false;
+		} catch (IOException e) {
+			logger.error("Fatal transport error: {}", e.toString());
+			return false;
+		} finally {
+			getMethod.releaseConnection();
+		}
+
+		// parse image type
+		String imageType;
+		try {
+			ImageInputStream iis = ImageIO
+					.createImageInputStream(new ByteArrayInputStream(
+							imageFromURL));
+			Iterator<ImageReader> imageReaders = ImageIO.getImageReaders(iis);
+			if (!imageReaders.hasNext()) {
+				logger.error("photoURL does not represent a known image type");
+				return false;
+			}
+			ImageReader reader = (ImageReader) imageReaders.next();
+			imageType = reader.getFormatName();
+		} catch (IOException e) {
+			logger.error("cannot parse photoURL as image: {}", e.getMessage());
+			return false;
+		}
+
+		// post photo to telegram
+		String url = String.format(TELEGRAM_PHOTO_URL, groupTokens.get(group)
+				.getToken());
+
+		PostMethod postMethod = new PostMethod(url);
+		try {
+			postMethod.getParams().setContentCharset("UTF-8");
+			postMethod.getParams().setSoTimeout(HTTP_PHOTO_TIMEOUT);
+			postMethod.getParams().setParameter(HttpMethodParams.RETRY_HANDLER,
+					new DefaultHttpMethodRetryHandler(3, false));
+			Part[] parts = new Part[caption != null ? 3 : 2];
+			parts[0] = new StringPart("chat_id", groupTokens.get(group)
+					.getChatId());
+			parts[1] = new FilePart("photo", new ByteArrayPartSource(
+					String.format("image.%s", imageType), imageFromURL));
+			if (caption != null) {
+				parts[2] = new StringPart("caption", caption);
+			}
+			postMethod.setRequestEntity(new MultipartRequestEntity(parts,
+					postMethod.getParams()));
+
+			HttpClient client = new HttpClient();
+			int statusCode = client.executeMethod(postMethod);
+
+			if (statusCode == HttpStatus.SC_NO_CONTENT
+					|| statusCode == HttpStatus.SC_ACCEPTED) {
+				return true;
+			}
+
+			if (statusCode != HttpStatus.SC_OK) {
+				logger.error("Method failed: {}", postMethod.getStatusLine());
+				return false;
+			}
+		} catch (HttpException e) {
+			logger.error("Fatal protocol violation: {}", e.toString());
+		} catch (IOException e) {
+			logger.error("Fatal transport error: {}", e.toString());
+		} finally {
+			postMethod.releaseConnection();
+		}
+
+		return true;
 	}
 }


### PR DESCRIPTION
Added method to send pictures to Telegram.
Pictures are downloaded from a URL and sent to Telegram
An optional caption can be added to the picture.

Can be used to send surveillance systems screenshots.

Usage example
```
rule "Send telegram with image"
when
    Item Light_GF_Living_Table changed
then
    sendTelegramPhoto("bot1", "http://www.openhab.org/assets/images/openhab-logo-top.png", "sent from openHAB")
end
```
The third  parameter (caption) can be null (no caption is sent)