### PR TITLE
Add Souliss types 54, 55, 56 and 58 (light, voltage, current, pressure).

### DIFF
--- a/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/Constants.java
+++ b/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/Constants.java
@@ -75,6 +75,7 @@ public class Constants {
 	public static final short Souliss_T55_VoltageSensor = 0x55;
 	public static final short Souliss_T56_CurrentSensor = 0x56;
 	public static final short Souliss_T57_PowerSensor = 0x57;
+	public static final short Souliss_T58_PressureSensor = 0x58;
 
 	// customized (remote) AirCon commands
 	public static final int Souliss_T_IrCom_AirCon_Pow_On = 0x8FFE;

--- a/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT54.java
+++ b/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT54.java
@@ -12,8 +12,8 @@ package org.openhab.binding.souliss.internal.network.typicals;
  * Typical T54 Lux Sensor Derived from T51 Analog input, half-precision
  * floating point
  * 
- * @author Tonino Fazio
- * @since 1.7.0o
+ * @author Stephen Olesen
+ * @since 1.8.0
  */
 public class SoulissT54 extends SoulissT51 {
 

--- a/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT54.java
+++ b/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT54.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.souliss.internal.network.typicals;
+
+/**
+ * Typical T54 Lux Sensor Derived from T51 Analog input, half-precision
+ * floating point
+ * 
+ * @author Tonino Fazio
+ * @since 1.7.0o
+ */
+public class SoulissT54 extends SoulissT51 {
+
+	public SoulissT54(String sSoulissNodeIPAddressOnLAN, int iIDNodo,
+			int iSlot, String sOHType) {
+		super(sSoulissNodeIPAddressOnLAN, iIDNodo, iSlot, sOHType);
+		this.setType(Constants.Souliss_T54_LuxSensor);
+	}
+}

--- a/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT55.java
+++ b/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT55.java
@@ -12,8 +12,8 @@ package org.openhab.binding.souliss.internal.network.typicals;
  * Typical T55 Voltage Sensor Derived from T51 Analog input, half-precision
  * floating point
  * 
- * @author Tonino Fazio
- * @since 1.7.0o
+ * @author Stephen Olesen
+ * @since 1.8.0
  */
 public class SoulissT55 extends SoulissT51 {
 

--- a/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT55.java
+++ b/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT55.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.souliss.internal.network.typicals;
+
+/**
+ * Typical T55 Voltage Sensor Derived from T51 Analog input, half-precision
+ * floating point
+ * 
+ * @author Tonino Fazio
+ * @since 1.7.0o
+ */
+public class SoulissT55 extends SoulissT51 {
+
+	public SoulissT55(String sSoulissNodeIPAddressOnLAN, int iIDNodo,
+			int iSlot, String sOHType) {
+		super(sSoulissNodeIPAddressOnLAN, iIDNodo, iSlot, sOHType);
+		this.setType(Constants.Souliss_T55_VoltageSensor);
+	}
+}

--- a/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT56.java
+++ b/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT56.java
@@ -12,8 +12,8 @@ package org.openhab.binding.souliss.internal.network.typicals;
  * Typical T56 Current Sensor Derived from T51 Analog input, half-precision
  * floating point
  * 
- * @author Tonino Fazio
- * @since 1.7.0o
+ * @author Stephen Olesen
+ * @since 1.8.0
  */
 public class SoulissT56 extends SoulissT51 {
 

--- a/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT56.java
+++ b/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT56.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.souliss.internal.network.typicals;
+
+/**
+ * Typical T56 Current Sensor Derived from T51 Analog input, half-precision
+ * floating point
+ * 
+ * @author Tonino Fazio
+ * @since 1.7.0o
+ */
+public class SoulissT56 extends SoulissT51 {
+
+	public SoulissT56(String sSoulissNodeIPAddressOnLAN, int iIDNodo,
+			int iSlot, String sOHType) {
+		super(sSoulissNodeIPAddressOnLAN, iIDNodo, iSlot, sOHType);
+		this.setType(Constants.Souliss_T56_CurrentSensor);
+	}
+}

--- a/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT58.java
+++ b/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT58.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.souliss.internal.network.typicals;
+
+/**
+ * Typical T58 Pressure Sensor Derived from T51 Analog input, half-precision
+ * floating point
+ * 
+ * @author Tonino Fazio
+ * @since 1.7.0o
+ */
+public class SoulissT58 extends SoulissT51 {
+
+	public SoulissT58(String sSoulissNodeIPAddressOnLAN, int iIDNodo,
+			int iSlot, String sOHType) {
+		super(sSoulissNodeIPAddressOnLAN, iIDNodo, iSlot, sOHType);
+		this.setType(Constants.Souliss_T58_PressureSensor);
+	}
+}

--- a/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT58.java
+++ b/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/SoulissT58.java
@@ -12,8 +12,8 @@ package org.openhab.binding.souliss.internal.network.typicals;
  * Typical T58 Pressure Sensor Derived from T51 Analog input, half-precision
  * floating point
  * 
- * @author Tonino Fazio
- * @since 1.7.0o
+ * @author Stephen Olesen
+ * @since 1.8.0
  */
 public class SoulissT58 extends SoulissT51 {
 

--- a/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/TypicalFactory.java
+++ b/bundles/binding/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/network/typicals/TypicalFactory.java
@@ -85,8 +85,24 @@ public class TypicalFactory {
 			T = new SoulissT53(sSoulissNodeIPAddressOnLAN, iIDNodo, iSlot,
 					sOHType);
 			break;
+		case Constants.Souliss_T54_LuxSensor:
+			T = new SoulissT54(sSoulissNodeIPAddressOnLAN, iIDNodo, iSlot,
+					sOHType);
+			break;
+		case Constants.Souliss_T55_VoltageSensor:
+			T = new SoulissT55(sSoulissNodeIPAddressOnLAN, iIDNodo, iSlot,
+					sOHType);
+			break;
+		case Constants.Souliss_T56_CurrentSensor:
+			T = new SoulissT56(sSoulissNodeIPAddressOnLAN, iIDNodo, iSlot,
+					sOHType);
+			break;
 		case Constants.Souliss_T57_PowerSensor:
 			T = new SoulissT57(sSoulissNodeIPAddressOnLAN, iIDNodo, iSlot,
+					sOHType);
+			break;
+		case Constants.Souliss_T58_PressureSensor:
+			T = new SoulissT58(sSoulissNodeIPAddressOnLAN, iIDNodo, iSlot,
 					sOHType);
 			break;
 		case Constants.Souliss_TService_NODE_HEALTY:


### PR DESCRIPTION
Simple addition of Souliss types that are missing in the analog input typicals.