### PR TITLE
InsteonPLM: removed comments after port configuration in openhab_default.cfg

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1513,11 +1513,17 @@ tcp:refreshinterval=250
 #
 # examples of valid port configurations for serial or usb modems:
 #
-# insteonplm:port_0=/dev/insteon  (Linux, with serial port symlinked to /dev/insteon)
-# insteonplm:port_0=/dev/ttyS0    (Linux, with plain old serial modem)
-# insteonplm:port_0=/dev/ttyUSB0  (Linux, with usb based PLM modem)
-# insteonplm:port_0=COM1	  (Windows, with serial/usb modem on COM1)
-
+# Linux, with serial port symlinked to /dev/insteon:
+# insteonplm:port_0=/dev/insteon
+#
+# Linux, with plain old serial modem:
+# insteonplm:port_0=/dev/ttyS0
+#
+# Linux, with usb based PLM modem:
+# insteonplm:port_0=/dev/ttyUSB0
+#
+# Windows, with serial/usb modem on COM1:
+# insteonplm:port_0=COM1
 #
 # to connect to an Insteon Hub2 (the 2014 version) on port 25105 with
 # a poll interval of 1000ms = 1sec, use the following line. Use the login


### PR DESCRIPTION
Several people did not remove the comment behind the port configuration line in openhab_default.cfg. Fixed this to avoid users reporting the port does not work.