### PR TITLE
InsteonPLM: Improved logging of items that match devices in modem database

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/InsteonPLMActiveBinding.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/InsteonPLMActiveBinding.java
@@ -36,6 +36,7 @@ import org.openhab.binding.insteonplm.internal.driver.Poller;
 import org.openhab.binding.insteonplm.internal.message.FieldException;
 import org.openhab.binding.insteonplm.internal.message.Msg;
 import org.openhab.binding.insteonplm.internal.message.MsgListener;
+import org.openhab.binding.insteonplm.internal.utils.Utils;
 import org.openhab.core.binding.AbstractActiveBinding;
 import org.openhab.core.binding.BindingProvider;
 import org.openhab.core.types.Command;
@@ -476,7 +477,7 @@ public class InsteonPLMActiveBinding
 		HashMap<InsteonAddress, ModemDBEntry> dbes = m_driver.lockModemDBEntries();
 		if (dbes.containsKey(addr)) {
 			if (!dev.hasModemDBEntry()) {
-				logger.info("device {} found in the modem database!", addr);
+				logger.info("device {} found in the modem database and {}.", addr, getLinkInfo(dbes, addr));
 				dev.setHasModemDBEntry(true);
 			}
 		} else {
@@ -523,6 +524,48 @@ public class InsteonPLMActiveBinding
 		f.addListener(fl);	
 	}
 
+	private String getLinkInfo(HashMap<InsteonAddress, ModemDBEntry> dbes,
+			InsteonAddress a) {
+		ModemDBEntry dbe = dbes.get(a);
+		ArrayList<Byte> controls = dbe.getControls();
+		ArrayList<Byte> responds = dbe.getRespondsTo();
+
+		StringBuffer buf = new StringBuffer("the modem");
+		if (!controls.isEmpty()) {
+			buf.append(" controls groups [");
+			buf.append(toGroupString(controls));
+			buf.append("]");
+		}
+
+		if (!responds.isEmpty()) {
+			if (!controls.isEmpty()) {
+				buf.append(" and");
+			}
+
+			buf.append(" responds to groups [");
+			buf.append(toGroupString(responds));
+			buf.append("]");
+		}
+
+		return buf.toString();
+	}
+
+	private String toGroupString(ArrayList<Byte> group) {
+		ArrayList<Byte> sorted = new ArrayList<Byte>(group);
+		Collections.sort(sorted);
+
+		StringBuffer buf = new StringBuffer();
+		for (Byte b : sorted) {
+			if (buf.length() > 0) {
+				buf.append(",");
+			}
+			buf.append("0x");
+			buf.append(Utils.getHexString(b));
+		}
+
+		return buf.toString();
+	}
+
 	/**
 	 * Handles messages that come in from the ports.
 	 * Will only process one message at a time.
@@ -556,6 +599,7 @@ public class InsteonPLMActiveBinding
 			for (InsteonAddress k : dbes.keySet()) {
 				logger.debug("modem db entry: {}", k);
 			}
+			HashSet<InsteonAddress> addrs = new HashSet<InsteonAddress>();
 			for (InsteonDevice dev : m_devices.values()) {
 				InsteonAddress a = dev.getAddress();
 				if (!dbes.containsKey(a)) {
@@ -563,12 +607,19 @@ public class InsteonPLMActiveBinding
 						logger.warn("device {} not found in the modem database. Did you forget to link?", a);
 				} else {
 					if (!dev.hasModemDBEntry()) {
-						logger.info("device {}     found in the modem database!", a);
+						addrs.add(a);
+						logger.info("device {} found in the modem database and {}.", a, getLinkInfo(dbes, a));
 						dev.setHasModemDBEntry(true);
 					}
 					if (dev.getStatus() != DeviceStatus.POLLING) {
 						Poller.s_instance().startPolling(dev, dbes.size());
 					}
+				}
+			}
+			for (InsteonAddress k : dbes.keySet()) {
+				if (!addrs.contains(k) && !k.equals(dbes.get(k).getPort().getAddress())) {
+					logger.info("device {} found in the modem database, but is not configured as an item and {}.",
+							k, getLinkInfo(dbes, k));
 				}
 			}
 			m_driver.unlockModemDBEntries();

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/ModemDBBuilder.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/ModemDBBuilder.java
@@ -163,6 +163,17 @@ public class ModemDBBuilder implements MsgListener, Runnable {
 		dbe.setPort(port);
 		if (m != null) {
 			dbe.addLinkRecord(m);
+			try {
+				byte group =  m.getByte("ALLLinkGroup");
+				int recordFlags = m.getByte("RecordFlags") & 0xff;
+				if ((recordFlags & (0x1 << 6)) != 0) {
+					dbe.addControls(group);
+				} else {
+					dbe.addRespondsTo(group);
+				}
+			} catch (FieldException e) {
+				logger.error("cannot access field:", e);
+			}
 		}
 		port.getDriver().unlockModemDBEntries();
 	}

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/ModemDBEntry.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/ModemDBEntry.java
@@ -9,8 +9,11 @@
 package org.openhab.binding.insteonplm.internal.driver;
 
 import java.util.ArrayList;
+import java.util.Collections;
+
 import org.openhab.binding.insteonplm.internal.device.InsteonAddress;
 import org.openhab.binding.insteonplm.internal.message.Msg;
+import org.openhab.binding.insteonplm.internal.utils.Utils;
 
 /*
  * The ModemDBEntry class holds a modem device type record
@@ -23,19 +26,41 @@ public class ModemDBEntry {
 	private InsteonAddress	m_address = null;
 	private Port			m_port = null;
 	private	ArrayList<Msg>	m_linkRecords = new ArrayList<Msg>();
+	private ArrayList<Byte> m_controls = new ArrayList<Byte>();
+	private ArrayList<Byte> m_respondsTo = new ArrayList<Byte>();
 	
 	public ModemDBEntry(InsteonAddress aAddr) {	m_address = aAddr; }
 	public ArrayList<Msg> getLinkRecords() { return m_linkRecords; }
 	public void addLinkRecord(Msg m) { m_linkRecords.add(m); }
+	public void addControls(byte c) { m_controls.add(c); }
+	public ArrayList<Byte> getControls() { return m_controls; }
+	public void addRespondsTo(byte r) { m_respondsTo.add(r); }
+	public ArrayList<Byte> getRespondsTo() { return m_respondsTo; }
 	public void setPort(Port p) { m_port = p; }
 	public Port getPort() { return m_port; }
 	
 	public String toString() {
-		String s = "addr:" + m_address + "|link_recors";
+		String s = "addr:" + m_address +"|controls:[" + toGroupString(m_controls)
+				+ "]|responds_to:["+ toGroupString(m_respondsTo) + "]|link_recors";
 		for (Msg m : m_linkRecords) {
 			s += ":(" + m + ")";
 		}
 		return s;
 	}
-	
+
+	private String toGroupString(ArrayList<Byte> group) {
+		ArrayList<Byte> sorted = new ArrayList<Byte>(group);
+		Collections.sort(sorted);
+
+		StringBuffer buf = new StringBuffer();
+		for (Byte b : sorted) {
+			if (buf.length() > 0) {
+				buf.append(",");
+			}
+			buf.append("0x");
+			buf.append(Utils.getHexString(b));
+		}
+
+		return buf.toString();
+	}
 }


### PR DESCRIPTION
Improved logging of items that match devices in modem database by including groups that the modem controls and responds to with the device. Also log info about devices that are not configured with any items. For example:

    2015-12-28 08:55:29.402 [INFO ] [.o.b.i.InsteonPLMActiveBinding] - device 21.F7.C8 found in the modem database and the modem controls groups [0xFE].
    2015-12-28 08:55:29.406 [INFO ] [.o.b.i.InsteonPLMActiveBinding] - device 23.A0.51 found in the modem database and the modem controls groups [0xFE] and responds to groups [0x01].
    2015-12-28 08:55:29.412 [INFO ] [.o.b.i.InsteonPLMActiveBinding] - device 22.F6.88 found in the modem database and the modem controls groups [0xFE,0x03,0x04,0x05,0x06] and responds to groups [0x01,0x03,0x04,0x05,0x06].
    2015-12-28 08:55:29.416 [INFO ] [.o.b.i.InsteonPLMActiveBinding] - device 24.F2.7E found in the modem database, but is not configured as an item and the modem controls groups [0xFE] and responds to groups [0x01].
