### PR TITLE
Corrected signature for add and remove methods of BindingProviders

### DIFF
--- a/bundles/binding/org.openhab.binding.ebus/src/main/java/org/openhab/binding/ebus/internal/EBusBinding.java
+++ b/bundles/binding/org.openhab.binding.ebus/src/main/java/org/openhab/binding/ebus/internal/EBusBinding.java
@@ -27,6 +27,7 @@ import org.openhab.binding.ebus.internal.parser.EBusTelegramParser;
 import org.openhab.binding.ebus.internal.utils.EBusUtils;
 import org.openhab.binding.ebus.internal.utils.StateUtils;
 import org.openhab.core.binding.AbstractBinding;
+import org.openhab.core.binding.BindingProvider;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.osgi.service.cm.Configuration;
@@ -202,7 +203,7 @@ public class EBusBinding extends AbstractBinding<EBusBindingProvider> implements
 	 * @see org.openhab.core.binding.AbstractBinding#addBindingProvider(org.openhab.core.binding.BindingProvider)
 	 */
 	@Override
-	public void addBindingProvider(EBusBindingProvider provider) {
+	public void addBindingProvider(BindingProvider provider) {
 		super.addBindingProvider(provider);
 
 		if(commandProcessor == null) {
@@ -222,7 +223,7 @@ public class EBusBinding extends AbstractBinding<EBusBindingProvider> implements
 	 * @see org.openhab.core.binding.AbstractBinding#removeBindingProvider(org.openhab.core.binding.BindingProvider)
 	 */
 	@Override
-	public void removeBindingProvider(EBusBindingProvider provider) {
+	public void removeBindingProvider(BindingProvider provider) {
 		super.removeBindingProvider(provider);
 		provider.removeBindingChangeListener(commandProcessor);
 	}

--- a/bundles/binding/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/internal/ExecBinding.java
+++ b/bundles/binding/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/internal/ExecBinding.java
@@ -28,6 +28,7 @@ import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.exec.ExecBindingProvider;
 import org.openhab.core.binding.AbstractActiveBinding;
+import org.openhab.core.binding.BindingProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.ContactItem;
 import org.openhab.core.library.items.NumberItem;
@@ -411,9 +412,8 @@ public class ExecBinding extends AbstractActiveBinding<ExecBindingProvider> impl
 	}
 
 	@Override
-	public void addBindingProvider(ExecBindingProvider provider) {
+	public void addBindingProvider(BindingProvider provider) {
 		super.addBindingProvider(provider);
-		
 		
 		setProperlyConfigured(true);
 	}

--- a/bundles/binding/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnBinding.java
+++ b/bundles/binding/org.openhab.binding.lcn/src/main/java/org/openhab/binding/lcn/internal/LcnBinding.java
@@ -201,14 +201,14 @@ public class LcnBinding<P extends LcnGenericBindingProvider> extends AbstractBin
 	
 	/** {@inheritDoc} */
 	@Override
-	public void addBindingProvider(P provider) {
+	public void addBindingProvider(BindingProvider provider) {
 		super.addBindingProvider(provider);
 		this.activeService.start();
 	}
 
 	/** {@inheritDoc} */
 	@Override
-	public void removeBindingProvider(P provider) {
+	public void removeBindingProvider(BindingProvider provider) {
 		super.removeBindingProvider(provider);
 		// If there are no binding providers left, we can stop the service
 		if (this.providers.size() == 0) {

--- a/bundles/core/org.openhab.core/src/main/java/org/openhab/core/binding/AbstractActiveBinding.java
+++ b/bundles/core/org.openhab.core/src/main/java/org/openhab/core/binding/AbstractActiveBinding.java
@@ -37,7 +37,7 @@ public abstract class AbstractActiveBinding<P extends BindingProvider> extends A
 	 * 
 	 * @param provider the new {@link BindingProvider} to add
 	 */
-	public void addBindingProvider(P provider) {
+	public void addBindingProvider(BindingProvider provider) {
 		super.addBindingProvider(provider);
 		activeService.activate();
 	}
@@ -48,7 +48,7 @@ public abstract class AbstractActiveBinding<P extends BindingProvider> extends A
 	 * 
 	 * @param provider the {@link BindingProvider} to remove
 	 */
-	public void removeBindingProvider(P provider) {
+	public void removeBindingProvider(BindingProvider provider) {
 		super.removeBindingProvider(provider);
 		
 		// if there are no binding providers there is no need to run this 

--- a/bundles/core/org.openhab.core/src/main/java/org/openhab/core/binding/AbstractBinding.java
+++ b/bundles/core/org.openhab.core/src/main/java/org/openhab/core/binding/AbstractBinding.java
@@ -53,8 +53,9 @@ public abstract class AbstractBinding<P extends BindingProvider> extends Abstrac
 	 * 
 	 * @param provider the new {@link BindingProvider} to add
 	 */
-	public void addBindingProvider(P provider) {
-		this.providers.add(provider);
+	@SuppressWarnings("unchecked")
+	public void addBindingProvider(BindingProvider provider) {
+		this.providers.add((P) provider);
         provider.addBindingChangeListener(this);
         allBindingsChanged(provider);
     }
@@ -65,7 +66,7 @@ public abstract class AbstractBinding<P extends BindingProvider> extends Abstrac
 	 * 
 	 * @param provider the {@link BindingProvider} to remove
 	 */
-	public void removeBindingProvider(P provider) {
+	public void removeBindingProvider(BindingProvider provider) {
 		this.providers.remove(provider);
 		provider.removeBindingChangeListener(this);
 	}


### PR DESCRIPTION
Declarative Service components expect the interface to be the parameter to these methods and not a generified subtype of it.

Signed-off-by: Kai Kreuzer <kai@openhab.org>