### PR TITLE
Update default config for BenQ binding

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1672,14 +1672,21 @@ tcp:refreshinterval=250
 
 ############################# BenqProjector Binding  ##################################
 
-# Define the Serial to Ethernet device location
+# mode controls how the projector can be reached. 'serial' is for a directly
+# connected RS232 serial interface while 'network' is for using a TCP/IP to
+# serial converter
+#benqprojector:mode=network
+
+# For mode=network, define the Serial to Ethernet device location
 #benqprojector:deviceId=<hostname>:<port>
+
+# For mode=serial, define the serial device (e.g. /dev/ttyUSB0) and speed
+# (defaults to 57600 bps)
+#benqprojector:deviceId=<device>:<speed>
 
 # Define polling interval in milliseconds
 #benqprojector:refresh=15000
 
-# following is default, non-network mode is not implemented
-#benqprojector:networkMode=true 
 
 ############################### Libelium eHealth ######################################
 #


### PR DESCRIPTION
Since we actually have a working direct serial binding for BenQ
projectors it's only appropriate we also update the default
configuration to reflect this!