### PR TITLE
Osram-Par16-50-Workaround

### DIFF
--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
  * 
  * @author Roman Hartmann
  * @author Jos Schering
+ * @author Markus Mazurczak - Added function to retrieve the model ID of a bulb
  * @since 1.2.0
  */
 public class HueSettings {
@@ -78,6 +79,21 @@ public class HueSettings {
 			}
 		}
 		return isAuthorizationError;
+	}
+	
+	/**
+	 * Returns the model-ID of the bulb
+	 * 
+	 * @param deviceId The bulb id the bridge has filed the bulb under.
+	 * @return The model-ID. Null if Hue bridge is not initialized correctly or if the ID was not parsed correctly
+	 */
+	public String getModelId(String deviceId) {
+		if (settingsData == null) {
+			logger.error("Hue bridge settings not initialized correctly.");
+			return null;
+		}
+		Object modelId = settingsData.node("lights").node(deviceId).value("modelid");
+		return modelId != null ? modelId.toString() : null;
 	}
 	
 	/**


### PR DESCRIPTION
Implemented workaround code to correctly manage On/Off Switching of
Osram Par16 50 TW bulbs.

I dont know why git thinks that I deleted the complete content of both files. I did the following changes:
* [HueSettings.java](https://github.com/openhab/openhab/blob/b15d832a3195947a20bd7534cfbe8e0dbf2f138a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java#L84-L102)
* [HueBulb.java](https://github.com/openhab/openhab/blob/b15d832a3195947a20bd7534cfbe8e0dbf2f138a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBulb.java#L49-L52)
* [HueBulb.java](https://github.com/openhab/openhab/blob/b15d832a3195947a20bd7534cfbe8e0dbf2f138a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBulb.java#L95-L98)
* [HueBulb.java](https://github.com/openhab/openhab/blob/b15d832a3195947a20bd7534cfbe8e0dbf2f138a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBulb.java#L170-L171)
* [HueBulb.java](https://github.com/openhab/openhab/blob/b15d832a3195947a20bd7534cfbe8e0dbf2f138a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBulb.java#L188-L200)

Signed-off-by: markusmazurczak <coding@markus-mazurczak.de>