### PR TITLE
Add type for maxCube binding to get informed about connection errors

### DIFF
--- a/bundles/binding/org.openhab.binding.maxcube.test/src/test/java/org/openhab/binding/maxcube/internal/message/ConfigurationTest.java
+++ b/bundles/binding/org.openhab.binding.maxcube.test/src/test/java/org/openhab/binding/maxcube/internal/message/ConfigurationTest.java
@@ -12,7 +12,6 @@ import junit.framework.Assert;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.openhab.binding.maxcube.internal.Utils;
 
 /**
 * @author Andreas Heil (info@aheil.de)
@@ -52,12 +51,9 @@ public final String rawData = "C:003508,0gA1CAEBFP9JRVEwMTA5MTI1KCg9CQcoAzAM/wBE
 	}
 	
 	@Test
-	public void getSerialNumberTes() {
+	public void getSerialNumberTest() {
 		String serialNumber = configuration.getSerialNumber();
 		
 		Assert.assertEquals("IEQ0109125", serialNumber);
 	}
-	
-	
-	
 }

--- a/bundles/binding/org.openhab.binding.maxcube.test/src/test/java/org/openhab/binding/maxcube/internal/message/L_MessageTest.java
+++ b/bundles/binding/org.openhab.binding.maxcube.test/src/test/java/org/openhab/binding/maxcube/internal/message/L_MessageTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.maxcube.internal.message;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.junit.Before;
+
+import static junit.framework.Assert.*;
+
+/**
+ * @author Dominic Lerbs
+ * @since 1.8.0
+ */
+public class L_MessageTest {
+
+	private static final String rawData = "L:BgVPngkSEAsLhBkJEhkLJQDAAAsLhwwJEhkRJwDKAAYO8ZIJEhAGBU+kCRIQCwxuRPEaGQMmAMcACwxuQwkSGQgnAM8ACwQd5t0SGQ0oAMsA";
+
+	private final Map<String, Device> testDevices = new HashMap<>();
+
+	private L_Message message;
+	private final List<Configuration> configurations = new ArrayList<>();
+
+	@Before
+	public void setUp() {
+		message = new L_Message(rawData);
+		createTestDevices();
+	}
+	
+	private void createTestDevices(){
+		addShutterContact("054f9e");
+		addShutterContact("0ef192");
+		addShutterContact("054fa4");
+		addHeatingThermostat("0b8419");
+		addHeatingThermostat("0b870c");
+		addHeatingThermostat("0c6e43");
+		addHeatingThermostat("041de6");
+		addHeatingThermostat("0c6e44").setError(true);
+	}
+
+	private ShutterContact addShutterContact(String rfAddress){
+		ShutterContact device = new ShutterContact(createConfiguration(DeviceType.ShutterContact, rfAddress));
+		testDevices.put(rfAddress, device);
+		return device;
+	}
+	
+	private HeatingThermostat addHeatingThermostat(String rfAddress){
+		HeatingThermostat device = new HeatingThermostat(createConfiguration(DeviceType.HeatingThermostat, rfAddress));
+		testDevices.put(rfAddress, device);
+		return device;
+	}
+	
+	private Configuration createConfiguration(DeviceType type, String rfAddress) {
+		Configuration configuration = Configuration.create(new DeviceInformation(type, "", rfAddress, "", 1));
+		configurations.add(configuration);
+		return configuration;
+	}
+
+	@Test
+	public void isCorrectMessageType() {
+		MessageType messageType = ((Message) message).getType();
+		assertEquals(MessageType.L, messageType);
+	}
+
+	@Test
+	public void allDevicesCreatedFromMessage() {
+		Collection<? extends Device> devices = message.getDevices(configurations);
+		assertEquals("Incorrect number of devices created", testDevices.size(), devices.size());
+		for (Device device : devices) {
+			assertTrue("Unexpected device created: " + device.getRFAddress(),
+					testDevices.containsKey(device.getRFAddress()));
+		}
+	}
+
+	@Test
+	public void isCorrectErrorState() {
+		Collection<? extends Device> devices = message.getDevices(configurations);
+		for (Device device : devices) {
+			Device testDevice = testDevices.get(device.getRFAddress());
+			assertEquals("Error set incorrectly in Device", testDevice.isError(), device.isError());
+		}
+	}
+	
+}

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/BindingType.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/BindingType.java
@@ -15,5 +15,5 @@ package org.openhab.binding.maxcube.internal;
 * @since 1.4.0
 */
 public enum BindingType {
-	VALVE, BATTERY , MODE, ACTUAL
+	VALVE, BATTERY , MODE, ACTUAL, CONNECTION_ERROR
 }

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/MaxCubeGenericBindingProvider.java
@@ -15,6 +15,7 @@ import org.openhab.core.library.items.DimmerItem;
 import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.items.ContactItem;
 import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.items.SwitchItem;
 import org.openhab.model.item.binding.AbstractGenericBindingProvider;
 import org.openhab.model.item.binding.BindingConfigParseException;
 
@@ -34,6 +35,7 @@ import org.openhab.model.item.binding.BindingConfigParseException;
  * <li>{ maxcube="JEQ304492:type=battery" } - returns the current battery state as text.</li>
  * <li>{ maxcube="JEQ304492:type=mode" } - returns the current mode as text.</li>
  * <li>{ maxcube="JEQ304492:type=actual" } - returns the current measured temparature.</li>
+ * <li>{ maxcube="JEQ304492:type=connectionError" } - returns if connection error exists between cube and device.</li>
  * </ul>
  * @author Andreas Heil
  * @since 1.4.0
@@ -52,9 +54,14 @@ public class MaxCubeGenericBindingProvider extends AbstractGenericBindingProvide
 	 */
 	@Override
 	public void validateItemType(Item item, String bindingConfig) throws BindingConfigParseException {
-		if (!(item instanceof NumberItem || item instanceof DimmerItem || item instanceof ContactItem || item instanceof StringItem)) {
-			throw new BindingConfigParseException("item '" + item.getName() + "' is of type '" + item.getClass().getSimpleName()
-					+ "', only Number-, Dimmer-, Contact- and StringItems are allowed - please check your *.items configuration");
+		if (!(item instanceof NumberItem || item instanceof DimmerItem || item instanceof ContactItem
+				|| item instanceof StringItem || item instanceof SwitchItem)) {
+			throw new BindingConfigParseException(
+					"item '"
+							+ item.getName()
+							+ "' is of type '"
+							+ item.getClass().getSimpleName()
+							+ "', only Number-, Dimmer-, Contact-, Switch- and StringItems are allowed - please check your *.items configuration");
 		}
 	}
 
@@ -71,9 +78,6 @@ public class MaxCubeGenericBindingProvider extends AbstractGenericBindingProvide
 		}
 
 		MaxCubeBindingConfig config = new MaxCubeBindingConfig();
-
-		item.getName();
-
 		config.serialNumber = configParts[0];
 
 		for (int i = 1; i < configParts.length; i++) {
@@ -87,10 +91,11 @@ public class MaxCubeGenericBindingProvider extends AbstractGenericBindingProvide
 					config.bindingType = BindingType.ACTUAL;
 				} else if (bindingToken[1].toLowerCase().equals("battery")) {
 					config.bindingType = BindingType.BATTERY;
+				} else if (bindingToken[1].toLowerCase().equals("connectionerror")) {
+					config.bindingType = BindingType.CONNECTION_ERROR;
 				}
 			}
 		}
-
 		addBindingConfig(item, config);
 	}
 

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/Device.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/Device.java
@@ -9,7 +9,6 @@
 package org.openhab.binding.maxcube.internal.message;
 
 import java.util.Date;
-import java.util.Calendar;
 import java.util.List;
 
 import org.openhab.binding.maxcube.internal.Utils;
@@ -29,15 +28,16 @@ public abstract class Device {
 
 	protected final static Logger logger = LoggerFactory.getLogger(Device.class);
 
-	private String serialNumber = "";
-	private String rfAddress = "";
-	private int roomId = -1;
+	private final String serialNumber;
+	private final String rfAddress;
+	private final int roomId;
 
 	private final Battery battery = new Battery();
 
 	private boolean initialized;
 	private boolean answer;
-	private boolean error;
+	private Boolean error = null;
+	private boolean errorUpdated;
 	private boolean valid;
 	private boolean DstSettingsActive;
 	private boolean gatewayKnown;
@@ -51,10 +51,6 @@ public abstract class Device {
 	}
 
 	public abstract DeviceType getType();
-
-	public abstract String getName();
-
-	public abstract Calendar getLastUpdate();
 
 	private static Device create(String rfAddress, List<Configuration> configurations) {
 		Device returnValue = null;
@@ -204,16 +200,8 @@ public abstract class Device {
 		return this.rfAddress;
 	}
 
-	public final void setRFAddress(String rfAddress) {
-		this.rfAddress = rfAddress;
-	}
-
 	public final int getRoomId() {
 		return roomId;
-	}
-
-	public final void setRoomId(int roomId) {
-		this.roomId = roomId;
 	}
 
 	private void setLinkStatusError(boolean linkStatusError) {
@@ -236,9 +224,20 @@ public abstract class Device {
 		this.valid = valid;
 	}
 
-	private void setError(boolean error) {
-		this.error = error;
-
+	protected void setError(boolean newError) {
+		errorUpdated = (this.error == null) || (this.error != newError);
+		this.error = newError;
+		if (newError){
+			logger.warn("Connection error occurred between cube and device '{}'", this.toString());
+		}
+	}
+	
+	public boolean isError(){
+		return Boolean.TRUE.equals(error);
+	}
+	
+	public boolean isErrorUpdated(){
+		return errorUpdated;
 	}
 
 	public String getSerialNumber() {
@@ -251,5 +250,10 @@ public abstract class Device {
 
 	private void setAnswer(boolean answer) {
 		this.answer = answer;
+	}
+	
+	@Override
+	public String toString() {
+		return rfAddress + " - " + serialNumber;
 	}
 }

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/HeatingThermostat.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/HeatingThermostat.java
@@ -8,8 +8,6 @@
  */
 package org.openhab.binding.maxcube.internal.message;
 
-import java.text.DecimalFormat;
-import java.util.Calendar;
 import java.util.Date;
 
 import org.openhab.core.library.types.DecimalType;
@@ -61,19 +59,6 @@ public class HeatingThermostat extends Device {
 	 */
 	void setType (DeviceType type) {
 		this.deviceType = type;
-	}
-
-
-	@Override
-	public String getName() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public Calendar getLastUpdate() {
-		// TODO Auto-generated method stub
-		return null;
 	}
 
 	/**
@@ -140,8 +125,8 @@ public class HeatingThermostat extends Device {
 	}
 
 	/**
-	 * Returns the measured temperature  of this thermostat. 
-	 * 0�C is displayed if no actual is measured. Temperature is only updated after valve position changes
+	 * Returns the measured temperature of this thermostat. 
+	 * 0°C is displayed if no actual is measured. Temperature is only updated after valve position changes
 	 *
 	 * @return 
 	 * 			the actual temperature as <code>DecimalType</code>

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/ShutterContact.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/ShutterContact.java
@@ -8,8 +8,6 @@
  */
 package org.openhab.binding.maxcube.internal.message;
 
-import java.util.Calendar;
-
 import org.openhab.core.library.types.OpenClosedType;
 
 /**
@@ -22,11 +20,6 @@ public class ShutterContact extends Device {
 
 	private OpenClosedType shutterState = null;
 	private boolean shutterStateUpdated = false;
-	private boolean linkError;
-	private boolean panelLocked;
-	private boolean gatewayOk;
-	private boolean error;
-	private boolean valid;
 	
 	public ShutterContact(Configuration c) {
 		super(c);
@@ -53,38 +46,5 @@ public class ShutterContact extends Device {
 	@Override
 	public DeviceType getType() {
 		return DeviceType.ShutterContact;
-	}
-
-	@Override
-	public String getName() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public Calendar getLastUpdate() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	void setLinkError(boolean linkError) {
-		this.linkError = linkError;
-	}
-
-	void setPanelLocked(boolean panelLock) {
-		this.panelLocked = panelLock;
-	}
-
-	void setGatewayOk(boolean gatewayOk) {
-		this.gatewayOk = gatewayOk;
-
-	}
-
-	void setError(boolean error) {
-		this.error = error;
-	}
-
-	void setValid(boolean valid) {
-		this.valid = valid;
 	}
 }

--- a/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/UnsupportedDevice.java
+++ b/bundles/binding/org.openhab.binding.maxcube/src/main/java/org/openhab/binding/maxcube/internal/message/UnsupportedDevice.java
@@ -8,8 +8,6 @@
  */
 package org.openhab.binding.maxcube.internal.message;
 
-import java.util.Calendar;
-
 public class UnsupportedDevice extends Device {
 
 	public UnsupportedDevice(Configuration c) {
@@ -20,16 +18,4 @@ public class UnsupportedDevice extends Device {
 	public DeviceType getType() {
 		return DeviceType.Invalid;
 	}
-
-	@Override
-	public String getName() {
-		return "Unsupported device";
-	}
-
-	@Override
-	public Calendar getLastUpdate() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
 }


### PR DESCRIPTION
Signed-off-by: Dominic Lerbs <dominicdesu@hallojapan.de>

The Max!Cube reports connection errors for each single device in a L-Message. This flag was not evaluated in the max binding yet, so I have added it. It will map to a Switch-Item if the item is defined with type=connectionError.

I had the situation that one of my devices didn't react to openHAB commands anymore (which I only found out after several days), even though in openHAB everything was displayed correctly. Only when I checked in the MAX! software a connection problem with one of my thermostats were displayed. 
With this PR it will be possible to react on connection errors of any of the MAX devices (e.g. display in UI or send an according e-mail).

If this PR gets merged, I will also update the wiki to add the new type.