### PR TITLE
Update products.xml - Fibaro Roller Shutter 2 v2.5

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -1438,6 +1438,10 @@
 				<Type>0301</Type>
 				<Id>1001</Id>
 			</Reference>
+			<Reference>
+				<Type>0302</Type>
+				<Id>1000</Id>
+			</Reference>
 			<Model>FGRM222</Model>
 			<Label lang="en">Roller Shutter</Label>
 			<ConfigFile>fibaro/fgrm222.xml</ConfigFile>


### PR DESCRIPTION
Fibaro Roller Shutter 2 with label V2.5 is reported as Type 302 and ID 1000.  Config remains the same.