### PR TITLE
Include binding fritzboxtr064 into build process

### DIFF
--- a/bundles/binding/pom.xml
+++ b/bundles/binding/pom.xml
@@ -174,5 +174,6 @@
     <module>org.openhab.binding.octoller</module>
     <module>org.openhab.binding.akm868</module>
     <module>org.openhab.binding.sonance</module>	
+    <module>org.openhab.binding.fritzboxtr064</module>	
   </modules>
 </project>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -1395,6 +1395,13 @@
             <version>${project.version}</version>
             <type>jar</type>
         </dependency>
+	<dependency>
+            <groupId>org.openhab.binding</groupId>
+            <artifactId>org.openhab.binding.fritzboxtr064</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
+
 		<dependency>
 			<groupId>org.openhab.binding</groupId>
 			<artifactId>org.openhab.binding.sonance</artifactId>


### PR DESCRIPTION
as discussed [here] (https://github.com/openhab/openhab/pull/3569#issuecomment-167629598) I tried to add the binding into the automatic build process for addons.