### PR TITLE
[sallegra] Added Sallegra binding (replaces #3520)

### DIFF
--- a/bundles/binding/org.openhab.binding.sallegra/.classpath
+++ b/bundles/binding/org.openhab.binding.sallegra/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/binding/org.openhab.binding.sallegra/.project
+++ b/bundles/binding/org.openhab.binding.sallegra/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.sallegra</name>
+	<comment>This is the Sallegra binding of the open Home Automation Bus (openHAB)</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/binding/org.openhab.binding.sallegra/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.sallegra/META-INF/MANIFEST.MF
@@ -1,0 +1,30 @@
+Manifest-Version: 1.0
+Private-Package: org.openhab.binding.sallegra.internal
+Ignore-Package: org.openhab.binding.sallegra.internal
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-Name: openHAB Sallegra Binding
+Bundle-SymbolicName: org.openhab.binding.sallegra
+Bundle-Vendor: openHAB.org
+Bundle-Version: 1.8.0.qualifier
+Bundle-ManifestVersion: 2
+Bundle-Description: This is the Sallegra binding of the open Home Aut
+ omation Bus (openHAB)
+Import-Package: org.apache.commons.lang,
+ org.openhab.core.binding,
+ org.openhab.core.events,
+ org.openhab.core.items,
+ org.openhab.core.library.items,
+ org.openhab.core.library.types,
+ org.openhab.core.types,
+ org.openhab.io.net.http,
+ org.openhab.model.item.binding,
+ org.osgi.framework,
+ org.osgi.service.cm,
+ org.osgi.service.component,
+ org.osgi.service.event,
+ org.slf4j
+Export-Package: org.openhab.binding.sallegra
+Bundle-DocURL: http://www.openhab.org
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Service-Component: OSGI-INF/binding.xml, OSGI-INF/genericbindingprovider.xml
+Bundle-ClassPath: .

--- a/bundles/binding/org.openhab.binding.sallegra/OSGI-INF/binding.xml
+++ b/bundles/binding/org.openhab.binding.sallegra/OSGI-INF/binding.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2015, openHAB.org and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" name="org.openhab.binding.sallegra.binding">
+    <implementation class="org.openhab.binding.sallegra.internal.SallegraBinding" />
+
+    <service>
+        <provide interface="org.osgi.service.event.EventHandler" />
+        <provide interface="org.osgi.service.cm.ManagedService" />
+    </service>
+
+    <property name="event.topics" type="String" value="openhab/command/*" />
+    <property name="service.pid" type="String" value="org.openhab.sallegra" />
+
+    <reference bind="setEventPublisher" cardinality="1..1"
+        interface="org.openhab.core.events.EventPublisher" name="EventPublisher"
+        policy="dynamic" unbind="unsetEventPublisher" />
+    <reference bind="addBindingProvider" cardinality="1..n"
+        interface="org.openhab.binding.sallegra.SallegraBindingProvider" name="SallegraBindingProvider"
+        policy="dynamic" unbind="removeBindingProvider" />
+    
+</scr:component>

--- a/bundles/binding/org.openhab.binding.sallegra/OSGI-INF/genericbindingprovider.xml
+++ b/bundles/binding/org.openhab.binding.sallegra/OSGI-INF/genericbindingprovider.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2015, openHAB.org and others.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.openhab.binding.sallegra.genericbindingprovider">
+   <implementation class="org.openhab.binding.sallegra.internal.SallegraGenericBindingProvider"/>
+   
+   <service>
+      <provide interface="org.openhab.model.item.binding.BindingConfigReader"/>
+      <provide interface="org.openhab.binding.sallegra.SallegraBindingProvider"/>
+   </service>
+   
+</scr:component>

--- a/bundles/binding/org.openhab.binding.sallegra/build.properties
+++ b/bundles/binding/org.openhab.binding.sallegra/build.properties
@@ -1,0 +1,6 @@
+source.. = src/main/java/,\
+           src/main/resources/
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/
+output.. = target/classes/

--- a/bundles/binding/org.openhab.binding.sallegra/pom.xml
+++ b/bundles/binding/org.openhab.binding.sallegra/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<parent>
+		<groupId>org.openhab.bundles</groupId>
+		<artifactId>binding</artifactId>
+		<version>1.8.0-SNAPSHOT</version>
+	</parent>
+
+	<properties>
+		<bundle.symbolicName>org.openhab.binding.sallegra</bundle.symbolicName>
+		<bundle.namespace>org.openhab.binding.sallegra</bundle.namespace>
+		<deb.name>openhab-addon-binding-sallegra</deb.name>
+		<deb.description>${project.name}</deb.description>
+	</properties>
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.openhab.binding</groupId>
+	<artifactId>org.openhab.binding.sallegra</artifactId>
+
+	<name>openHAB Sallegra Binding</name>
+
+	<packaging>eclipse-plugin</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.vafer</groupId>
+				<artifactId>jdeb</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/bundles/binding/org.openhab.binding.sallegra/src/main/java/org/openhab/binding/sallegra/SallegraBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.sallegra/src/main/java/org/openhab/binding/sallegra/SallegraBindingProvider.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.sallegra;
+
+import org.openhab.binding.sallegra.internal.SallegraBindingConfig;
+import org.openhab.core.binding.BindingProvider;
+import org.openhab.core.items.Item;
+
+/**
+ * @author Benjamin Marty (Developed on behalf of Satelco.ch)
+ * @since 1.8.0
+ */
+public interface SallegraBindingProvider extends BindingProvider {
+	/**
+	 * Lookup method for binding configs
+	 * 
+	 * @param itemName
+	 *            name of the item
+	 * @return the binding config for the item with the name itemName
+	 */
+	public SallegraBindingConfig getBindingConfigFor(String itemName);
+
+	/**
+	 * Returns the class for the item
+	 * 
+	 * @param name
+	 *            name of the item
+	 * @return the class of the item with the name itemName
+	 */
+	public Class<? extends Item> getItemType(String name);
+}

--- a/bundles/binding/org.openhab.binding.sallegra/src/main/java/org/openhab/binding/sallegra/internal/SallegraBinding.java
+++ b/bundles/binding/org.openhab.binding.sallegra/src/main/java/org/openhab/binding/sallegra/internal/SallegraBinding.java
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.sallegra.internal;
+
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openhab.binding.sallegra.SallegraBindingProvider;
+import org.apache.commons.lang.StringUtils;
+import org.openhab.core.binding.AbstractActiveBinding;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.cm.ManagedService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.StringType;
+
+/**
+ * Implement this class if you are going create an actively polling service like querying a Website/Device.
+ * 
+ * @author Benjamin Marty (Developed on behalf of Satelco.ch)
+ * @since 1.8.0
+ */
+public class SallegraBinding extends AbstractActiveBinding<SallegraBindingProvider> implements ManagedService {
+
+	private static final Logger logger = LoggerFactory.getLogger(SallegraBinding.class);
+
+	private HashMap<String, SallegraNode> sallegraNodes = new HashMap<String, SallegraNode>();
+
+	/**
+	 * The BundleContext. This is only valid when the bundle is ACTIVE. It is set in the activate() method and must not
+	 * be accessed anymore once the deactivate() method was called or before activate() was called.
+	 */
+	public BundleContext bundleContext;
+
+	/**
+	 * the refresh interval which is used to poll values from the Sallegra server (optional, defaults to 60000ms)
+	 */
+	private long refreshInterval = 1000;
+
+	public SallegraBinding() {
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public void activate(final BundleContext bundleContext, final Map<String, Object> configuration) {
+		this.bundleContext = bundleContext;
+		logger.debug("Binding started!");
+
+		// read further config parameters here ...
+		setProperlyConfigured(true);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public void modified(final Map<String, Object> configuration) {
+		// update the internal configuration accordingly
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	public void deactivate(final int reason) {
+		this.bundleContext = null;
+		// deallocate resources here that are no longer needed and
+		// should be reset when activating this binding again
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	protected long getRefreshInterval() {
+		return refreshInterval;
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	protected String getName() {
+		return "Sallegra Refresh Service";
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	protected void execute() {
+		for (SallegraBindingProvider provider : providers) {
+			Collection<String> names = provider.getItemNames();
+			for (String name : names) {
+				logger.debug("Name {}", name);
+				SallegraBindingConfig bindingConfig = provider.getBindingConfigFor(name);
+				String deviceId = bindingConfig.getModuleName();
+
+				/*
+				 * check if a device with this id is already configured
+				 */
+				if (sallegraNodes.containsKey(deviceId)) {
+					SallegraNode node = sallegraNodes.get(deviceId);
+
+					/*
+					 * yes, there is a device with this id, now update it
+					 */
+					String value = null;
+					switch (bindingConfig.getCmdId()) {
+					case RELAY:
+						value = node.getRelay(bindingConfig.getCmdValue());
+						break;
+					case DIMMER:
+						value = node.getDimmer(bindingConfig.getCmdValue());
+						break;
+					case INPUT:
+						value = node.getInput(bindingConfig.getCmdValue());
+						break;
+					}
+					// If a value is got returned update it in openhab
+					if (value != null) {
+						postUpdate(provider, bindingConfig, value);
+					}
+				} else {
+					logger.error("Unknown deviceId \"{}\"", deviceId);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	protected void internalReceiveCommand(String itemName, Command command) {
+		// the code being executed when a command was sent on the openHAB
+		// event bus goes here. This method is only called if one of the
+		// BindingProviders provide a binding for the given 'itemName'.
+		logger.debug("internalReceiveCommand({},{}) is called!", itemName, command);
+
+		/*
+		 * do we have a binding for this item at all?
+		 */
+		if (providesBindingFor(itemName)) {
+			/*
+			 * go through all the providers and look for a BindingConfig
+			 */
+			for (SallegraBindingProvider provider : providers) {
+				SallegraBindingConfig bindingConfig = provider.getBindingConfigFor(itemName);
+
+				if (bindingConfig != null) {
+					/*
+					 * Found one
+					 */
+					SallegraNode node = sallegraNodes.get(bindingConfig.getModuleName());
+					if (node == null) {
+						logger.error("Invalid deviceId {}", bindingConfig.getModuleName());
+					}
+
+					switch (bindingConfig.getCmdId()) {
+					case RELAY:
+						node.setRelay(command, bindingConfig.getCmdValue());
+						break;
+					case DIMMER:
+						node.setDimmer(command, bindingConfig.getCmdValue());
+						break;
+					case INPUT:
+						logger.error("You can't set anything on the Sallegra Input Module");
+						break;
+					default:
+						logger.error("Unknown cmdId \"{}\"", bindingConfig.getCmdId());
+					}
+				}
+			}
+		} else {
+			logger.trace("No provider found for this item");
+		}
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	protected void internalReceiveUpdate(String itemName, State newState) {
+		// the code being executed when a state was sent on the openHAB
+		// event bus goes here. This method is only called if one of the
+		// BindingProviders provide a binding for the given 'itemName'.
+		logger.debug("internalReceiveUpdate({},{}) is called!", itemName, newState);
+	}
+
+	/**
+	 * @{inheritDoc
+	 */
+	@Override
+	public void updated(Dictionary<String, ?> config) throws ConfigurationException {
+		if (config != null) {
+
+			String refreshIntervalString = (String) config.get("refresh");
+
+			if (StringUtils.isNotBlank(refreshIntervalString)) {
+				refreshInterval = Long.parseLong(refreshIntervalString);
+			}
+
+			Enumeration<String> keys = config.keys();
+			while (keys.hasMoreElements()) {
+				String key = keys.nextElement();
+
+				// Escape of dot absolutely necessary
+				String[] keyElements = key.split("\\.");
+
+				String deviceId = keyElements[0];
+
+				if (keyElements.length >= 2) {
+
+					SallegraNode node = sallegraNodes.get(deviceId);
+					if (node == null) {
+						node = new SallegraNode();
+						sallegraNodes.put(deviceId, node);
+					}
+
+					String option = keyElements[1];
+					if (option.equals("password")) {
+						node.setPassword((String) config.get(key));
+					} else if (option.equals("hostname")) {
+						node.setHostName((String) config.get(key));
+					}
+				}
+			}
+
+			setProperlyConfigured(checkProperlyConfigured());
+		}
+	}
+
+	/**
+	 * Used to update Status of Items
+	 */
+	private void postUpdate(SallegraBindingProvider provider, SallegraBindingConfig string, final String value) {
+
+		switch (string.getCmdId()) {
+		case RELAY:
+			eventPublisher.postUpdate(string.getItem(), OnOffType.valueOf(value));
+			break;
+		case DIMMER:
+			eventPublisher.postUpdate(string.getItem(), PercentType.valueOf(value));
+			break;
+		case INPUT:
+			eventPublisher.postUpdate(string.getItem(), StringType.valueOf(value));
+			break;
+		}
+	}
+
+	private boolean checkProperlyConfigured() {
+		for (SallegraNode node : this.sallegraNodes.values()) {
+			if (!node.properlyConfigured()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+}

--- a/bundles/binding/org.openhab.binding.sallegra/src/main/java/org/openhab/binding/sallegra/internal/SallegraBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.sallegra/src/main/java/org/openhab/binding/sallegra/internal/SallegraBindingConfig.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.sallegra.internal;
+
+import org.openhab.core.binding.BindingConfig;
+
+/**
+ * Wrapper to represent a Binding Item Configuration
+ * 
+ * @author Benjamin Marty (Developed on behalf of Satelco.ch)
+ * @since 1.8.0
+ * 
+ */
+public class SallegraBindingConfig implements BindingConfig {
+
+	private String item;
+	private String property;
+	private String moduleName;
+	private SallegraCommand cmdId;
+	private String cmdValue;
+
+	public SallegraBindingConfig(String moduleName, SallegraCommand cmdId, String cmdValue) {
+		this.moduleName = moduleName;
+		this.cmdId = cmdId;
+		this.cmdValue = cmdValue;
+	}
+
+	public String getItem() {
+		return item;
+	}
+
+	public void setItem(String itemName) {
+		this.item = itemName;
+	}
+
+	public String getProperty() {
+		return property;
+	}
+
+	public void setProperty(String Property) {
+		this.property = Property;
+	}
+
+	public String getModuleName() {
+		return moduleName;
+	}
+
+	public SallegraCommand getCmdId() {
+		return cmdId;
+	}
+
+	public String getCmdValue() {
+		return cmdValue;
+	}
+}

--- a/bundles/binding/org.openhab.binding.sallegra/src/main/java/org/openhab/binding/sallegra/internal/SallegraCommand.java
+++ b/bundles/binding/org.openhab.binding.sallegra/src/main/java/org/openhab/binding/sallegra/internal/SallegraCommand.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.sallegra.internal;
+
+/**
+ * Enum with the commands for later use in item configuration
+ * 
+ * @author Benjamin Marty (Developed on behalf of Satelco.ch)
+ * @since 1.8.0
+ * 
+ */
+public enum SallegraCommand {
+	RELAY, DIMMER, INPUT
+}

--- a/bundles/binding/org.openhab.binding.sallegra/src/main/java/org/openhab/binding/sallegra/internal/SallegraGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.sallegra/src/main/java/org/openhab/binding/sallegra/internal/SallegraGenericBindingProvider.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.sallegra.internal;
+
+import org.openhab.binding.sallegra.SallegraBindingProvider;
+import org.openhab.core.items.Item;
+import org.openhab.model.item.binding.AbstractGenericBindingProvider;
+import org.openhab.model.item.binding.BindingConfigParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is for parsing the items configuration.
+ * 
+ * @author Benjamin Marty (Developed on behalf of Satelco.ch)
+ * @since 1.8.0
+ */
+public class SallegraGenericBindingProvider extends AbstractGenericBindingProvider implements SallegraBindingProvider {
+
+	private static Logger logger = LoggerFactory.getLogger(SallegraGenericBindingProvider.class);
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public String getBindingType() {
+		return "sallegra";
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * [deviceId:command:value]
+	 * 
+	 */
+	@Override
+	public void processBindingConfiguration(String context, Item item, String bindingConfig)
+			throws BindingConfigParseException {
+		super.processBindingConfiguration(context, item, bindingConfig);
+
+		if (bindingConfig == null || item == null) {
+			logger.error("invalid null input, item={}, bindingConfig={}", item, bindingConfig);
+			return;
+		}
+
+		/*
+		 * remove unnecessary chars
+		 */
+		String strippedBindingConfig = bindingConfig.replace("[", "").replace("]", "").trim();
+
+		/*
+		 * get configpart
+		 */
+		String[] configpart = strippedBindingConfig.split(":");
+		SallegraBindingConfig config = null;
+
+		/*
+		 * check for valid command
+		 */
+		if (configpart.length == 3) {
+			SallegraCommand cmdId = null;
+			try {
+				cmdId = SallegraCommand.valueOf(configpart[1].toUpperCase());
+			} catch (IllegalArgumentException e) {
+				throw new BindingConfigParseException("Unknown command: " + configpart[1]);
+			}
+
+			config = new SallegraBindingConfig(configpart[0], cmdId, configpart[2]);
+			config.setItem(item.getName());
+		} else {
+			throw new BindingConfigParseException(
+					"Configuration must have at at least 2 or 3 configpart separated by ':'");
+		}
+
+		logger.debug("Found \"{}\" binding config for deviceId \"{}\". Command is \"{}\" and value is \"{}\"",
+				configpart[0], configpart[1], configpart.length > 2 ? configpart[2] : "-");
+
+		addBindingConfig(item, config);
+	}
+
+	@Override
+	public SallegraBindingConfig getBindingConfigFor(String itemName) {
+		return (SallegraBindingConfig) this.bindingConfigs.get(itemName);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void validateItemType(Item item, String bindingConfig) throws BindingConfigParseException {
+	}
+
+	@Override
+	public Class<? extends Item> getItemType(String name) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+}

--- a/bundles/binding/org.openhab.binding.sallegra/src/main/java/org/openhab/binding/sallegra/internal/SallegraNode.java
+++ b/bundles/binding/org.openhab.binding.sallegra/src/main/java/org/openhab/binding/sallegra/internal/SallegraNode.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.sallegra.internal;
+
+import org.openhab.binding.sallegra.internal.xml.XmlUtils;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.types.Command;
+import org.openhab.io.net.http.HttpUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Node structure to kindly represent a Sallegra Module
+ * 
+ * @author Benjamin Marty (Developed on behalf of Satelco.ch)
+ * @since 1.8.0
+ * 
+ */
+public class SallegraNode {
+
+	private static final Logger logger = LoggerFactory.getLogger(SallegraNode.class);
+
+	private static final String GET = "GET";
+
+	/*
+	 * Suffix for specific recurring Parts in Sallegra Modules
+	 */
+	private static final String SUFFIX_PASSWORD = "pw=";
+	private static final String XML_PATH = "current_state.xml";
+
+	/*
+	 * Suffix for specific recurring Parts in URL gen
+	 */
+	private static final String SUFFIX_DIMMER = "Dimmer";
+	private static final String SUFFIX_RELAY = "Relay";
+
+	private String hostName;
+	private String password;
+	private int timeOut = 10000;
+
+	/*
+	 * Getter
+	 */
+	public String getHostName() {
+		return hostName;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	protected void setHostName(String hostName) {
+		this.hostName = hostName;
+	}
+
+	protected void setPassword(String password) {
+		this.password = password;
+	}
+
+	/**
+	 * Properly configured if hostname & password is set
+	 */
+	public boolean properlyConfigured() {
+		return (hostName != null && password != null) || timeOut != 0;
+	}
+
+	/**
+	 * Sets the State of the Relay on the Relay Module
+	 */
+	public void setRelay(Command command, String number) {
+		// Check if Instance is Digital OnOff Value
+		if (command instanceof OnOffType) {
+			if (((OnOffType) command) == OnOffType.ON) {
+				String URL = createURL() + "/" + XML_PATH + "?" + SUFFIX_PASSWORD + getPassword() + "&" + SUFFIX_RELAY
+						+ number + "=" + "1";
+				HttpUtil.executeUrl(GET, URL, this.timeOut);
+			} else {
+				String URL = createURL() + "/" + XML_PATH + "?" + SUFFIX_PASSWORD + getPassword() + "&" + SUFFIX_RELAY
+						+ number + "=" + "0";
+				HttpUtil.executeUrl(GET, URL, this.timeOut);
+			}
+		} else {
+			logger.error("Unsupported command type");
+		}
+	}
+
+	/**
+	 * Get the State of the Relay on the Relay Module
+	 */
+	public String getRelay(String number) {
+		String URL = createURL() + "/" + XML_PATH + "?" + SUFFIX_PASSWORD + getPassword();
+		String content = HttpUtil.executeUrl(GET, URL, this.timeOut);
+
+		content = XmlUtils.getContentOfElement(content, SUFFIX_RELAY + number);
+
+		// Get Java happy
+		int status = Integer.parseInt(XmlUtils.getContentOfElement(content, "State"));
+
+		if (status == 1) {
+			return "ON";
+		} else {
+			return "OFF";
+		}
+	}
+
+	/**
+	 * Sets the State of the Dimmer on the Dimmer Module
+	 */
+	public void setDimmer(Command command, String number) {
+		// Check if Instance is a Decimal Value
+		if (command instanceof DecimalType) {
+			int value = (int) ((double) ((DecimalType) command).intValue() * 2.54);
+			String URL = createURL() + "/" + XML_PATH + "?" + SUFFIX_PASSWORD + getPassword() + "&" + SUFFIX_DIMMER
+					+ number + "=" + value;
+			HttpUtil.executeUrl(GET, URL, this.timeOut);
+
+		} else {
+			logger.error("Unsupported command type");
+		}
+	}
+
+	/**
+	 * 
+	 * Gets the State of the Dimmer on the Dimmer Module
+	 */
+	public String getDimmer(String number) {
+		String URL = createURL() + "/" + XML_PATH + "?" + SUFFIX_PASSWORD + getPassword();
+		String content = HttpUtil.executeUrl(GET, URL, this.timeOut);
+
+		content = XmlUtils.getContentOfElement(content, SUFFIX_DIMMER + number);
+
+		double dimmer_value = Double.parseDouble(XmlUtils.getContentOfElement(content, "Value"));
+		double calc = Math.round(dimmer_value / 2.54);
+
+		String string_value = String.valueOf((int) calc);
+
+		return string_value;
+	}
+
+	/**
+	 * Gets the State of the Input on the Input Module
+	 */
+	public String getInput(String input) {
+		String URL = createURL() + "/" + XML_PATH + "?" + SUFFIX_PASSWORD + getPassword();
+		String content = HttpUtil.executeUrl(GET, URL, this.timeOut);
+
+		content = XmlUtils.getContentOfElement(content, input);
+
+		// Get Java happy
+		int status = Integer.parseInt(XmlUtils.getContentOfElement(content, "Value"));
+
+		if (status == 1) {
+			return "OPEN";
+		} else {
+			return "CLOSED";
+		}
+	}
+
+	/**
+	 * Put "http://" before the hostname/ip
+	 */
+	private String createURL() {
+		return "http://" + getHostName();
+	}
+}

--- a/bundles/binding/org.openhab.binding.sallegra/src/main/java/org/openhab/binding/sallegra/internal/xml/XmlUtils.java
+++ b/bundles/binding/org.openhab.binding.sallegra/src/main/java/org/openhab/binding/sallegra/internal/xml/XmlUtils.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2015, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.sallegra.internal.xml;
+
+/**
+ * Util method for xml response handling
+ * 
+ * @author Sebastian Kutschbach
+ * @author Benjamin Marty (brought from source)
+ * @see <a
+ *      href="https://github.com/openhab/openhab/blob/master/bundles/binding/org.openhab.binding.enigma2/src/main/java/org/openhab/binding/enigma2/internal/xml/XmlUtils.java">source</a>
+ * @since 1.8.0
+ */
+public final class XmlUtils {
+
+	private XmlUtils() {
+		// hide constructor
+	}
+
+	/**
+	 * Processes an string containing xml and returning the content of a specific tag (alyways lowercase)
+	 */
+	public static String getContentOfElement(String content, String element) {
+
+		final String beginTag = "<" + element + ">";
+		final String endTag = "</" + element + ">";
+
+		final int startIndex = content.indexOf(beginTag) + beginTag.length();
+		final int endIndex = content.indexOf(endTag);
+
+		if (startIndex != -1 && endIndex != -1) {
+			return content.substring(startIndex, endIndex);
+		} else {
+			return null;
+		}
+	}
+}

--- a/bundles/binding/org.openhab.binding.sallegra/src/main/resources/readme.txt
+++ b/bundles/binding/org.openhab.binding.sallegra/src/main/resources/readme.txt
@@ -1,0 +1,1 @@
+Bundle resources go in here!

--- a/bundles/binding/pom.xml
+++ b/bundles/binding/pom.xml
@@ -175,5 +175,6 @@
     <module>org.openhab.binding.akm868</module>
     <module>org.openhab.binding.sonance</module>
     <module>org.openhab.binding.stiebelheatpump</module>
+    <module>org.openhab.binding.sallegra</module>
   </modules>
 </project>

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -2290,3 +2290,13 @@ tcp:refreshinterval=250
 
 # version string of the heatpump
 #stiebelheatpump:version=2.06
+
+############################### Sallegra Binding ####################################
+#
+# IP address or hostname for the module
+#sallegra:livingroom.hostname=192.168.0.52
+#sallegra:bedroom.hostname=192.168.0.54
+
+# Password for the module
+#sallegra:livingroom.password=admin
+#sallegra:bedroom.password=admin

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -1407,6 +1407,12 @@
             <version>${project.version}</version>
             <type>jar</type>
         </dependency>
+		<dependency>
+			<groupId>org.openhab.binding</groupId>
+			<artifactId>org.openhab.binding.sallegra</artifactId>
+			<version>${project.version}</version>
+			<type>jar</type>
+		</dependency>
 
 		<dependency>
 			<groupId>org.openhab.io</groupId>


### PR DESCRIPTION
* Sallegra Dimmer DA-ET-4, Sallegra Relay R-ET-4 and Sallegra Input ADI-ET-8/8 are currently supported
* Syncs the Openhab status with the actual status on the Sallegra Module

See [wiki](https://github.com/openhab/openhab/wiki/Sallegra-Binding) here.

Changed from copy of #3520 by formatting changes, resolve merge conflicts, etc.