### PR TITLE
InsteonPLM: add support for rampdimmer with KeypadLinc dimmers

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/device/MessageHandler.java
@@ -409,31 +409,28 @@ public abstract class MessageHandler {
 		@Override
 		public void handleMessage(int group, byte cmd1, Msg msg,
 				DeviceFeature f, String fromPort) {
-			if (isMybutton(msg, f)) {
-				if (cmd1 == onCmd) {
-					int level = getLevel(msg);
-					logger.info("{}: device {} was switched on using ramp to level {}.", 
-							nm(), f.getDevice().getAddress(), level);
-					if (level == 100) {
-						f.publish(OnOffType.ON, StateChangeType.ALWAYS);						
-					}
-					else {
-						// The publisher will convert an ON at level==0 to an OFF.
-						// However, this is not completely accurate since a ramp
-						// off at level == 0 may not turn off the dimmer completely
-						// (if I understand the Insteon docs correctly). In any case,
-						// it would be an odd scenario to turn ON a light at level == 0
-						// rather than turn if OFF.
-						f.publish(new PercentType(level), StateChangeType.ALWAYS);
-					}
+			if (cmd1 == onCmd) {
+				int level = getLevel(msg);
+				logger.info(
+						"{}: device {} was switched on using ramp to level {}.",
+						nm(), f.getDevice().getAddress(), level);
+				if (level == 100) {
+					f.publish(OnOffType.ON, StateChangeType.ALWAYS);
+				} else {
+					// The publisher will convert an ON at level==0 to an OFF.
+					// However, this is not completely accurate since a ramp
+					// off at level == 0 may not turn off the dimmer completely
+					// (if I understand the Insteon docs correctly). In any
+					// case,
+					// it would be an odd scenario to turn ON a light at level
+					// == 0
+					// rather than turn if OFF.
+					f.publish(new PercentType(level), StateChangeType.ALWAYS);
 				}
-				else if (cmd1 == offCmd) {
-					logger.info("{}: device {} was switched off using ramp.", nm(),
-							f.getDevice().getAddress());
-					f.publish(new PercentType(0), StateChangeType.ALWAYS);
-				}
-			} else {
-				logger.debug("ignored message: {}", isMybutton(msg,f));
+			} else if (cmd1 == offCmd) {
+				logger.info("{}: device {} was switched off using ramp.", nm(),
+						f.getDevice().getAddress());
+				f.publish(new PercentType(0), StateChangeType.ALWAYS);
 			}
 		}
 

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_features.xml
@@ -127,6 +127,15 @@
 	<poll-handler>NoPollHandler</poll-handler>
 </feature>
 
+<feature name="LoadDimmerRamp">
+	<message-dispatcher>DefaultDispatcher</message-dispatcher>
+	<!-- cmd1 defaults to 0x2E, 0x2F -->
+	<!-- default dispatcher uses 0x19 for lookup key instead of cmd1 -->
+	<message-handler cmd="0x19" group="1">RampDimmerHandler</message-handler>
+	<command-handler command="PercentType">RampPercentHandler</command-handler>
+	<command-handler command="OnOffType">RampOnOffCommandHandler</command-handler>
+</feature>
+
 <feature name="KeyPadButtonGroup">
 	<message-dispatcher>DefaultGroupDispatcher</message-dispatcher>
 	<poll-handler ext="0" cmd1="0x19" cmd2="0x01" >FlexPollHandler</poll-handler>

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/resources/device_types.xml
@@ -83,6 +83,7 @@ Example entry:
      <model>2486DWH6</model>
      <description>KeypadLinc Dimmer - 6 Button</description>
      <feature name="loaddimmer">LoadDimmerButton</feature>
+     <feature name="rampdimmer">LoadDimmerRamp</feature>
      <feature name="manualchange">ManualChange</feature>
      <feature name="fastonoff">LoadDimmerFastOnOff</feature>
      <feature_group name="button_group" type="KeyPadButtonGroup">
@@ -97,6 +98,7 @@ Example entry:
      <model>2486DWH8</model>
      <description>KeypadLinc Dimmer - 8 Button</description>
      <feature name="loaddimmer">LoadDimmerButton</feature>
+     <feature name="rampdimmer">LoadDimmerRamp</feature>
      <feature name="manualchange">ManualChange</feature>
      <feature name="fastonoff">LoadDimmerFastOnOff</feature>     
      <feature_group name="button_group" type="KeyPadButtonGroup">
@@ -319,6 +321,7 @@ Example entry:
      <model>2334-232</model>
      <description>Keypad Dimmer Switch, 6-Button </description>
      <feature name="loaddimmer">LoadDimmerButton</feature>
+     <feature name="rampdimmer">LoadDimmerRamp</feature>
      <feature name="manualchange">ManualChange</feature>
      <feature name="fastonoff">LoadDimmerFastOnOff</feature>
      <feature_group name="button_group" type="KeyPadButtonGroup">
@@ -334,6 +337,7 @@ Example entry:
      <model>2334-232</model>
      <description>Keypad Dimmer Switch, 8-Button </description>
      <feature name="loaddimmer">LoadDimmerButton</feature>
+     <feature name="rampdimmer">LoadDimmerRamp</feature>
      <feature name="manualchange">ManualChange</feature>
      <feature name="fastonoff">LoadDimmerFastOnOff</feature>     
      <feature_group name="button_group" type="KeyPadButtonGroup">


### PR DESCRIPTION
Added rampdimmer support for the KeypadLinc dimmers described in http://cache.insteon.com/developer/2672-222dev-052014-en.pdf. The button check in RampDimmerHandler was causing the state to not get updated for the load button. It is not needed since button commands for the non-load buttons are sent to groups, not to the actual device.

@steve-bate and @berndpfrommer can you please review?