### PR TITLE
Modbus binding: coil commands executed no matter current state

### DIFF
--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
@@ -91,14 +91,14 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider>i
             if (provider.providesBindingFor(itemName)) {
                 ModbusBindingConfig config = provider.getConfig(itemName);
                 ModbusSlave slave = modbusSlaves.get(config.slaveName);
-                slave.executeCommand(command, config.readRegister, config.writeRegister);
+                slave.executeCommand(command, config);
             }
         }
     }
 
     /**
      * Posts update event to OpenHAB bus for "holding" type slaves
-     * 
+     *
      * @param binding ModbusBinding to get item configuration from BindingProviding
      * @param registers data received from slave device in the last pollInterval
      * @param itemName item to update
@@ -116,7 +116,7 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider>i
             String slaveValueType = modbusSlaves.get(slaveName).getValueType();
             double rawDataMultiplier = modbusSlaves.get(slaveName).getRawDataMultiplier();
 
-            State newState = extractStateFromRegisters(registers, config.readRegister, slaveValueType);
+            State newState = extractStateFromRegisters(registers, config.readIndex, slaveValueType);
             /* receive data manipulation */
             State newStateBoolean = provider.getConfig(itemName)
                     .translateBoolean2State(!newState.equals(DecimalType.ZERO));
@@ -170,7 +170,7 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider>i
 
     /**
      * Posts update event to OpenHAB bus for "coil" type slaves
-     * 
+     *
      * @param binding ModbusBinding to get item configuration from BindingProviding
      * @param registers data received from slave device in the last pollInterval
      * @param item item to update
@@ -180,7 +180,7 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider>i
             if (provider.providesBindingFor(itemName)) {
                 ModbusBindingConfig config = provider.getConfig(itemName);
                 if (config.slaveName.equals(slaveName)) {
-                    boolean state = coils.getBit(config.readRegister);
+                    boolean state = coils.getBit(config.readIndex);
                     State currentState = provider.getConfig(itemName).getItemState();
                     State newState = provider.getConfig(itemName).translateBoolean2State(state);
                     if (!newState.equals(currentState)) {
@@ -193,7 +193,7 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider>i
 
     /**
      * Returns names of all the items, registered with this binding
-     * 
+     *
      * @return list of item names
      */
     public Collection<String> getItemNames() {

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusGenericBindingProvider.java
@@ -29,15 +29,15 @@ import org.slf4j.LoggerFactory;
  *
  * 1) single coil/register per item
  * Switch MySwitch "My Modbus Switch" (ALL) {modbus="slave1:5"}
- * 
+ *
  * This binds MySwitch to modbus slave defined as "slave1" in openhab.config reading/writing to the coil 5
  *
  * 2) separate coils/registers for reading and writing
  * Switch MySwitch "My Modbus Switch" (ALL) {modbus="slave1:<6:>7"}
- * 
+ *
  * In this case coil 6 is used as status coil (readonly) and commands are put to coil 7 by setting coil 7 to true.
  * You hardware should then set coil 7 back to false to allow further commands processing.
- * 
+ *
  * @author Dmitry Krasnov
  * @since 1.1.0
  */
@@ -127,10 +127,13 @@ public class ModbusGenericBindingProvider extends AbstractGenericBindingProvider
     public class ModbusBindingConfig implements BindingConfig {
 
         /**
-         * readRegister and writeRegister store references to the register in device data space
+         * Index to read, relative to start
          */
-        int readRegister;
-        int writeRegister;
+        int readIndex;
+        /**
+         * Index to write, relative to start
+         */
+        int writeIndex;
 
         /**
          * Name of the ModbusSlave instance to read/write data
@@ -195,8 +198,8 @@ public class ModbusGenericBindingProvider extends AbstractGenericBindingProvider
                 String[] items = config.split(":");
                 slaveName = items[0];
                 if (items.length == 2) {
-                    readRegister = Integer.valueOf(items[1]);
-                    writeRegister = Integer.valueOf(items[1]);
+                    readIndex = Integer.valueOf(items[1]);
+                    writeIndex = Integer.valueOf(items[1]);
                 } else if (items.length == 3) {
                     assignRegisters(items[1]);
                     assignRegisters(items[2]);
@@ -216,9 +219,9 @@ public class ModbusGenericBindingProvider extends AbstractGenericBindingProvider
          */
         private void assignRegisters(String item) throws BindingConfigParseException {
             if (item.startsWith("<")) {
-                readRegister = Integer.valueOf(item.substring(1, item.length()));
+                readIndex = Integer.valueOf(item.substring(1, item.length()));
             } else if (item.startsWith(">")) {
-                writeRegister = Integer.valueOf(item.substring(1, item.length()));
+                writeIndex = Integer.valueOf(item.substring(1, item.length()));
             } else {
                 throw new BindingConfigParseException("Register references should be either :X or :<X:>Y");
             }

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusSlave.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusSlave.java
@@ -11,6 +11,7 @@ package org.openhab.binding.modbus.internal;
 import java.util.Collection;
 
 import org.openhab.binding.modbus.ModbusBindingProvider;
+import org.openhab.binding.modbus.internal.ModbusGenericBindingProvider.ModbusBindingConfig;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.OnOffType;
@@ -36,6 +37,7 @@ import net.wimpi.modbus.msg.WriteMultipleRegistersRequest;
 import net.wimpi.modbus.msg.WriteSingleRegisterRequest;
 import net.wimpi.modbus.procimg.InputRegister;
 import net.wimpi.modbus.procimg.Register;
+import net.wimpi.modbus.procimg.SimpleRegister;
 import net.wimpi.modbus.util.BitVector;
 
 /**
@@ -86,10 +88,10 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
 
     /**
      * A multiplier for the raw incoming data
-     * 
+     *
      * @note rawMultiplier can also be used for divisions, by simply
      *       setting the value smaller than zero.
-     * 
+     *
      *       E.g.:
      *       - data/100 ... rawDataMultiplier=0.01
      */
@@ -108,24 +110,23 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
     /**
      * writes data to Modbus device corresponding to OpenHAB command
      * works only with types "coil" and "holding"
-     * 
+     *
      * @param command OpenHAB command received
-     * @param readRegister data from readRegister are used to define value to write to the device
-     * @param writeRegister register address to write new data to
+     * @param config
      */
-    void executeCommand(Command command, int readRegister, int writeRegister) {
+    void executeCommand(Command command, ModbusBindingConfig config) {
         if (ModbusBindingProvider.TYPE_COIL.equals(getType())) {
-            setCoil(command, readRegister, writeRegister);
+            setCoil(command, config);
         }
         if (ModbusBindingProvider.TYPE_HOLDING.equals(getType())) {
-            setRegister(command, readRegister, getStart() + writeRegister);
+            setRegister(command, config);
         }
     }
 
     /**
      * Calculates boolean value that will be written to the device as a result of OpenHAB command
      * Used with item bound to "coil" type slaves
-     * 
+     *
      * @param command OpenHAB command received by the item
      * @return new boolean value to be written to the device
      */
@@ -147,68 +148,73 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
 
     /**
      * Performs physical write to device when slave type is "coil"
-     * 
+     *
      * @param command command received from OpenHAB
-     * @param readRegister reference to the register that stores current value
-     * @param writeRegister register reference to write data to
+     * @param config
      */
-    private void setCoil(Command command, int readRegister, int writeRegister) {
-        synchronized (storage) {
-            boolean b = translateCommand2Boolean(command);
-            if (((BitVector) storage).getBit(readRegister) != b) {
-                if (b) {
-                    doSetCoil(getStart() + writeRegister, true);
-                } else {
-                    doSetCoil(getStart() + writeRegister, readRegister == writeRegister ? false : true);
-                }
-            }
-        }
+    private void setCoil(Command command, ModbusBindingConfig config) {
+        int writeRegister = config.writeIndex;
+        boolean b = translateCommand2Boolean(command);
+        doSetCoil(getStart() + writeRegister, b);
     }
 
     /**
      * Performs physical write to device when slave type is "holding" using Modbus FC06 function
-     * 
+     *
      * @param command command received from OpenHAB
-     * @param readRegister reference to the register that stores current value
-     * @param writeRegister register reference to write data to
+     * @param config
      */
-    protected void setRegister(Command command, int readRegister, int writeRegister) {
+    protected void setRegister(Command command, ModbusBindingConfig config) {
+        int readIndex = config.readIndex;
+        int writeRegister = getStart() + config.writeIndex;
 
         if (!isConnected()) {
             return;
         }
 
-        Register newValue = null;
-        synchronized (storage) {
-            newValue = (Register) ((InputRegister[]) storage)[readRegister];
-        }
-
+        Register newValue;
         if (command instanceof IncreaseDecreaseType) {
+            newValue = readCachedRegisterValue(readIndex);
+            if (newValue == null) {
+                logger.warn("Not polled value for item {}. Cannot process command {}", config.getItem(), command);
+                return;
+            }
             if (command.equals(IncreaseDecreaseType.INCREASE)) {
                 newValue.setValue(newValue.getValue() + 1);
             } else if (command.equals(IncreaseDecreaseType.DECREASE)) {
                 newValue.setValue(newValue.getValue() - 1);
             }
         } else if (command instanceof UpDownType) {
+            newValue = readCachedRegisterValue(readIndex);
+            if (newValue == null) {
+                logger.warn("Not polled value for item {}. Cannot process command {}", config.getItem(), command);
+                return;
+            }
             if (command.equals(UpDownType.UP)) {
                 newValue.setValue(newValue.getValue() + 1);
             } else if (command.equals(UpDownType.DOWN)) {
                 newValue.setValue(newValue.getValue() - 1);
             }
         } else if (command instanceof DecimalType) {
+            newValue = new SimpleRegister();
             newValue.setValue(((DecimalType) command).intValue());
         } else if (command instanceof OnOffType) {
+            newValue = new SimpleRegister();
             if (command.equals(OnOffType.ON)) {
                 newValue.setValue(1);
             } else if (command.equals(OnOffType.OFF)) {
                 newValue.setValue(0);
             }
         } else if (command instanceof OpenClosedType) {
+            newValue = new SimpleRegister();
             if (command.equals(OpenClosedType.OPEN)) {
                 newValue.setValue(1);
             } else if (command.equals(OpenClosedType.CLOSED)) {
                 newValue.setValue(0);
             }
+        } else {
+            logger.warn("Item {} received unsupported command: {}. Not setting register.", config.getItem(), command);
+            return;
         }
 
         ModbusRequest request = null;
@@ -232,6 +238,17 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
         }
     }
 
+    private Register readCachedRegisterValue(int readIndex) {
+        if (storage == null) {
+            return null;
+        }
+        Register newValue = null;
+        synchronized (storage) {
+            newValue = (Register) ((InputRegister[]) storage)[readIndex];
+        }
+        return newValue;
+    }
+
     /**
      * @return slave name from cfg file
      */
@@ -241,7 +258,7 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
 
     /**
      * Sends boolean (bit) data to the device using Modbus FC05 function
-     * 
+     *
      * @param writeRegister
      * @param b
      */
@@ -264,7 +281,7 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
 
     /**
      * Reads data from the connected device and updates items with the new data
-     * 
+     *
      * @param binding ModbusBindig that stores providers information
      */
     public void update(ModbusBinding binding) {
@@ -320,7 +337,7 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
     /**
      * Updates OpenHAB item with data read from slave device
      * works only for type "coil" and "holding"
-     * 
+     *
      * @param binding ModbusBinding
      * @param item item to update
      */
@@ -337,7 +354,7 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
 
     /**
      * Executes Modbus transaction that reads data from the device and returns response data
-     * 
+     *
      * @param request describes what data are requested from the device
      * @return response data
      */


### PR DESCRIPTION
Ensures that coil commands are written to the modbus slave no matter what the current state is.

Furthermore, now handling nicely if no poll is done but we receive a command.
