### PR TITLE
Modbus binding: holding/input register state updates now support all the same item types as coil/discrete inputs

### DIFF
--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
@@ -29,12 +29,14 @@ import org.openhab.binding.modbus.ModbusBindingProvider;
 import org.openhab.binding.modbus.internal.ModbusGenericBindingProvider.ModbusBindingConfig;
 import org.openhab.core.binding.AbstractActiveBinding;
 import org.openhab.core.binding.BindingProvider;
+import org.openhab.core.library.items.ContactItem;
 import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
+import org.openhab.core.types.UnDefType;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 import org.slf4j.Logger;
@@ -121,10 +123,10 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider> 
 
 			State newState = extractStateFromRegisters(registers, config.readRegister, slaveValueType);
 			/* receive data manipulation */
-			if (config.getItem() instanceof SwitchItem) {
-				newState = newState.equals(DecimalType.ZERO) ? OnOffType.OFF : OnOffType.ON;
-			}
-			if (( rawDataMultiplier != 1 ) && (config.getItem() instanceof NumberItem)) {
+			State newStateBoolean = provider.getConfig(itemName).translateBoolean2State(!newState.equals(DecimalType.ZERO));
+			if (!UnDefType.UNDEF.equals(newStateBoolean)) {
+				newState = newStateBoolean;
+			} else if (( rawDataMultiplier != 1 ) && (config.getItem() instanceof NumberItem)) {
 				double tmpValue = (double)((DecimalType)newState).doubleValue() * rawDataMultiplier;
 				newState =  new DecimalType( String.valueOf(tmpValue) );
 			}


### PR DESCRIPTION
Resolves #3686