### PR TITLE
Add node information frame into saved node XML file

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -78,6 +78,10 @@ public class ZWaveNode {
 	private boolean routing;
 	private String healState;
 	
+    // Keep the NIF - just used for information and debug in the XML
+    @SuppressWarnings("unused")
+    private List<Integer> nodeInformationFrame = null;
+	
 	private Map<CommandClass, ZWaveCommandClass> supportedCommandClasses = new HashMap<CommandClass, ZWaveCommandClass>();
 	private List<Integer> nodeNeighbors = new ArrayList<Integer>();
 	private Date lastSent = null;
@@ -821,4 +825,8 @@ public class ZWaveNode {
 	public void setApplicationUpdateReceived(boolean received) {
 		applicationUpdateReceived = received;
 	}
+	
+    public void updateNIF(List<Integer> nif) {
+        nodeInformationFrame = nif;
+    }
 }

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ApplicationUpdateMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ApplicationUpdateMessageClass.java
@@ -8,7 +8,9 @@
  */
 package org.openhab.binding.zwave.internal.protocol.serialmessage;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
@@ -77,6 +79,8 @@ public class ApplicationUpdateMessageClass  extends ZWaveCommandProcessor {
 				}
 			}
 			else {
+				List<Integer> nif = new ArrayList<Integer>();
+
 				for (int i = 6; i < length + 3; i++) {
 					int data = incomingMessage.getMessagePayloadByte(i);
 					if(data == 0xef) {
@@ -89,6 +93,8 @@ public class ApplicationUpdateMessageClass  extends ZWaveCommandProcessor {
 						node.addCommandClass(commandClass);
 					}
 				}
+				
+                node.updateNIF(nif);
 			}
 
 			// Notify we received an info frame


### PR DESCRIPTION
This just saves the NIF into the Node class so that it is saved into the XML file. This is useful for debugging as it helps describe the device.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>