### PR TITLE
[nest] Added optional nest:timeout config parameter

### DIFF
--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.prefs.Preferences;
 
 import org.openhab.binding.nest.NestBindingProvider;
+import org.openhab.binding.nest.internal.messages.AbstractRequest;
 import org.openhab.binding.nest.internal.messages.AccessTokenRequest;
 import org.openhab.binding.nest.internal.messages.AccessTokenResponse;
 import org.openhab.binding.nest.internal.messages.DataModel;
@@ -61,6 +62,7 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider> impl
 	protected static final String CONFIG_CLIENT_ID = "client_id";
 	protected static final String CONFIG_CLIENT_SECRET = "client_secret";
 	protected static final String CONFIG_PIN_CODE = "pin_code";
+	protected static final String CONFIG_TIMEOUT = "timeout";
 
 	/**
 	 * the refresh interval which is used to poll values from the Nest server (optional, defaults to 60000ms)
@@ -442,13 +444,20 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider> impl
 				refreshInterval = Long.parseLong(refreshIntervalString);
 			}
 
+			// to override the default HTTP request timeout one has to add a
+			// parameter to openhab.cfg like nest:timeout=20000
+			String timeoutString = (String) config.get(CONFIG_TIMEOUT);
+			if (isNotBlank(timeoutString)) {
+				AbstractRequest.setHttpRequestTimeout(Integer.parseInt(timeoutString));
+			}
+
 			Enumeration<String> configKeys = config.keys();
 			while (configKeys.hasMoreElements()) {
 				String configKey = (String) configKeys.nextElement();
 
 				// the config-key enumeration contains additional keys that we
 				// don't want to process here ...
-				if (CONFIG_REFRESH.equals(configKey) || "service.pid".equals(configKey)) {
+				if (CONFIG_REFRESH.equals(configKey) || CONFIG_TIMEOUT.equals(configKey) || "service.pid".equals(configKey)) {
 					continue;
 				}
 

--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/AbstractRequest.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/AbstractRequest.java
@@ -50,7 +50,7 @@ public abstract class AbstractRequest extends AbstractMessage implements Request
 
 	private static final Properties HTTP_HEADERS;
 
-	private static final int HTTP_REQUEST_TIMEOUT = 10000;
+	private static final int DEFAULT_HTTP_REQUEST_TIMEOUT = 10000;
 
 	protected static final String HTTP_GET = "GET";
 
@@ -61,6 +61,8 @@ public abstract class AbstractRequest extends AbstractMessage implements Request
 	protected static final String API_BASE_URL = "https://developer-api.nest.com/";
 
 	protected static final ObjectMapper JSON = new ObjectMapper();
+
+	protected static int httpRequestTimeout = DEFAULT_HTTP_REQUEST_TIMEOUT;
 
 	static {
 		HTTP_HEADERS = new Properties();
@@ -74,6 +76,10 @@ public abstract class AbstractRequest extends AbstractMessage implements Request
 		DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 		df.setTimeZone(tz);
 		JSON.setDateFormat(df);
+	}
+
+	public static void setHttpRequestTimeout(int timeout) {
+		httpRequestTimeout = timeout;
 	}
 
 	protected final RuntimeException newException(final String message, final Exception cause, final String url,
@@ -106,7 +112,7 @@ public abstract class AbstractRequest extends AbstractMessage implements Request
 		HttpClient client = new HttpClient();
 
 		HttpMethod method = HttpUtil.createHttpMethod(httpMethod, url);
-		method.getParams().setSoTimeout(HTTP_REQUEST_TIMEOUT);
+		method.getParams().setSoTimeout(httpRequestTimeout);
 		method.getParams().setParameter(HttpMethodParams.RETRY_HANDLER, new DefaultHttpMethodRetryHandler(3, false));
 
 		for (String httpHeaderKey : HTTP_HEADERS.stringPropertyNames()) {

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1924,6 +1924,9 @@ tcp:refreshinterval=250
 # Data refresh interval in ms (optional, defaults to 60000)
 #nest:refresh=
 
+# HTTP request timeout in ms (optional, defaults to 10000)
+#nest:timeout=
+
 # the Nest Client ID needed to use the API, must be supplied
 #nest:client_id=
 


### PR DESCRIPTION
[A user reports](https://community.openhab.org/t/how-to-access-the-nest/4310/13?u=watou) and I also see occasional request timeouts trying to query the Nest API.  The default 10-second timeout is occasionally not enough time to successfully query the API.  So this PR adds an optional `nest:timeout` config parameter to openhab.cfg, so the user can override the default 10000ms timeout with a different timeout value.

@teichsta, sorry for the late addition.  If you would prefer that this is deferred, OK!