### PR TITLE
Add Leviton VRE06-1LZ dimmer to DB

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/leviton/vre06-1lz.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/leviton/vre06-1lz.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+	<Model>VRE06-1LZ</Model>
+	<Label lang="en">Scene Capable Push On/Off Dimmer</Label>
+	<CommandClasses>
+		<Class><id>0x20</id></Class>
+		<Class><id>0x85</id></Class>
+		<Class><id>0x26</id></Class>
+		<Class><id>0x27</id></Class>
+		<Class><id>0x2b</id></Class>
+		<Class><id>0x2c</id></Class>
+		<Class><id>0x91</id></Class>
+		<Class><id>0x72</id></Class>
+		<Class><id>0x73</id></Class>
+		<Class><id>0x77</id></Class>
+		<Class><id>0x86</id></Class>
+	</CommandClasses>
+	
+	<Configuration>
+
+	</Configuration>
+        <Associations>
+                <Group>
+                        <Index>1</Index>
+                        <Maximum>5</Maximum>
+                        <Label lang="en">Group 1</Label>
+                        <SetToController>true</SetToController>
+                </Group>
+        </Associations>	
+</Product>
+

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -2339,6 +2339,15 @@
 			<Label lang="en">Scene Capable Push On/Off Dimmer</Label>
 			<ConfigFile>leviton/vrmx1-1lz.xml</ConfigFile>
 		</Product>
+                <Product>
+                        <Reference>
+                                <Type>0e01</Type>
+                                <Id>0334</Id>
+                        </Reference>
+                        <Model>VRE06-1LZ</Model>
+                        <Label lang="en">Scene Capable Push On/Off Dimmer</Label>
+                        <ConfigFile>leviton/vre06-1lz.xml</ConfigFile>
+                </Product>
 		<Product>
 			<Reference>
 				<Type>1902</Type>


### PR DESCRIPTION
Electronic Low Voltage, trailing edge dimmer otherwise functionally identical
to VRMX1 Leviton dimmer. Based config off VRMX1, confirmed association group
works to set status updates back to controller.