### PR TITLE
reduce log level

### DIFF
--- a/bundles/persistence/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jService.java
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/src/main/java/org/openhab/persistence/rrd4j/internal/RRD4jService.java
@@ -386,7 +386,7 @@ public class RRD4jService implements QueryablePersistenceService {
                     } else if (property.equals("items")) {
                         rrdDef.addItems(value);
                     } else {
-                        logger.warn("Unknown property {} : {}", property, value);
+                        logger.debug("Unknown property {} : {}", property, value);
                     }
                 } catch (IllegalArgumentException e) {
                     logger.warn("Ignoring illegal configuration: {}", e.getMessage());


### PR DESCRIPTION
openHAB 2 demo package starts with this log message
```
18:55:10.475 [WARN ] [sistence.rrd4j.internal.RRD4jService] - Unknown property name : org.openhab.persistence.rrd4j
```
This PR removes this.
Please also pick for the 1.8 release, thanks!

Signed-off-by: Kai Kreuzer <kai@openhab.org>