### PR TITLE
Fix a bug preventing proper logout from energenie devices

### DIFF
--- a/bundles/binding/org.openhab.binding.energenie/src/main/java/org/openhab/binding/energenie/internal/EnergenieBinding.java
+++ b/bundles/binding/org.openhab.binding.energenie/src/main/java/org/openhab/binding/energenie/internal/EnergenieBinding.java
@@ -223,7 +223,7 @@ public class EnergenieBinding extends AbstractActiveBinding<EnergenieBindingProv
 
 	private void sendLogOut(String pmsId) {
 		String pmsIp = pmsIpConfig.get(pmsId);
-		String url = "http://"+pmsIp;
+		String url = "http://"+pmsIp+"/login.html";
 
 		try {
 			HttpUtil.executeUrl("POST", url, timeout);


### PR DESCRIPTION
As reported in the community, there is a bug in senLogOut() which will be fixed with this PR.
The bug only occurs when using the WebInterface or Smartphone App while openHAB is running.
Cause I only use openHAB for controlling my energenie devices, this never happend in my environment.

Signed-off-by: hmerk <hans-joerg.merk@t-online.de>