### PR TITLE
Corrected Ecobee action dependency

### DIFF
--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -6,6 +6,7 @@
     <feature name="openhab-action-ecobee" description="Ecobee Action" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-runtime-compat1x</feature>
+        <feature>openhab-binding-ecobee</feature>
         <bundle start-level="80">mvn:org.openhab.action/org.openhab.action.ecobee/${project.version}</bundle>
         <configfile finalname="${openhab.conf}/services/ecobee.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/ecobee</configfile>
     </feature>


### PR DESCRIPTION
I think this fixes the build problem I introduced with #3720.  I did a full mvn clean install locally and it gave
```
[INFO] Verification of feature openhab-action-ecobee/1.8.0.SNAPSHOT succeeded
```
