### PR TITLE
Added cause of ConnectException to the log call

### DIFF
--- a/bundles/binding/org.openhab.binding.xbmc/src/main/java/org/openhab/binding/xbmc/rpc/XbmcConnector.java
+++ b/bundles/binding/org.openhab.binding.xbmc/src/main/java/org/openhab/binding/xbmc/rpc/XbmcConnector.java
@@ -200,7 +200,7 @@ public class XbmcConnector {
 		@Override
 		public void onError(Throwable e) {
 			if (e instanceof ConnectException) {
-				logger.debug("[{}]: Websocket connection error", xbmc.getHostname());
+				logger.debug("[{}]: Websocket connection error '{}'", xbmc.getHostname(),e.getMessage());
 			} else if (e instanceof TimeoutException) {
 				logger.debug("[{}]: Websocket timeout error", xbmc.getHostname());
 			} else {


### PR DESCRIPTION
As it was impossible to determine the cause of a failed connection, I added the (formerly discarded) exception to the debug call so the user is able to see it.