### PR TITLE
DSC Alarm Binding: IT-100 TCP Connection Support

### DIFF
--- a/bundles/binding/org.openhab.binding.dscalarm/README.md
+++ b/bundles/binding/org.openhab.binding.dscalarm/README.md
@@ -13,6 +13,10 @@ There are some configuration settings that you can set in the openhab.cfg file. 
 ```
 ############################## DSC Alarm Binding #####################################
 #
+# DSC Alarm interface device type
+# Valid values are it100 (default for serial connection) or envisalink (default for tcp connection)
+#dscalarm:deviceType=
+
 # DSC Alarm port name for a serial connection.
 # Valid values are e.g. COM1 for Windows and /dev/ttyS0 or /dev/ttyUSB0 for Linux.
 # Leave undefined if not connecting by serial port.
@@ -23,9 +27,14 @@ There are some configuration settings that you can set in the openhab.cfg file. 
 # Leave undefined if using default.
 #dscalarm:baud=
 
-# DSC Alarm IP address for a TCP connection. 
+# DSC Alarm IP address for a TCP connection.
 # Leave undefined if not connecting by network connection.
 #dscalarm:ip=
+
+# DSC Alarm TCP port for a TCP connection.
+# Can be EyezOn Envisalink on 4025 (default) or a TCP serial server to IT-100
+# Leave undefined if not connecting by network connection.
+#dscalarm:tcpPort=
 
 # DSC Alarm password for logging into the EyezOn Envisalink 3/2DS interface.
 # Leave undefined if using default.

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmActiveBinding.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmActiveBinding.java
@@ -36,9 +36,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * DSCAlarmActiveBinding Class. Polls the DSC Alarm panel,
- * responds to item commands, and also handles events coming 
+ * responds to item commands, and also handles events coming
  * from the DSC Alarm panel.
- * 
+ *
  * @author Russell Stephens
  * @since 1.6.0
  */
@@ -53,7 +53,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 
 	/** Default Poll Period. **/
 	public static final long DEFAULT_POLL_PERIOD = 1;
-	
+
 	/** The serial port name of the DSC-IT100 Serial Interface
 	 * 	Valid values are e.g. COM1 for Windows and /dev/ttyS0 or /dev/ttyUSB0 for Linux
 	 * */
@@ -61,7 +61,8 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 
 	/** The IP address of the EyezOn Envisalink 3/2DS DSC Alarm Interface*/
 	private String ipAddress = null;
-	
+  private int tcpPort = 4025;
+
 	/** Baud rate for a serial connection */
 	private int baudRate = 0;
 
@@ -76,15 +77,15 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 
 	/** Suppress Acknowledge Messages when received */
 	private boolean suppressAcknowledgementMsgs = false;
-	
+
 	/** API Session for EyezOn Envisalink 3/2DS */
 	private API api = null;
 	private boolean connected = false;
-	
+
 	private long pollTime = 0;
 	private long pollTimeStart = 0;
 	private long pollPeriod = DEFAULT_POLL_PERIOD;
-	
+
 	/**
 	 * New items or items needing to be refreshed get added to refreshmao
 	 * the worker thread will refresh and remove them
@@ -94,7 +95,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 	private int itemCount = 0;
 	private boolean itemHasChanged = false;
 	private boolean processUpdates = false;
-		
+
 	/**
 	 * Activates the binding. Actually does nothing, because on activation
 	 * OpenHAB always calls updated to indicate that the config is updated
@@ -103,7 +104,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 	public void activate() {
 		logger.debug("DSC Alarm Binding Activated!");
 	}
-	
+
 	/**
 	 * Deactivates the binding
 	 */
@@ -122,14 +123,14 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 		if(api != null) {
 			connected = api.isConnected();
 		}
-		
+
 		if(connected) {
 			if(pollTimeStart == 0) {
 				pollTimeStart = System.currentTimeMillis();
 			}
-			
+
 			pollTime = ((System.currentTimeMillis() - pollTimeStart) / 1000) / 60;
-			
+
 			//Send Poll command to the DSC Alarm if idle for 'pollPeriod' minutes
 			if(pollTime >= pollPeriod) {
 				api.sendCommand(APICode.Poll);
@@ -165,20 +166,20 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 	@Override
 	public void bindingChanged(BindingProvider provider, String itemName) {
 		logger.debug("bindingChanged(): Item Name: {}", itemName);
-		
+
 		boolean itemRemoved = false;
 		int icount = provider.getItemNames().size();
 
 		if(icount < itemCount) {
 			itemRemoved = true;
 		}
-		
+
 		if(itemRemoved) {
 			dscAlarmUpdateMap.clear();
 		} else {
 
 			DSCAlarmBindingProvider dscAlarmBindingProvider = (DSCAlarmBindingProvider) provider;
-			
+
 			if(dscAlarmBindingProvider != null) {
 				DSCAlarmBindingConfig dscAlarmBindingConfig = dscAlarmBindingProvider.getDSCAlarmBindingConfig(itemName);
 				if(dscAlarmBindingConfig != null) {
@@ -190,7 +191,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 		itemCount = provider.getItemNames().size();
 		itemHasChanged = true;
 	}
-	
+
 	/**
 	 * @{inheritDoc
 	 */
@@ -202,11 +203,11 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 			dscAlarmBindingConfig = prov.getDSCAlarmBindingConfig(itemName);
 			item = prov.getItem(itemName);
 			if( dscAlarmBindingConfig != null) {
-				DSCAlarmDeviceType dscAlarmDeviceType = dscAlarmBindingConfig.getDeviceType(); 
+				DSCAlarmDeviceType dscAlarmDeviceType = dscAlarmBindingConfig.getDeviceType();
 				int partitionId;
 				int zoneId;
 				int cmd;
-				
+
 				logger.debug("internalReceiveCommand():  Item Name: {} Command: {} Item Device Type: {}",itemName,command,dscAlarmDeviceType);
 
 				if(connected) {
@@ -266,7 +267,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 								default:
 									break;
 							}
-							
+
 							break;
 						case PARTITION:
 							partitionId = dscAlarmBindingConfig.getPartitionId();
@@ -297,7 +298,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 								default:
 									break;
 							}
-							
+
 							dscAlarmUpdateMap.put(itemName, dscAlarmBindingConfig);
 							processUpdateMap();
 							break;
@@ -315,15 +316,15 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 										String data = String.valueOf(partitionId) + "*1" + String.format("%02d", zoneId) + "#";
 										if(api.sendCommand(APICode.KeySequence, data)) {
 											dscAlarmItemUpdate.updateDeviceProperties(item, dscAlarmBindingConfig, 1, "Zone Bypassed");
-										}										
+										}
 									}
 									break;
-	
-										
+
+
 								default:
 									break;
 							}
-							
+
 							break;
 						default:
 							logger.debug("internalReceiveCommand(): No Command Sent.");
@@ -350,7 +351,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 			}
 		}
 	}
-	
+
 
 	/**
 	 * @{inheritDoc
@@ -373,9 +374,21 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 	 */
 	public void updated(Dictionary<String, ?> config) throws ConfigurationException {
 		logger.debug("updated(): Configuration updated, config {}", config != null ? true:false);
-		
+
 		if (config != null) {
-			
+
+			String deviceType = null;
+			if(StringUtils.isNotBlank((String) config.get("deviceType"))) {
+				if(deviceType.equals("it100")) {
+					connectorType = DSCAlarmConnectorType.IT100;
+				} else if(deviceType.equals("envisalink")) {
+					connectorType = DSCAlarmConnectorType.ENVISALINK;
+				} else {
+					logger.error("updated(): Device type not configured correctly!");
+					return;
+				}
+			}
+
 			if(StringUtils.isNotBlank((String) config.get("serialPort"))) {
 				serialPort = (String) config.get("serialPort");
 			}
@@ -384,13 +397,23 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 				ipAddress = (String) config.get("ip");
 			}
 
+			try {
+				if(StringUtils.isNotBlank((String) config.get("tcpPort")))
+					tcpPort = Integer.parseInt((String) config.get("tcpPort"));
+			} catch(NumberFormatException numberFormatException) {
+				tcpPort=4025;
+				logger.error("updated(): TCP Port not configured correctly!");
+				return;
+			}
+
 			if(serialPort != null && ipAddress != null) {
 				logger.error("updated(): Can only configure one connection type at a time: Serial Port or Ip Address!");
 				return;
 			}
 
 			if(serialPort != null) {
-				connectorType = DSCAlarmConnectorType.SERIAL;
+				if(connectorType == null)
+					connectorType = DSCAlarmConnectorType.IT100;
 				try {
 					if(StringUtils.isNotBlank((String) config.get("baud")))
 						baudRate = Integer.parseInt((String) config.get("baud"));
@@ -400,14 +423,13 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 					return;
 				}
 			}
-			
-			if(ipAddress != null) {
-				connectorType = DSCAlarmConnectorType.TCP;
+
+			if(ipAddress != null && connectorType == null) {
+				connectorType = DSCAlarmConnectorType.ENVISALINK;
 			}
-			
-			logger.debug("updated(): Connector Type: {}",connectorType);
-			
-			
+
+			logger.debug("updated(): Connector Type: {}", connectorType);
+
 			if(StringUtils.isNotBlank((String) config.get("password"))) {
 				password = (String) config.get("password");
 			}
@@ -415,7 +437,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 			if(StringUtils.isNotBlank((String) config.get("usercode"))) {
 				userCode = (String) config.get("usercode");
 			}
-			
+
 			if(StringUtils.isNotBlank((String) config.get("pollPeriod"))) {
 				try {
 					pollPeriod = Integer.parseInt((String) config.get("pollperiod"));
@@ -433,22 +455,22 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 			} else {
 				pollPeriod = DEFAULT_POLL_PERIOD;
 			}
-			
+
 			if(StringUtils.isNotBlank((String) config.get("suppressAcknowledgementMsgs"))) {
 				try {
-					suppressAcknowledgementMsgs = Boolean.parseBoolean((String) config.get("suppressAcknowledgementMsgs"));				
+					suppressAcknowledgementMsgs = Boolean.parseBoolean((String) config.get("suppressAcknowledgementMsgs"));
 				} catch (NumberFormatException numberFormatException) {
 					suppressAcknowledgementMsgs = false;
 					logger.error("updated(): Error parsing 'suppressAcknowledgementMsgs'. This must be boolean!");
 				}
 			}
-			
+
 		}
 		else {
 			logger.debug("updated(): No Configuration!");
 			return;
 		}
-		
+
 		initialize();
 	}
 
@@ -457,12 +479,12 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 	 */
  	private void initialize() {
 
-		//Check to see if openHAB read in our items while the binding was configuring, and add them to dscAlarmUpdateMap. 
+		//Check to see if openHAB read in our items while the binding was configuring, and add them to dscAlarmUpdateMap.
 		 if(dscAlarmUpdateMap.isEmpty() && itemHasChanged == false) {
 			 buildUpdateMap();
 			 itemHasChanged = true;
 		 }
-		
+
 		//Open a connection to the DSC Alarm Panel
 		openConnection();
 		if(!connected) {
@@ -471,7 +493,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 		else {
 			dscAlarmItemUpdate.setConnected(true);
 		}
-		
+
 		this.setProperlyConfigured(true);
 		logger.debug("initialize(): Binding initialized!");
  	}
@@ -484,10 +506,10 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 
 		for (DSCAlarmBindingProvider prov : providers) {
 	 		if(!prov.getItemNames().isEmpty()) {
-	 			itemCount = prov.getItemNames().size();	 			
+	 			itemCount = prov.getItemNames().size();
 				dscAlarmUpdateMap.clear();
 				for (String iName : prov.getItemNames()) {
-					config = prov.getDSCAlarmBindingConfig(iName); 
+					config = prov.getDSCAlarmBindingConfig(iName);
 					if(config != null) {
 						dscAlarmUpdateMap.put(iName, config);
 					}
@@ -495,19 +517,19 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 			}
 		}
 	}
-	
+
 	/**
 	 * Processes the Update Items Map
 	 */
 	private void processUpdateMap() {
-	
+
 		if (dscAlarmUpdateMap.size() == 0) {
 			logger.debug("processUpdateMap(): Nothing to update.");
 			return;
 		}
-		
+
 		Map<String, DSCAlarmBindingConfig> itemsMap = new HashMap<String, DSCAlarmBindingConfig>(dscAlarmUpdateMap);
-	
+
 		for (String itemName : itemsMap.keySet()) {
 			DSCAlarmBindingConfig dscAlarmBindingConfig = itemsMap.get(itemName);
 			dscAlarmUpdateMap.remove(itemName);
@@ -527,14 +549,14 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
  	private void openConnection() {
 
     	switch (connectorType) {
-	    	case SERIAL:
+	    	case IT100:
 	     		if (api == null) {
 	    			api = new API(serialPort, baudRate, userCode);
 	    		}
 	     		break;
-	    	case TCP:
+	    	case ENVISALINK:
 	     		if (api == null) {
-	    			api = new API(ipAddress, password, userCode);
+	    			api = new API(ipAddress, tcpPort, password, userCode);
 	    		}
    			break;
 	        default:
@@ -549,16 +571,16 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 			api.addEventListener(this);
 		}
 	}
-	
+
 	/**
 	 * Attempt to reconnect to TCP or Serial connection
 	 */
 	private void reconnect() {
 		String itemName;
-		logger.debug("reconnect(): API Reconnection!");	
+		logger.debug("reconnect(): API Reconnection!");
 
 		openConnection();
-		
+
 		if(connected) {
 			dscAlarmItemUpdate.setConnected(true);
 			itemName = getItemName(DSCAlarmItemType.PANEL_CONNECTION,0,0);
@@ -571,7 +593,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 		}
 		else {
 			setPanelMessage("PANEL DISCONNECTED!!!");
-			logger.error("reconnect(): API reconnection failed!");	
+			logger.error("reconnect(): API reconnection failed!");
 		}
 	}
 
@@ -591,34 +613,34 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 		if(itemName != "") {
 			updateItem(itemName);
 		}
-		
-		logger.debug("closeConnection(): {} Connection Closed!",connectorType);	
-	}	
-	
+
+		logger.debug("closeConnection(): {} Connection Closed!",connectorType);
+	}
+
 	/**
 	 * Find Item by Item Name
-	 * 
+	 *
 	 * @param itemName
 	 * @return item
 	 */
 	private Item getItem(String itemName) {
 		Item item = null;
-		
+
 		for (DSCAlarmBindingProvider prov : providers) {
 			for (String iName : prov.getItemNames()) {
 				if(itemName == iName) {
 					item = prov.getItem(itemName);
 					break;
 				}
-			}			
+			}
 		}
-		
+
 		return item;
 	}
 
 	/**
 	 * Searches for an items name and returns it
-	 * 
+	 *
 	 * @param dscAlarmItemType
 	 * @param partitionId
 	 * @param zoneId
@@ -627,13 +649,13 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 	private String getItemName(DSCAlarmItemType dscAlarmItemType, int partitionId, int zoneId) {
 		String itemName = "";
 		DSCAlarmBindingConfig config = null;
-		
+
 		for (DSCAlarmBindingProvider prov : providers) {
 			for (String iName : prov.getItemNames()) {
 				config = prov.getDSCAlarmBindingConfig(iName);
 				if(config.getDSCAlarmItemType() == dscAlarmItemType) {
 					if(partitionId == -1) {
-						if(config.getZoneId() == zoneId) { 
+						if(config.getZoneId() == zoneId) {
 							itemName = iName;
 							break;
 						}
@@ -649,34 +671,34 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 				}
 			}
 		}
-		
+
 		return itemName;
 	}
-		
+
 	/**
 	 * Find Item Configuration by Item Name
-	 * 
+	 *
 	 * @param itemName
 	 * @return item
 	 */
 	private DSCAlarmBindingConfig getItemConfig(String itemName) {
 		DSCAlarmBindingConfig config = null;
-		
+
 		for (DSCAlarmBindingProvider prov : providers) {
 			for (String iName : prov.getItemNames()) {
 				if(itemName == iName) {
 					config = prov.getDSCAlarmBindingConfig(iName);
 					break;
 				}
-			}			
+			}
 		}
-		
+
 		return config;
 	}
 
 	/**
 	 * Update an item by item name
-	 * 
+	 *
 	 * @param itemName
 	 */
 	private void updateItem(String itemName) {
@@ -699,7 +721,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 
 	/**
 	 * Update an item by DSC Alarm Item Type
-	 * 
+	 *
 	 * @param dscAlarmItemType
 	 * @param trigger
 	 */
@@ -716,11 +738,11 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 
 	/**
 	 * Update a DSC Alarm device Properties
-	 * 
+	 *
 	 * @param itemName
 	 * @param state
 	 * @param description
-	 */	
+	 */
 	private void updateDeviceProperties(String itemName, int state, String description) {
 		DSCAlarmBindingConfig config = null;
 		Item item = null;
@@ -741,7 +763,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 
 	/**
 	 * Method to set the panel message item
-	 * 
+	 *
 	 * @param message
 	 */
 	private void setPanelMessage(String message) {
@@ -756,7 +778,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 
 	/**
 	 * Method to set a partition status item
-	 * 
+	 *
 	 * @param partitionID
 	 * @param state
 	 * @param description
@@ -770,31 +792,31 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 			updateItem(itemName);
 		}
 	}
-	
+
 	/**
 	 * Method to send a sequence of key presses one at a time using the '070' command.
-	 *  
+	 *
 	 * @param keySequence
 	 */
 	@SuppressWarnings("unused")
 	private boolean sendKeySequence(String keySequence) {
 		logger.debug("sendKeySequence(): Sending key sequence '{}'.", keySequence);
-		
+
 		boolean sent = false;
-		
+
 		for(char key : keySequence.toCharArray()) {
 			sent = api.sendCommand(APICode.KeyStroke, String.valueOf(key));
-			
+
 			if(!sent)
 				return sent;
 		}
-		
+
 		return sent;
 	}
 
 	/**
 	 * Method to set the time stamp state
-	 * 
+	 *
 	 * @param timeStamp
 	 */
 	private void setTimeStampState(String timeStamp) {
@@ -804,19 +826,19 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 		String itemName = "";
 
 		itemName = getItemName(DSCAlarmItemType.PANEL_TIME_STAMP, 0, 0);
-		
+
 		if(itemName != "") {
 			DSCAlarmBindingConfig config = getItemConfig(itemName);
-			
+
 			if(config != null) {
 				Item item = getItem(itemName);
 				if(item != null) {
 					DSCAlarmDeviceProperties dsclarmDeviceProperties = dscAlarmItemUpdate.getDeviceProperties(item, config);
-					
+
 					if(dsclarmDeviceProperties != null) {
-						
+
 						boolean isTimeStamp = dsclarmDeviceProperties.getSystemTimeStamp();
-						
+
 						if((timeStamp == "" && isTimeStamp == false)  || (timeStamp != "" && isTimeStamp == true)) {
 							logger.debug("setTimeStampState(): Already Set!", timeStamp);
 							return;
@@ -835,9 +857,9 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 
 	/**
 	 * Handle Keypad LED events for the EyezOn Envisalink 3/2DS DSC Alarm Interface
-	 * 
+	 *
 	 * @param event
-	 */	
+	 */
 	private void keypadLEDStateEventHandler(EventObject event) {
 		DSCAlarmEvent dscAlarmEvent = (DSCAlarmEvent) event;
 		APIMessage apiMessage = dscAlarmEvent.getAPIMessage();
@@ -851,18 +873,18 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 
 		String itemName;
 		APICode apiCode = APICode.getAPICodeValue(apiMessage.getAPICode());
-		
+
 		int bitField = Integer.decode("0x" + apiMessage.getAPIData());
 		int[] masks = {1,2,4,8,16,32,64,128};
 		int[] bits = new int[8];
 
 		for(int i=0; i < 8; i++) {
 			bits[i] = bitField & masks[i];
-			
+
 			itemName = getItemName(dscAlarmItemTypes[i],0,0);
 
 			if(itemName != "") {
-				
+
 				switch(apiCode) {
 					case KeypadLEDState: /*510*/
 						updateDeviceProperties(itemName, bits[i] != 0 ? 1:0, "");
@@ -875,17 +897,17 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 					default:
 						break;
 				}
-				
+
 				updateItem(itemName);
 			}
-		}		
+		}
 	}
-	
+
 	/**
 	 * Handle Verbose Trouble Status events for the EyezOn Envisalink 3/2DS DSC Alarm Interface
-	 * 
+	 *
 	 * @param event
-	 */	
+	 */
 	private void verboseTroubleStatusHandler(EventObject event) {
 		DSCAlarmEvent dscAlarmEvent = (DSCAlarmEvent) event;
 		APIMessage apiMessage = dscAlarmEvent.getAPIMessage();
@@ -898,26 +920,26 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 		};
 
 		String itemName;
-		
+
 		int bitField = Integer.decode("0x" + apiMessage.getAPIData());
 		int[] masks = {1,2,4,8,16,32,64,128};
 		int[] bits = new int[8];
 
 		for(int i=0; i < 8; i++) {
 			bits[i] = bitField & masks[i];
-			
+
 			itemName = getItemName(dscAlarmItemTypes[i],0,0);
 
-			if(itemName != "") {				
+			if(itemName != "") {
 				updateDeviceProperties(itemName, bits[i] != 0 ? 1:0, "");
 				updateItem(itemName);
 			}
-		}		
+		}
 	}
 
 	/**
 	 * DSC Alarm incoming message event handler
-	 * 
+	 *
 	 * @param event
 	 */
 	public void dscAlarmEventRecieved(EventObject event) {
@@ -935,11 +957,11 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 		boolean found = false;
 		boolean suppressPanelMsg = false;
 		int state = 0;
-		int partitionId = apiMessage.getPartition();		
+		int partitionId = apiMessage.getPartition();
 		int zoneId = apiMessage.getZone();
-		
+
 		setTimeStampState(apiMessage.getTimeStamp());
-		
+
 		switch(apiCode) {
 			case CommandAcknowledge: /*500*/
 				dscAlarmItemUpdate.setConnected(true);
@@ -950,7 +972,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 				if(suppressAcknowledgementMsgs) {
 					suppressPanelMsg = true;
 				}
-				
+
 				break;
 			case SystemError: /*502*/
 				dscAlarmItemType = DSCAlarmItemType.PANEL_SYSTEM_ERROR;
@@ -966,7 +988,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 				if(suppressAcknowledgementMsgs) {
 					suppressPanelMsg = true;
 				}
-				
+
 				break;
 			case PartitionReady: /*650*/
 			case PartitionNotReady: /*651*/
@@ -1044,7 +1066,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 				break;
 			case EntryDelayInProgress: /*656*/
 				updateItemType(DSCAlarmItemType.PARTITION_ENTRY_DELAY, apiMessage.getPartition(), -1, 1);
-				break;				
+				break;
 			case ExitDelayInProgress: /*656*/
 				updateItemType(DSCAlarmItemType.PARTITION_EXIT_DELAY, apiMessage.getPartition(), -1, 1);
 				break;
@@ -1098,7 +1120,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 				break;
 			case VerboseTroubleStatus: /*849*/
 				verboseTroubleStatusHandler(event);
-				break;			
+				break;
 			case CodeRequired: /*900*/
 				api.sendCommand(APICode.CodeSend);
 				break;
@@ -1135,7 +1157,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 				}
 			default:
 				break;
-		
+
 		}
 
 		if(!suppressPanelMsg) {
@@ -1178,9 +1200,9 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 								found = false;
 								break;
 						}
-						
+
 					}
-					
+
 					if(found) {
 						item = prov.getItem(itemName);
 						dscAlarmItemUpdate.updateDeviceItem(item, config, eventPublisher, dscAlarmEvent);
@@ -1188,7 +1210,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 						break;
 					}
 				}
-				
+
 				if(found)
 					break;
 			}
@@ -1198,11 +1220,11 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 	@Override
 	public boolean sendDSCAlarmCommand(String command, String data) {
 		logger.debug("sendDSCAlarmCommand(): Attempting to send DSC Alarm Command: command - {} - data: {}", command, data);
-		
+
 		try {
 			APICode apiCode = APICode.getAPICodeValue(command);
-			
-			if(connectorType.equals(DSCAlarmConnectorType.SERIAL) && apiCode.equals(APICode.KeySequence)) {
+
+			if(connectorType.equals(DSCAlarmConnectorType.IT100) && apiCode.equals(APICode.KeySequence)) {
 				return sendKeySequence(data);
 			}
 			else {
@@ -1214,4 +1236,3 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 		}
 	}
 }
-

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/connector/DSCAlarmConnectorType.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/connector/DSCAlarmConnectorType.java
@@ -10,11 +10,11 @@ package org.openhab.binding.dscalarm.internal.connector;
 
 /**
  * Enum class for the different connector types
- * 
+ *
  * @author Russell Stephens
  * @since 1.6.0
  */
 public enum DSCAlarmConnectorType {
-	SERIAL,
-	TCP;
+	IT100,
+	ENVISALINK;
 }

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/connector/SerialConnector.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/connector/SerialConnector.java
@@ -48,7 +48,7 @@ public class SerialConnector implements DSCAlarmConnector, SerialPortEventListen
 	private SerialPort serialPort = null;
 	private OutputStreamWriter serialOutput = null;
 	private BufferedReader serialInput = null;
-	private DSCAlarmConnectorType connectorType = DSCAlarmConnectorType.SERIAL;
+	private DSCAlarmConnectorType connectorType = DSCAlarmConnectorType.IT100;
 	private static boolean connected = false;
 	private static List<DSCAlarmEventListener> _listeners = new ArrayList<DSCAlarmEventListener>();
 

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/connector/TCPConnector.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/connector/TCPConnector.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A class that establishes a TCP Socket connection to the EyezOn Envisalink 3/2DS interface
- * 
+ *
  * @author Russell Stephens
  * @since 1.6.0
  */
@@ -43,10 +43,10 @@ public class TCPConnector implements DSCAlarmConnector {
 	private OutputStreamWriter tcpOutput = null;
 	private BufferedReader tcpInput = null;
 	private TCPListener TCPListener = null;
-	private DSCAlarmConnectorType connectorType = DSCAlarmConnectorType.TCP;
+	private DSCAlarmConnectorType connectorType = DSCAlarmConnectorType.ENVISALINK;
 	private static boolean connected = false;
 	private static List<DSCAlarmEventListener> _listeners = new ArrayList<DSCAlarmEventListener>();
-	
+
 	/**
 	 * Constructor.
 	 **/
@@ -55,14 +55,14 @@ public class TCPConnector implements DSCAlarmConnector {
 		tcpPort = port;
 		connectTimeout = timeout;
 	}
-	
+
 	/**
 	 * Returns Connector Type
 	 **/
 	public DSCAlarmConnectorType getConnectorType() {
-		return connectorType;		
+		return connectorType;
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 **/
@@ -98,11 +98,11 @@ public class TCPConnector implements DSCAlarmConnector {
 			logger.error("read(): Exception: ", exception);
 			connected = false;
         }
-        
+
         return message;
 
     }
-    
+
 	/**
 	 * {@inheritDoc}
 	 **/
@@ -114,7 +114,7 @@ public class TCPConnector implements DSCAlarmConnector {
 			tcpOutput = new OutputStreamWriter(tcpSocket.getOutputStream(), "US-ASCII");
             tcpInput = new BufferedReader(new InputStreamReader(tcpSocket.getInputStream()));
             connected = true;
-            
+
 			//Start the TCP Listener
 	    	TCPListener = new TCPListener();
 	    	TCPListener.start();
@@ -139,7 +139,7 @@ public class TCPConnector implements DSCAlarmConnector {
 
 	 /**
 	  * Handles an incoming  message
-	  * 
+	  *
 	  * @param incomingMessage
 	  */
 	 public synchronized void handleIncomingMessage(String incomingMessage) {
@@ -148,7 +148,7 @@ public class TCPConnector implements DSCAlarmConnector {
 
 		DSCAlarmEvent event = new DSCAlarmEvent(this);
 		event.dscAlarmEventMessage(Message);
-		
+
 		// send message to event listeners
 		try {
 			Iterator<DSCAlarmEventListener> iterator = _listeners.iterator();
@@ -162,14 +162,14 @@ public class TCPConnector implements DSCAlarmConnector {
 		}
 	 }
 
- 
+
 	/**
 	 * {@inheritDoc}
 	 **/
 	 public boolean isConnected() {
 		 return connected;
 	 }
-   
+
 	/**
 	 * {@inheritDoc}
 	 **/
@@ -209,25 +209,25 @@ public class TCPConnector implements DSCAlarmConnector {
 	 * {@inheritDoc}
 	 **/
 	public synchronized void removeEventListener(DSCAlarmEventListener listener) {
-		_listeners.remove(listener);		
+		_listeners.remove(listener);
 	}
 
 	/**
 	 * TCPMessageListener Thread. Receives  messages from the DSC Alarm Panel API.
-	 */	
+	 */
 	private class TCPListener extends Thread {
 		private final Logger logger = LoggerFactory.getLogger(TCPListener.class);
-	
+
 		public TCPListener() {
 		}
-		
+
 		/**
 		 * Run method. Runs the MessageListener thread
 		 */
 		@Override
 		public void run() {
 			String messageLine;
-			
+
 			try {
 				while(connected) {
 					if((messageLine = read()) != null) {

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
@@ -26,16 +26,16 @@ import org.slf4j.LoggerFactory;
  * @since 1.6.0
  */
 public class API {
-	
+
 	private static final Logger logger = LoggerFactory.getLogger(API.class);
-    
-	
+
+
     /** DSC Alarm connector type - Serial or TCP. **/
 	private DSCAlarmConnectorType connectorType = null;
-	
+
 	/** DSC Alarm Connector **/
 	private DSCAlarmConnector dscAlarmConnector = null;
-    
+
     /** DSC IT-100 Serial Interface serial port name. **/
     private String serialPort = "";
 
@@ -46,7 +46,7 @@ public class API {
     private String ipAddress = "192.168.0.100";
 
 	/** EyezOn Envisalink 3/2DS default TCP port. **/
-	public static final int DEFAULT_TCP_PORT = 4025;
+	private int tcpPort = 4025;
 
 	/** EyezOn Envisalink 3/2DS TCP Connection timeout in milliseconds **/
 	private static final int TCP_CONNECTION_TIMEOUT = 5000;
@@ -62,7 +62,7 @@ public class API {
 
 	/** User password for  network login - set to default **/
 	private String password = DEFAULT_PASSWORD;
- 
+
    	/** DSC Alarm user code for some commands - set to default **/
 	private String dscAlarmUserCode = DEFAULT_USER_CODE;
 
@@ -71,13 +71,13 @@ public class API {
 
 	/** DSC Alarm valid baud rates **/
 	private int[] baudRates = {9600,19200,38400,57600,115200};
-	
+
 	/**
 	 * Constructor for Serial Connection
-	 * 
+	 *
 	 * @param sPort
 	 * @param baud
-	 */	
+	 */
 	public API(String sPort, int baud, String userCode) {
 		if (StringUtils.isNotBlank(sPort)) {
 			serialPort = sPort;
@@ -93,20 +93,22 @@ public class API {
 		//The IT-100 requires 6 digit codes. Shorter codes are right padded with 0.
 		this.dscAlarmUserCode = StringUtils.rightPad(dscAlarmUserCode, 6, '0');
 
-		connectorType = DSCAlarmConnectorType.SERIAL;
+		connectorType = DSCAlarmConnectorType.IT100;
 	}
-       
+
 	/**
 	 * Constructor for TCP connection
-	 * 
+	 *
 	 * @param ip
 	 * @param password
 	 * @param userCode
 	 */
-	public API(String ip, String password, String userCode) {
+	public API(String ip, int port, String password, String userCode) {
 		if (StringUtils.isNotBlank(ip)) {
 			ipAddress = ip;
 		}
+
+		tcpPort = port;
 
 		if (StringUtils.isNotBlank(password)) {
 			this.password = password;
@@ -116,12 +118,12 @@ public class API {
 			this.dscAlarmUserCode = userCode;
 		}
 
-		connectorType = DSCAlarmConnectorType.TCP;
+		connectorType = DSCAlarmConnectorType.ENVISALINK;
 	}
 
 	/**
 	 * Add event listener
-	 * 
+	 *
 	 * @param listener
 	 **/
 	public void addEventListener(DSCAlarmEventListener listener) {
@@ -130,7 +132,7 @@ public class API {
 
 	/**
 	 * Remove event listener
-	 * 
+	 *
 	 * @param listener
 	 **/
 	public synchronized void removeEventListener(DSCAlarmEventListener listener) {
@@ -139,51 +141,51 @@ public class API {
 
 	/**
 	 * Returns Connector Type
-	 * 
+	 *
 	 * @return connectorType
 	 **/
 	public DSCAlarmConnectorType getConnectorType() {
-		return connectorType;		
+		return connectorType;
 	}
 
 	/**
 	 * Method to check if baud rate is valid
-	 * 
+	 *
 	 * @return boolean
 	 */
 	private boolean isValidBaudRate(int baudRate) {
 		boolean isValid = false;
-		
+
 		for (int i=0; i<baudRates.length; i++) {
-			if(baudRate == baudRates[i]) 
+			if(baudRate == baudRates[i])
 				isValid = true;
 		}
-		
+
 		return isValid;
 	}
-	
+
 	/**
 	 * Return DSC Alarm User Code.
 	 **/
 	public String getUserCode() {
 		return dscAlarmUserCode;
 	}
-	
+
 	/**
 	 * Connect to the DSC Alarm System through the EyezOn Envisalink 3/2DS or the DSC IT-100.
 	 **/
     public boolean open() {
 
     	switch (connectorType) {
-	    	case SERIAL:
-				if(dscAlarmConnector == null) { 
+	    	case IT100:
+				if(dscAlarmConnector == null) {
 					dscAlarmConnector = new SerialConnector(serialPort, baudRate);
 				}
 				break;
-	    	case TCP:
+	    	case ENVISALINK:
 	        	if(StringUtils.isNotBlank(ipAddress) ) {
-					if(dscAlarmConnector == null) { 
-						dscAlarmConnector = new TCPConnector(ipAddress, DEFAULT_TCP_PORT, TCP_CONNECTION_TIMEOUT);
+					if(dscAlarmConnector == null) {
+						dscAlarmConnector = new TCPConnector(ipAddress, tcpPort, TCP_CONNECTION_TIMEOUT);
 					}
 	        	}
 	        	else {
@@ -195,25 +197,25 @@ public class API {
 	        default:
 	        	break;
     	}
-    	
+
 		dscAlarmConnector.open();
 		connected = dscAlarmConnector.isConnected();
-	
+
     	if(connected) {
-    		if(connectorType == DSCAlarmConnectorType.TCP)
+    		if(connectorType == DSCAlarmConnectorType.ENVISALINK)
     			sendCommand(APICode.NetworkLogin);
-    		
+
     		connected = dscAlarmConnector.isConnected();
     	}
 
     	if(!connected)
     		logger.error("open(): Unable to Make API Connection!");
-    	
+
 		logger.debug("open(): Connected = {}, Connection Type: {}", connected ? true:false, connectorType);
 
 		return connected;
     }
-    
+
     /**
      * Close the connection to the DSC Alarm system.
      */
@@ -227,10 +229,10 @@ public class API {
     /**
      * Read a API message received from the DSC Alarm system.
      */
-    public String read() {        	
+    public String read() {
 		return dscAlarmConnector.read();
      }
-       
+
     /**
      * Return Connected Status.
      */
@@ -240,7 +242,7 @@ public class API {
 
      /**
       * Send an API command to the DSC Alarm system.
-      * 
+      *
       * @param apiCode
       * @param apiData
       * @return
@@ -248,26 +250,26 @@ public class API {
      public boolean sendCommand(APICode apiCode, String... apiData) {
     	boolean successful = false;
     	boolean validCommand = false;
-    	
+
     	String command = apiCode.getCode();
     	String data = "";
- 		
+
  		switch (apiCode) {
 			case Poll: /*000*/
 			case StatusReport: /*001*/
 				validCommand = true;
 				break;
  			case LabelsRequest: /*002*/
- 				if(!connectorType.equals(DSCAlarmConnectorType.SERIAL)) {
- 					break;					
+ 				if(!connectorType.equals(DSCAlarmConnectorType.IT100)) {
+ 					break;
  				}
 				validCommand = true;
  				break;
 			case NetworkLogin: /*005*/
- 				if(!connectorType.equals(DSCAlarmConnectorType.TCP)) {
- 					break;					
+ 				if(!connectorType.equals(DSCAlarmConnectorType.ENVISALINK)) {
+ 					break;
  				}
- 				
+
  				if (password == null || password.length() < 1 || password.length() > 6) {
  					logger.error("sendCommand(): Password is invalid, must be between 1 and 6 chars", password);
  					break;
@@ -276,8 +278,8 @@ public class API {
 				validCommand = true;
  				break;
  			case DumpZoneTimers: /*008*/
- 				if(!connectorType.equals(DSCAlarmConnectorType.TCP)) {
- 					break;					
+ 				if(!connectorType.equals(DSCAlarmConnectorType.ENVISALINK)) {
+ 					break;
  				}
 				validCommand = true;
  				break;
@@ -292,25 +294,25 @@ public class API {
  		    		logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: " + apiData[0]);
  	 				break;
  				}
- 
+
  				if (apiData[1] == null || !apiData[1].matches("[1-4]")) {
  		    		logger.error("sendCommand(): Output number must be a single character string from 1 to 4, it was: " + apiData[1]);
- 					break;					
+ 					break;
  				}
 
  				data = apiData[0];
  				validCommand = true;
  				break;
  			case KeepAlive: /*074*/
- 				if(!connectorType.equals(DSCAlarmConnectorType.TCP)) {
- 					break;					
+ 				if(!connectorType.equals(DSCAlarmConnectorType.ENVISALINK)) {
+ 					break;
  				}
  			case PartitionArmControlAway: /*030*/
  			case PartitionArmControlStay: /*031*/
  			case PartitionArmControlZeroEntryDelay: /*032*/
  				if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
  			    	logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}", apiData[0]);
- 					break;					
+ 					break;
  				}
 				data = apiData[0];
 				validCommand = true;
@@ -321,17 +323,21 @@ public class API {
  			    	logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}", apiData[0]);
  					break;
  				}
- 				
+
  				if (dscAlarmUserCode == null || dscAlarmUserCode.length() < 4 || dscAlarmUserCode.length() > 6) {
  					logger.error("sendCommand(): User Code is invalid, must be between 4 and 6 chars: {}", dscAlarmUserCode);
  					break;
  				}
-				data = apiData[0] + dscAlarmUserCode;
+
+				if(!connectorType.equals(DSCAlarmConnectorType.IT100))
+					data = apiData[0] + String.format("%-6s",dscAlarmUserCode).replace(' ','0');
+				else
+					data = apiData[0] + dscAlarmUserCode;
 				validCommand = true;
   				break;
  			case VirtualKeypadControl: /*058*/
- 				if(!connectorType.equals(DSCAlarmConnectorType.SERIAL)) {
- 					break;					
+ 				if(!connectorType.equals(DSCAlarmConnectorType.IT100)) {
+ 					break;
  				}
  			case TimeStampControl: /*055*/
  			case TimeDateBroadcastControl: /*056*/
@@ -347,8 +353,8 @@ public class API {
  				if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
  				   	logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}", apiData[0]);
  	 				break;
- 				}		 
- 				 
+ 				}
+
  				if (apiData[1] == null || !apiData[1].matches("[1-3]")) {
  		    		logger.error("sendCommand(): FAPcode must be a single character string from 1 to 3, it was: {}", apiData[1]);
  					break;
@@ -365,10 +371,10 @@ public class API {
 				validCommand = true;
  				break;
  			case KeySequence: /*071*/
- 				if(!connectorType.equals(DSCAlarmConnectorType.TCP)) {
+ 				if(!connectorType.equals(DSCAlarmConnectorType.ENVISALINK)) {
  					break;
  				}
- 				
+
  				if (apiData[0] == null || apiData[0].length() > 6 || !apiData[0].matches("(\\d|#|\\*)+")) {
  		    		logger.error("sendCommand(): \'keysequence\' must be a string of up to 6 characters consiting of 0 to 9, *, or #, it was: {}", apiData[0]);
  					break;
@@ -389,7 +395,7 @@ public class API {
  				validCommand = false;
 				break;
 
- 		} 		
+ 		}
 
  		if(validCommand) {
  			APICommand apiCommand = new APICommand();
@@ -400,7 +406,7 @@ public class API {
     	}
     	else
     		logger.error("sendCommand(): Command Not Sent - Invalid!");
-    	 
+
     	return successful;
     }
 }

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -4,9 +4,9 @@
 # update openHAB one day.
 
 
-####################################################################################### 
+#######################################################################################
 #####                        General configurations                               #####
-####################################################################################### 
+#######################################################################################
 
 # Configuration folders (must exist as a subdirectory of "configurations"; the value
 # tells the number of seconds for the next scan of the directory for changes. A
@@ -22,7 +22,7 @@ folder:persistence=10,persist
 # configures the security options. The following values are valid:
 # ON = security is switched on generally
 # OFF = security is switched off generally
-# EXTERNAL = security is switched on for external requests 
+# EXTERNAL = security is switched on for external requests
 #            (e.g. originating from the Internet) only
 # (optional, defaults to 'OFF')
 #security:option=
@@ -34,7 +34,7 @@ folder:persistence=10,persist
 # The name of the default persistence service to use
 persistence:default=rrd4j
 
-# The refresh interval for the main configuration file. A value of '-1' 
+# The refresh interval for the main configuration file. A value of '-1'
 # deactivates the scan (optional, defaults to '-1' hence scanning is deactivated)
 #mainconfig:refresh=
 
@@ -62,9 +62,9 @@ chart:provider=default
 #chart:scale=1
 
 
-####################################################################################### 
+#######################################################################################
 #####                       Action configurations                                 #####
-####################################################################################### 
+#######################################################################################
 
 ######################## Mail Action configuration ####################################
 #
@@ -149,7 +149,7 @@ chart:provider=default
 #prowl:defaultpriority=
 
 # the url of the Prowl public api
-# (optional, defaults to 'https://prowl.weks.net/publicapi/') 
+# (optional, defaults to 'https://prowl.weks.net/publicapi/')
 #prowl:url=
 
 #################### Pushover Action configuration #####################
@@ -225,9 +225,9 @@ chart:provider=default
 #openwebif:receiver.<name>.password=
 #openwebif:receiver.<name>.https=
 
-####################################################################################### 
+#######################################################################################
 #####                   I/O component configurations                              #####
-####################################################################################### 
+#######################################################################################
 
 ########################## Google Calendar configuration ##############################
 #
@@ -271,25 +271,25 @@ chart:provider=default
 # files (optional, defaults to '.')
 #dropbox:contentdir=
 
-# defines a comma separated list of regular expressions which matches the 
+# defines a comma separated list of regular expressions which matches the
 # filenames to upload to Dropbox (optional, defaults to '/configurations/.*,
 # /logs/.*, /etc/.*')
 #dropbox:uploadfilter=
 
-# defines a comma separated list of regular expressions which matches the 
+# defines a comma separated list of regular expressions which matches the
 # filenames to download from Dropbox (optional, defaults to '/configurations/.*')
 #dropbox:downloadfilter=
 
 ############################# MaryTTS configuration ###################################
 #
-# the default voice used by the MaryTTS engine. Available voices are: bits1-hsmm 
+# the default voice used by the MaryTTS engine. Available voices are: bits1-hsmm
 # (german, female), bits3-hsmm (german, male), cmu-slt-hsmm (english, male) (optional,
 # defaults to the systems' default voice or the first available voice)
 #marytts:voice=
 
 ###################### Speech-Dispatcher TTS configuration ############################
 #
-# Hostname or ip of the first Speech Dispatcher device to control 
+# Hostname or ip of the first Speech Dispatcher device to control
 # speechdispatcher:<SDId1>.host=
 # Port of the Speech Dispatcher to control (optional, defaults to 6560)
 # speechdispatcher:<SDId1>.port=6560
@@ -301,13 +301,13 @@ chart:provider=default
 # googletts:language=en
 # Sentence delimiters used to split text into sentences (optional, default: !.?:;)
 # googletts:sentenceDelimiters=
-# Google Translate URL to be used for converting text to speech (optional, 
+# Google Translate URL to be used for converting text to speech (optional,
 # defaults to http://translate.google.com/translate_tts?tl=%s&q=%s&client=t).
 # googletts:translateUrl=
 
-####################################################################################### 
+#######################################################################################
 #####                      Persistence configurations                             #####
-####################################################################################### 
+#######################################################################################
 
 ########################### RRD4J Persistence Service #################################
 #
@@ -320,12 +320,12 @@ chart:provider=default
 
 #rrd4j:<defname>.def=[ABSOLUTE|COUNTER|DERIVE|GAUGE],<heartbeat>,[<min>|U],[<max>|U],<step>
 #rrd4j:<defname>.archives=[AVERAGE|MIN|MAX|LAST|FIRST|TOTAL],<xff>,<steps>,<rows>
-#rrd4j:<defname>.items=<list of items for this defname> 
+#rrd4j:<defname>.items=<list of items for this defname>
 
 ######################## Open.Sen.se Persistence Service ##############################
 #
-# the url of the Open.Sen.se public api (optional, defaults to 
-# 'http://api.sen.se/events/?sense_key=') 
+# the url of the Open.Sen.se public api (optional, defaults to
+# 'http://api.sen.se/events/?sense_key=')
 #sense:url=
 
 # the Open.Sen.se API-Key for authentication (generated on the Open.Sen.se website)
@@ -340,10 +340,10 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 
 ########################### Db4o Persistence Service ##################################
 #
-# the backup interval as Cron-Expression (optional, defaults to '0 0 1 * * ?' 
+# the backup interval as Cron-Expression (optional, defaults to '0 0 1 * * ?'
 # which means every morning at 1 o'clock)
 #db4o:backupinterval=
-	
+
 # the commit interval in seconds (optional, default to '5')
 #db4o:commitinterval=
 
@@ -369,7 +369,7 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 
 ############################ Cosm Persistence Service #################################
 #
-# the url of the Cosm feed (optional, defaults to 'http://api.cosm.com/v2/feeds/') 
+# the url of the Cosm feed (optional, defaults to 'http://api.cosm.com/v2/feeds/')
 #cosm:url=
 
 # the Cosm API-Key for authentication (generated on the Cosm website)
@@ -391,7 +391,7 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 # the base script which is written to the newly created Calendar-Events by
 # the GCal-based presence simulation. It must contain two format markers '%s'.
 # The first marker represents the Item to send the command to and the second
-# represents the State (optional, defaults to 
+# represents the State (optional, defaults to
 # '> if (PresenceSimulation.state == ON) sendCommand(%s,%s)')
 #gcal-persistence:executescript=
 
@@ -420,7 +420,7 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 
 ############################ InfluxDB 0.8 Persistence Service #############################
 #
-# The database URL, e.g. http://127.0.0.1:8086 or https://127.0.0.1:8084 . 
+# The database URL, e.g. http://127.0.0.1:8086 or https://127.0.0.1:8084 .
 # Defaults to: http://127.0.0.1:8086
 # influxdb08:url=http(s)://<host>:<port>
 
@@ -437,7 +437,7 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 
 ############################ InfluxDB Persistence Service #############################
 #
-# The database URL, e.g. http://127.0.0.1:8086 or https://127.0.0.1:8084 . 
+# The database URL, e.g. http://127.0.0.1:8086 or https://127.0.0.1:8084 .
 # Defaults to: http://127.0.0.1:8086
 # influxdb:url=http(s)://<host>:<port>
 
@@ -526,8 +526,8 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 # Optional. Password to authenticate with the broker.
 #mqtt:<broker>.pwd=<password>
 
-# Optional. Set the quality of service level for sending messages to this broker. 
-# Possible values are 0 (Deliver at most once),1 (Deliver at least once) or 2 
+# Optional. Set the quality of service level for sending messages to this broker.
+# Possible values are 0 (Deliver at most once),1 (Deliver at least once) or 2
 # (Deliver exactly once). Defaults to 0.
 #mqtt:<broker>.qos=<qos>
 
@@ -551,7 +551,7 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 
 ################################ KNX Binding ##########################################
 #
-# KNX gateway IP address 
+# KNX gateway IP address
 # (optional, if serialPort or connection type 'ROUTER' is specified)
 #knx:ip=
 
@@ -568,7 +568,7 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 #knx:ignorelocalevents=
 
 # KNX IP connection type. Could be either TUNNEL or ROUTER (optional, defaults to TUNNEL)
-# Note: If you cannot get the ROUTER mode working (even if it claims it is connected), 
+# Note: If you cannot get the ROUTER mode working (even if it claims it is connected),
 # use TUNNEL mode instead with setting both the ip of the KNX gateway and the localIp.
 #knx:type=
 
@@ -587,7 +587,7 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 # initialization (optional, defaults to 50)
 #knx:pause=
 
-# Timeout in milliseconds to wait for a response from the KNX bus (optional, 
+# Timeout in milliseconds to wait for a response from the KNX bus (optional,
 # defaults to 10000)
 #knx:timeout
 
@@ -603,19 +603,23 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 #knx:autoReconnectPeriod=30
 
 ### Auto refresh feature
-# Number of entries permissible in the item refresher queue. 
+# Number of entries permissible in the item refresher queue.
 # (optional, defaults to 10000)
 #knx:maxRefreshQueueEntries=
 
 # Number of parallel threads for refreshing items. (optional, defaults to 5)
 #knx:numberOfThreads=
 
-# Seconds to wait for an orderly shutdown of the auto refresher's 
+# Seconds to wait for an orderly shutdown of the auto refresher's
 # ScheduledExecutorService. (optional, defaults to 5)
 #knx:scheduledExecutorServiceShutdownTimeoutString=
 
 ############################## DSC Alarm Binding #####################################
 #
+# DSC Alarm interface device type
+# Valid values are it100 (default for serial connection) or envisalink (default for tcp connection)
+#dscalarm:deviceType=
+
 # DSC Alarm port name for a serial connection.
 # Valid values are e.g. COM1 for Windows and /dev/ttyS0 or /dev/ttyUSB0 for Linux.
 # Leave undefined if not connecting by serial port.
@@ -626,9 +630,14 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 # Leave undefined if using default.
 #dscalarm:baud=
 
-# DSC Alarm IP address for a TCP connection. 
+# DSC Alarm IP address for a TCP connection.
 # Leave undefined if not connecting by network connection.
 #dscalarm:ip=
+
+# DSC Alarm TCP port for a TCP connection.
+# Can be EyezOn Envisalink on 4025 (default) or a TCP serial server to IT-100
+# Leave undefined if not connecting by network connection.
+#dscalarm:tcpPort=
 
 # DSC Alarm password for logging into the EyezOn Envisalink 3/2DS interface.
 # Leave undefined if using default.
@@ -646,7 +655,7 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 
 ############################# Bluetooth Binding #######################################
 #
-# Bluetooth refresh rate in seconds 
+# Bluetooth refresh rate in seconds
 # (defines, how often a new device detection scan is performed)
 #bluetooth:refresh=20
 
@@ -655,18 +664,18 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 # Used to connect to Cal DAV. All parameters are required.
 # Path to the calendar
 # caldavio:<calendarId>:url=
-# 
+#
 # Username for the calendar
 # caldavio:<calendarId>:username=
-# 
+#
 # Password for the calendar
 # caldavio:<calendarId>:password=
-# 
-# Reload interval unit is minutes. 
+#
+# Reload interval unit is minutes.
 # Defines how often the calendar should be reloaded from server.
 # Default is 60 minutes
 # caldavio:<calendarId>:reloadInterval=
-# 
+#
 # This defines which events are relevant for execution. Unit is in minutes.
 # Default is 1 Day (1440 minutes)
 # caldavio:<calendarId>:preloadTime=
@@ -696,23 +705,23 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 # Used to toggle switch items for presence. Switched to ON if an event in the calendar occurs.
 # And back to OFF if the event ends.
 # Can also be used to show upcoming or active events
-# 
+#
 # Which calendars should be used to detect presence (comma separated)
 # caldavPersonal:usedCalendars=<ids from caldav-io>
-# 
+#
 # If the location of the event is one of this identifiers, the presence will not be changed.
 # Can be used for events which are at home or are just reminders. (comma separated, optional)
 # caldavPersonal:homeIdentifiers=
 
 ############################## OneWire Binding ########################################
 #
-# OwServer IP address 
+# OwServer IP address
 #onewire:ip=
 
 # OwServer Port (optional, defaults to 4304)
 #onewire:port=
 
-# the retry count in case no valid value was returned 
+# the retry count in case no valid value was returned
 # upon read (optional, defaults to 3)
 #onewire:retry=
 
@@ -751,7 +760,7 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 # http:<id1>.url=
 # http:<id1>.updateInterval=
 
-# configuration of the second cache item  
+# configuration of the second cache item
 # http:<id2>.url=
 # http:<id2>.updateInterval=
 
@@ -763,7 +772,7 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 # IP address of Fritz!Box to connect to
 #fritzbox:ip=fritz.box
 
-# Only if you would like to use the switches to turn wifi, dect, ... on and off you 
+# Only if you would like to use the switches to turn wifi, dect, ... on and off you
 # need to configure the password of your Fritz!Box.
 #fritzbox:password=
 
@@ -795,7 +804,7 @@ ntp:hostname=ptbtime1.ptb.de
 
 ################################ MPD Binding ##########################################
 #
-# Host and port of the first MPD to control 
+# Host and port of the first MPD to control
 # mpd:<player-id-1>.host=
 # mpd:<player-id-1>.port=
 
@@ -803,7 +812,7 @@ ntp:hostname=ptbtime1.ptb.de
 # indicate that no authentication is required)
 # mpd:<player-id-1>.password=
 
-# Host and port of the second MPD to control 
+# Host and port of the second MPD to control
 # mpd:<player-id-2>.host=
 # mpd:<player-id-2>.port=
 
@@ -820,11 +829,11 @@ ntp:hostname=ptbtime1.ptb.de
 
 ################################ VDR Binding ##########################################
 #
-# Host and port of the first VDR to control 
+# Host and port of the first VDR to control
 # vdr:<vdr-id-1>.host=
 # vdr:<vdr-id-1>.port=6419
 
-# Host and port of the second VDR to control 
+# Host and port of the second VDR to control
 # vdr:<vdr-id-2>.host=
 # vdr:<vdr-id-2>.port=6419
 
@@ -886,13 +895,13 @@ ntp:hostname=ptbtime1.ptb.de
 #plugwise:stick.interval=150
 
 # "circleplus" is reserved plug wise id
-#plugwise:circleplus.mac= 
+#plugwise:circleplus.mac=
 
 #plugwise:<plugwise-id-1>.mac=
 
 ############################### Modbus Binding ########################################
 #
-# sets refresh interval to Modbus polling service. 
+# sets refresh interval to Modbus polling service.
 # Value in milliseconds (optional, defaults to 200)
 #modbus:poll=
 
@@ -924,7 +933,7 @@ ntp:hostname=ptbtime1.ptb.de
 
 ############################# Sonance Binding #######################################
 #
-# Sonance refresh rate in ms 
+# Sonance refresh rate in ms
 # (defines, how often a values are updated when command are send or buttons are pressed)
 #sonance:refresh=60000
 
@@ -940,14 +949,14 @@ ntp:hostname=ptbtime1.ptb.de
 #hue:ip=
 
 # Default secret key for the pairing of the Philips Hue Bridge.
-# It has to be between 10-40 (alphanumeric) characters 
+# It has to be between 10-40 (alphanumeric) characters
 # This may be changed by the user for security reasons.
 hue:secret=openHABRuntime
 
 # Polling interval in msec to retrieve Philips bulb status.
-# Other apps can change Hue status or a physical switch can turn on / off lamp status. 
+# Other apps can change Hue status or a physical switch can turn on / off lamp status.
 # If this happens the status of hue lamps within OpenHAB won't reflect the real status.
-# Currently (September 2014) there is no push technology available, so the only option is 
+# Currently (September 2014) there is no push technology available, so the only option is
 # to poll Philips bulbs to retrieve status and update items accordingly to reflect changes.
 # Polling is enabled if refresh is specified, by commenting out "hue:refresh=10000" statement.
 # Be aware that polling will consume resources, so a small refresh interval will increase cpu load.
@@ -960,12 +969,12 @@ hue:secret=openHABRuntime
 #rfxcom:serialPort=
 
 # Set mode command for controller (optional)
-# E.g. rfxcom:setMode=0D000000035300000C2F00000000 
+# E.g. rfxcom:setMode=0D000000035300000C2F00000000
 #rfxcom:setMode=
 
 ############################## Pulseaudio Binding #####################################
 #
-# PulseaudioServer IP address 
+# PulseaudioServer IP address
 #pulseaudio:Main.host=
 
 # PulseaudioServer Port (optional, defaults to 4712)
@@ -977,12 +986,12 @@ hue:secret=openHABRuntime
 # homematic:host=
 
 # The timeout in seconds for connections to a slower CCU (optional, default is 15)
-# If you have a CCU1 with many devices, you may get a read time out exception. 
+# If you have a CCU1 with many devices, you may get a read time out exception.
 # Increase this timeout to give the CCU1 more time to respond.
 # homematic:host.timeout=
 
 # Hostname / IP address for the callback server (optional, default is auto-discovery)
-# This is normally the IP / hostname of the local host (but not "localhost" or "127.0.0.1"). 
+# This is normally the IP / hostname of the local host (but not "localhost" or "127.0.0.1").
 # homematic:callback.host=
 
 # Port number for the callback server. (optional, default is 9123)
@@ -993,9 +1002,9 @@ hue:secret=openHABRuntime
 # homematic:alive.interval=
 
 # The interval in seconds to reconnect to the Homematic server (optional, default is disabled)
-# If you have no sensors which sends messages in regular intervals and/or you have low communication, 
+# If you have no sensors which sends messages in regular intervals and/or you have low communication,
 # the alive.interval may restart the connection to the Homematic server to often.
-# The reconnect.interval disables the alive.interval and reconnects after a fixed period of time. 
+# The reconnect.interval disables the alive.interval and reconnects after a fixed period of time.
 # Think in hours when configuring (one hour = 3600)
 # homematic:reconnect.interval=
 
@@ -1004,11 +1013,11 @@ hue:secret=openHABRuntime
 # refresh interval in milliseconds (optional, defaults to 900000ms, 15m)
 #koubachi:refresh
 
-# The URL of the Device list  (optional, defaults to 
+# The URL of the Device list  (optional, defaults to
 # 'https://api.koubachi.com/v2/user/smart_devices?user_credentials=%1$s&app_key=%2$s')
 #koubachi:deviceurl
 
-# The URL of the Plant list  (optional, defaults to 
+# The URL of the Plant list  (optional, defaults to
 # 'https://api.koubachi.com/v2/plants?user_credentials=%1$s&app_key=%2$s')
 #koubachi:planturl
 
@@ -1035,24 +1044,24 @@ hue:secret=openHABRuntime
 
 ################################ SAMSUNG TV Binding ###################################
 #
-# Host of the first TV to control 
+# Host of the first TV to control
 # samsungtv:<TVid1>.host=
 # Port of the TV to control (optional, defaults to 55000)
 # samsungtv:<TVid1>.port=
 
-# Host of the second TV to control 
+# Host of the second TV to control
 # samsungtv:<TVid2>.host=
 # Port of the TV to control (optional, defaults to 55000)
 # samsungtv:<TVid2>.port=
 
 ################################# Onkyo  Binding ######################################
 #
-# Host of the first Onkyo device to control 
+# Host of the first Onkyo device to control
 # onkyo:<OnkyoId1>.host=
 # Port of the Onkyo to control (optional, defaults to 60128)
 # onkyo:<OnkyoId1>.port=
 
-# Host of the second Onkyo device to control 
+# Host of the second Onkyo device to control
 # onkyo:<OnkyoId2>.host=
 # Port of the Onkyo to control (optional, defaults to 60128)
 # onkyo:<OnkyoId2>.port=
@@ -1062,7 +1071,7 @@ hue:secret=openHABRuntime
 # The type of OpenSprinkler connection to make (optional, defaults to 'gpio').
 # There are two valid options:
 #
-# gpio: this mode is only applicable when running openHAB on a Raspberry Pi, which 
+# gpio: this mode is only applicable when running openHAB on a Raspberry Pi, which
 #       is connected directly to an OpenSprinkler Pi. In this mode the communication
 #       is directly over the GPIO pins of the Raspberry Pi
 # http: this mode is applicable to both OpenSprinkler and OpenSprinkler Pi, as long as
@@ -1085,13 +1094,13 @@ hue:secret=openHABRuntime
 
 ############################ Epson Projector Binding ##################################
 #
-# Serial port or Host and port of the first Epson projector to control 
+# Serial port or Host and port of the first Epson projector to control
 # epsonprojector:<devId1>.serialPort=
 # epsonprojector:<devId1>.host=
 # Port of the Epson projector to control (optional, defaults to 60128)
 # epsonprojector:<devId1>.port=
 
-# Serial port or Host and port of the second Epson projector to control 
+# Serial port or Host and port of the second Epson projector to control
 # epsonprojector:<devId2>.serialPort=
 # epsonprojector:<devId2>.host=
 # Port of the Epson projector to control (optional, defaults to 60128)
@@ -1107,10 +1116,10 @@ hue:secret=openHABRuntime
 
 ############################### EDS OWSever Binding ###################################
 #
-# Host of the first OWServer device to control 
+# Host of the first OWServer device to control
 # owserver:<serverId1>.host=
 
-# Host of the second OWServer device to control 
+# Host of the second OWServer device to control
 # owserver:<serverId2>.host=
 
 ################################ digitalSTROM Binding #################################
@@ -1128,7 +1137,7 @@ hue:secret=openHABRuntime
 #digitalstrom:loginToken=
 
 # to login with username and password; default user is dssadmin and default password
-# is dssadmin if you have loginToken and username with password the loginToken will 
+# is dssadmin if you have loginToken and username with password the loginToken will
 # be prefered by default
 #digitalstrom:user=
 #digitalstrom:password=
@@ -1171,12 +1180,12 @@ hue:secret=openHABRuntime
 
 ################################### Milight Binding ###################################
 #
-# Host of the first Milight bridge to control 
+# Host of the first Milight bridge to control
 #milight:<MilightId1>.host=
 # Port of the bridge to control (optional, defaults to 50000)
 #milight:<MilightId1>.port=
 #
-# Host of the second Milight bridge to control 
+# Host of the second Milight bridge to control
 #milight:<MilightId2>.host=
 # Port of the bridge to control (optional, defaults to 50000)
 #milight:<MilightId2>.port=
@@ -1195,7 +1204,7 @@ hue:secret=openHABRuntime
 # Watchdog polling interval (optional, defaults to 60000)
 #piface:watchdog.interval=
 
-# Host of the first Raspberry PI carrying a PiFace board 
+# Host of the first Raspberry PI carrying a PiFace board
 #piface:<piface-id1>.host=
 # Port of the Piface listener of the first RasPi (optional, defaults to 15432)
 #piface:<piface-id1>.listenerport=
@@ -1226,7 +1235,7 @@ hue:secret=openHABRuntime
 # Username of the first AHA host. User must have HomeAuto permissions.
 # (optional for local networks, required for remote access)
 #fritzaha:<hostID1>.username=
-# Password of the first AHA host's web interface. 
+# Password of the first AHA host's web interface.
 # (optional, but required if password is set in host)
 #fritzaha:<hostID1>.password=
 # timeout for synchronous http-connections (optional, default 2000)
@@ -1236,8 +1245,8 @@ hue:secret=openHABRuntime
 
 ############################## Tinkerforge  Binding ###################################
 #
-# IP addresses / Hostnames  of the hosts running the brickd (optional port 
-# separated by a colon, defaults to 4223) 
+# IP addresses / Hostnames  of the hosts running the brickd (optional port
+# separated by a colon, defaults to 4223)
 # tinkerforge:hosts=
 
 ######################## NIBE HEAT PUMP Binding #######################################
@@ -1264,11 +1273,11 @@ hue:secret=openHABRuntime
 # /dev/ttyUSB0 for Linux
 #nikobus:serial.port=
 
-# Directory path where the command cache file should be created.  
+# Directory path where the command cache file should be created.
 # Optional. Defaults to the users' home directory.
 #nikobus:cache.location=
 
-# Perform a module status query every x seconds (optional, defaults to 600 (10 minutes)). 
+# Perform a module status query every x seconds (optional, defaults to 600 (10 minutes)).
 #nikobus:refresh=
 
 ################################# EnOcean Binding #####################################
@@ -1278,7 +1287,7 @@ hue:secret=openHABRuntime
 
 ################################# TCP - UDP Binding ###################################
 #
-# all parameters can be applied to both the TCP and UDP binding unless 
+# all parameters can be applied to both the TCP and UDP binding unless
 # specified otherwise
 
 # Port to listen for incoming connections
@@ -1287,7 +1296,7 @@ hue:secret=openHABRuntime
 # Cron-like string to reconnect remote ends, e.g for unstable connection or remote ends
 #tcp:reconnectcron=0 0 0 * * ?
 
-# Interval between reconnection attempts when recovering from a communication error, 
+# Interval between reconnection attempts when recovering from a communication error,
 # in seconds
 #tcp:retryinterval=5
 
@@ -1341,14 +1350,14 @@ tcp:refreshinterval=250
 # Mqttitude can track your presence in two ways;
 #
 #  1. Regions - by defining a region in your Mqttitude app (on your phone) you specify
-#               a set of lat/lon coordinates, a geofence, and a name - by using this name 
-# 				in your item binding openHAB will listen for enter/leave events for this 
+#               a set of lat/lon coordinates, a geofence, and a name - by using this name
+# 				in your item binding openHAB will listen for enter/leave events for this
 #               region and thus allow you to track your presence in multiple locations
-#  2. Home    - by defining the lat/lon of your home, along with a geofence radius (below), 
-#               the binding will listen for location publishes from the Mqttitude app and 
+#  2. Home    - by defining the lat/lon of your home, along with a geofence radius (below),
+#               the binding will listen for location publishes from the Mqttitude app and
 #               manually calculate the distance from your 'home'
 #
-# Optional. The latitude/longitude coordinates of 'home'. 
+# Optional. The latitude/longitude coordinates of 'home'.
 #mqttitude:home.lat=
 #mqttitude:home.lon=
 
@@ -1378,8 +1387,8 @@ tcp:refreshinterval=250
 # Interval in milliseconds to poll for user location (optional, defaults to 5mins).
 #openpaths:refresh=
 
-# Distance in metres a user must be from 'home' to be considered inside the 
-# geofence (optional, defaults to 100m). 
+# Distance in metres a user must be from 'home' to be considered inside the
+# geofence (optional, defaults to 100m).
 #openpaths:geofence=
 
 # OpenPaths access/secret keys for each user.
@@ -1482,7 +1491,7 @@ tcp:refreshinterval=250
 #freeswitch:host=
 
 # Port that your freeswitch server is listening for ESL connections on
-# (optional, defaults to 8021) 
+# (optional, defaults to 8021)
 #freeswitch:port=
 
 # Password set for ESL connections
@@ -1536,7 +1545,7 @@ tcp:refreshinterval=250
 
 # Daikin Online Controller - host address and optional username/password
 # NOTE: currently the username/password are ignored - you must configure
-#       the KKRP01A with no security - i.e. empty password for all logins 
+#       the KKRP01A with no security - i.e. empty password for all logins
 #daikin:<id>.host=
 #daikin:<id>.username=
 #daikin:<id>.password=
@@ -1638,7 +1647,7 @@ tcp:refreshinterval=250
 # and /dev/ttyS0 or /dev/ttyUSB0 for Linux
 #iec6205621meter:<meter-id1>.serialPort=/dev/ttyS0
 
-# Delay of baud rate change in ms. Default is 0. USB to serial converters often 
+# Delay of baud rate change in ms. Default is 0. USB to serial converters often
 # require a delay of up to 250ms default is 0ms
 #iec6205621meter:<meter-id1>.baudRateChangeDelay=
 
@@ -1707,7 +1716,7 @@ tcp:refreshinterval=250
 ################################# Davis Binding #######################################
 #
 # The Davis weather station port. Valid values are e.g. COM1 for Windows and
-# /dev/ttyS0 or /dev/ttyUSB0 for Linux. 
+# /dev/ttyS0 or /dev/ttyUSB0 for Linux.
 #
 #davis:port=COM7
 
@@ -1734,7 +1743,7 @@ tcp:refreshinterval=250
 
 ############################### Libelium eHealth ######################################
 #
-# Configures the serial port where the eHealth kit is attached to 
+# Configures the serial port where the eHealth kit is attached to
 # (e.g. '/dev/tty.usbmodem1411')
 #ehealth:serialPort=
 
@@ -1777,15 +1786,15 @@ tcp:refreshinterval=250
 # The TCP port address to use
 #lgtv:<lgtvId1>.port=
 
-# The the pairkey / if it's wrong the device shows the right pairkey 
+# The the pairkey / if it's wrong the device shows the right pairkey
 # at every connection attempt
 #lgtv:<lgtvId1>.pairkey=
 
-# The TCP port address of the openhab system to receive lgtv status messages 
+# The TCP port address of the openhab system to receive lgtv status messages
 # (only first occurance is used for all tvs)
 #lgtv:<lgtvId1>.serverport=
 
-# The location to put xml files with the information of availiable 
+# The location to put xml files with the information of availiable
 # channels and apps (optional)
 #lgtv:<lgtvId1>.xmldatafiles=./
 
@@ -1794,7 +1803,7 @@ tcp:refreshinterval=250
 
 ############################### Enigma2 Binding #######################################
 #
-# Refresh interval for state updates in milliseconds (configured once, valid 
+# Refresh interval for state updates in milliseconds (configured once, valid
 # for each device), e.g.
 #enigma2:refresh=10000
 #
@@ -1817,15 +1826,15 @@ tcp:refreshinterval=250
 # pilight:<instance name>.<parameter>=<value>
 #
 
-# IP address of the pilight daemon 
+# IP address of the pilight daemon
 #pilight:kaku.host=192.168.1.22
 
 # Port of the pilight daemon
 #pilight:kaku.port=5000
 
-# Optional delay (in millisecond) between consecutive commands. 
-# Recommended value without band pass filter: 1000 
-# Recommended value with band pass filter: somewhere between 200-500 
+# Optional delay (in millisecond) between consecutive commands.
+# Recommended value without band pass filter: 1000
+# Recommended value with band pass filter: somewhere between 200-500
 #pilight:kaku.delay=1000
 
 ################################### Weather Binding ###################################
@@ -1893,7 +1902,7 @@ tcp:refreshinterval=250
 # Refresh interval for state updates in milliseconds (optional)
 #networkupstools:refresh=60000
 
-# UPS device name 
+# UPS device name
 #networkupstools:ups1.device=ups
 
 # UPS server hostname (optional)
@@ -1941,7 +1950,7 @@ tcp:refreshinterval=250
 ############################### Satel Binding #########################################
 #
 # Satel ETHM-1 module hostname or IP.
-# Leave this commented out for INT-RS module.  
+# Leave this commented out for INT-RS module.
 #satel:host=
 
 # ETHM-1 port to use (optional, defaults to 7094), if host setting is not empty.
@@ -1996,18 +2005,18 @@ tcp:refreshinterval=250
 # Optional, port that the Plex server is running on. Default = 32400
 #plex:port=32400
 
-# Refresh interval in ms. Default = 5000. 
+# Refresh interval in ms. Default = 5000.
 #plex:refresh=5000
 
  # If you're using Plex Home you need to supply the username and password of your
  # Plex account here. If you don't want to enter your credentials you can also
- # directly set your account token below instead. 
+ # directly set your account token below instead.
 #plex:username=Plex username
 
  # Plex password
 #plex:password=Plex password
 
-# Plex account token, use instead of username/password when using Plex Home. 
+# Plex account token, use instead of username/password when using Plex Home.
 #plex:token=abcdefghijklmnopqrst
 
 ############################### Denon Binding #########################################
@@ -2017,13 +2026,13 @@ tcp:refreshinterval=250
 # IP adress of the Denon receiver instance
 #denon:avr2000.host=192.168.1.70
 
-# Optional, set connection method for receiving updates. Can be http or telnet. 
-# Denon receivers only support one concurrent telnet connection, so use http if 
+# Optional, set connection method for receiving updates. Can be http or telnet.
+# Denon receivers only support one concurrent telnet connection, so use http if
 # you have any other app using the telnet connection. Default = telnet
 #denon:avr2000.update=telnet
 
-# Optional, this sets the refresh interval (in milliseconds) for all instances 
-# if you're using the http connection method. Default = 5000 
+# Optional, this sets the refresh interval (in milliseconds) for all instances
+# if you're using the http connection method. Default = 5000
 #denon:refresh=5000
 
 ############################ Frontier Silicon Radio Binding ###########################
@@ -2068,7 +2077,7 @@ tcp:refreshinterval=250
 # primare:myspa20.serial=/dev/ttyAMA0
 
 # If connected to TCP-serial converter (such as a linux box running socat):
-# Host of the first Primare device to control 
+# Host of the first Primare device to control
 # primare:myspa20.host=10.0.0.1
 # Port of the first Primare to control
 # primare:myspa20.port=8001
@@ -2081,13 +2090,13 @@ tcp:refreshinterval=250
 # The port to monitor for messages you shouldn't need to change this
 #lightwaverf:receiveport=9760
 
-# The port to send messages on, it will also be monitored for incoming messages 
+# The port to send messages on, it will also be monitored for incoming messages
 # you shouldn't need to change this
 #lightwaverf:sendport=9761
 
-# For a new computer you will need to register it with the wifi link to be allowed to 
-# send messages setting this to true we will send a registration message on startup. 
-# You will need to confirm registration on the wifi link. There is no harm leaving 
+# For a new computer you will need to register it with the wifi link to be allowed to
+# send messages setting this to true we will send a registration message on startup.
+# You will need to confirm registration on the wifi link. There is no harm leaving
 # this as true but you can set to false once you have registerd for the first time.
 #lightwaverf:registeronstartup=true
 
@@ -2193,7 +2202,7 @@ tcp:refreshinterval=250
 # Too low values may cause errors, too high values will lead to longer delays, until updates are seen
 # in OpenHAB. Should not be smaller than 1000.
 # rwesmarthome:poll.interval=2000
- 
+
 # The interval in seconds to check if the communication with the RWE Smarthome server is still alive.
 # If no message receives from the RWE Smarthome server, the binding restarts. (optional, default is 300)
 # rwesmarthome:alive.interval=300
@@ -2246,10 +2255,10 @@ tcp:refreshinterval=250
 # Device specification token used if device is not already registered.
 # sitewhere:specificationToken=5a95f3f2-96f0-47f9-b98d-f5c081d01948
 #
-# MQTT broker hostname SiteWhere is listening to. 
+# MQTT broker hostname SiteWhere is listening to.
 # sitewhere:mqttHost=localhost
 #
-# MQTT broker port SiteWhere is listening to. 
+# MQTT broker port SiteWhere is listening to.
 # sitewhere:mqttPort=1883
 
 ################################ UCProjects.eu Relay Board Binding ###################################
@@ -2290,7 +2299,7 @@ tcp:refreshinterval=250
 # default is 5
 #stiebelheatpump:serialTimeout=
 
-# Perform a module status query every x miliseconds (optional, defaults to 60000 (10 minutes)). 
+# Perform a module status query every x miliseconds (optional, defaults to 60000 (10 minutes)).
 #stiebelheatpump:refresh=
 
 # version string of the heatpump


### PR DESCRIPTION
As per the following discussion with @RSStephens 

https://community.openhab.org/t/dsc-alarm-binding-with-tcp-serial-server/5701

I have added support for the DSC Alarm binding to communicate with an IT-100 through a TCP/IP serial server.

Note that for some reason I'm getting a bad checksum when trying to send "partition disarm" from the web console, but everything else seems to work.

Also note that I have only tested this with my setup (IT-100 behind a Moxa N-Port tcp/serial server).

Let me know if there's anything you'd like changed.  Thanks!