### PR TITLE
Remove the switch_all command class from the default command classes …

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveDeviceClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveDeviceClass.java
@@ -521,7 +521,7 @@ public class ZWaveDeviceClass {
 					return new CommandClass[] { CommandClass.ASSOCIATION, CommandClass.SCENE_CONTROLLER_CONF, CommandClass.MANUFACTURER_SPECIFIC };
 				case POWER_SWITCH_BINARY:
 				case POWER_SWITCH_MULTILEVEL:
-					return new CommandClass[] { CommandClass.SWITCH_ALL };
+					return new CommandClass[0];
 				case SCENE_SWITCH_BINARY:
 				case SCENE_SWITCH_BINARY_DISCONTINUED:
 				case SCENE_SWITCH_MULTILEVEL:


### PR DESCRIPTION
…for switches

This isn't a mandatory class and is causing problems with devices that do not support this class.

@xsnrg FYI - regarding the garage door sensor