### PR TITLE
Fixed device id and type id for Popp 004001 smoke detector

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -2792,8 +2792,8 @@
 		</Product>
 		<Product>
 			<Reference>
-				<Type>201</Type>
-				<Id>100</Id>
+				<Type>100</Type>
+				<Id>201</Id>
 			</Reference>
 			<Model>004001</Model>
 			<Label lang="en">Smoke Detector and Siren</Label>


### PR DESCRIPTION
This will fix issue #3700 