### PR TITLE
Fix for tcpbinding base config regex

### DIFF
--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/ProtocolGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/ProtocolGenericBindingProvider.java
@@ -56,7 +56,7 @@ abstract class ProtocolGenericBindingProvider extends AbstractGenericBindingProv
 			LoggerFactory.getLogger(ProtocolGenericBindingProvider.class);
 
 	/** {@link Pattern} which matches a binding configuration part */
-	private static final Pattern BASE_CONFIG_PATTERN = Pattern.compile("([<>]\\[.*?\\])(?:\\s|$)");
+	private static final Pattern BASE_CONFIG_PATTERN = Pattern.compile("([<>]\\[.*?\\])(?:[,\\s]|$)");
 	private static final Pattern ACTION_CONFIG_PATTERN = Pattern.compile("(<|>)\\[(.*?):(.*?):(.*?):(?:'(.*)'|(.*))\\]");
 	private static final Pattern STATUS_CONFIG_PATTERN = Pattern.compile("(<|>)\\[(.*?):(.*?):(?:'(.*)'|(.*))\\]");
 


### PR DESCRIPTION
This fixes a regression in the tcpbinding base config regex that causes issues when there are multiple binding config elements. The current expression matches space-separated config elements and it should match comma-separated elements. 