### PR TITLE
Replaced unicode single quotes with standard single quotes

### DIFF
--- a/bundles/model/org.openhab.model.item/src/org/openhab/model/item/internal/GenericItemProvider.java
+++ b/bundles/model/org.openhab.model.item/src/org/openhab/model/item/internal/GenericItemProvider.java
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Copyright (c) 2010-2015, openHAB.org and others.
  *
  * All rights reserved. This program and the accompanying materials
@@ -348,11 +348,11 @@ public class GenericItemProvider implements ItemProvider, ModelRepositoryChangeL
 					localReader.processBindingConfiguration(modelName, item, config);
 				} catch (BindingConfigParseException e) {
 					logger.error("Binding configuration of type '" + bindingType
-						+ "' of item ‘" + item.getName() + "‘ could not be parsed correctly.", e);
+						+ "' of item '" + item.getName() + "' could not be parsed correctly.", e);
 				} catch (Exception e) {
 					// Catch badly behaving binding exceptions and continue processing
 					logger.error("Binding configuration of type '" + bindingType
-						+ "' of item ‘" + item.getName() + "‘ could not be parsed correctly.", e);
+						+ "' of item '" + item.getName() + "' could not be parsed correctly.", e);
 				}
 			} else {
 				logger.trace("Couldn't find config reader for binding type '{}' > " +


### PR DESCRIPTION
The error message in #2486 displays badly due to the use of unicode single quotes.  This patch replaces them with standard single quotes.
