### PR TITLE
Rename duplicate influxdb project Eclipse

### DIFF
--- a/bundles/persistence/org.openhab.persistence.influxdb08/.project
+++ b/bundles/persistence/org.openhab.persistence.influxdb08/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.persistence.influxdb</name>
+	<name>org.openhab.persistence.influxdb08</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
There were two projects named 'influxdb', this renames the second one to 'influxdb08'. 