### PR TITLE
[weather] Add name examples to default weather binding config

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1840,12 +1840,14 @@ tcp:refreshinterval=250
 #weather:apikey2.Hamweather=
 
 # location configuration, you can specify multiple locations
+#weather:location.<locationId1>.name=
 #weather:location.<locationId1>.latitude=
 #weather:location.<locationId1>.longitude=
 #weather:location.<locationId1>.provider=
 #weather:location.<locationId1>.language=
 #weather:location.<locationId1>.updateInterval=
 
+#weather:location.<locationId2>.name=
 #weather:location.<locationId2>.latitude=
 #weather:location.<locationId2>.longitude=
 #weather:location.<locationId2>.provider=


### PR DESCRIPTION
Add 
```
#weather:location.<locationId1>.name=
#weather:location.<locationId2>.name=
```
to weather binding defaults in openhab_default.cfg.

From [forum request](https://community.openhab.org/t/openhab-1-8-default-cfg-weather-location-locationid1-name-missing/6333).