### PR TITLE
Modbus TCP connections closed after every transaction

### DIFF
--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ModbusTCPTransaction.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/io/ModbusTCPTransaction.java
@@ -212,12 +212,7 @@ public class ModbusTCPTransaction implements ModbusTransaction {
                 throw new ModbusSlaveException(((ExceptionResponse) m_Response).getExceptionCode());
             }
 
-            // 6. close connection if reconnecting
-            if (isReconnecting()) {
-                m_Connection.close();
-            }
-
-            // 7. Check transaction validity
+            // 6. Check transaction validity
             if (isCheckingValidity()) {
                 checkValidity();
             }
@@ -225,6 +220,11 @@ public class ModbusTCPTransaction implements ModbusTransaction {
         } catch (InterruptedException ex) {
             throw new ModbusIOException("Thread acquiring lock was interrupted.");
         } finally {
+            // Finally: close connection if reconnecting
+            if (isReconnecting() && m_Connection != null) {
+                m_Connection.close();
+            }
+
             m_TransactionLock.release();
         }
     }// execute

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusTcpSlave.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusTcpSlave.java
@@ -68,7 +68,10 @@ public class ModbusTcpSlave extends ModbusIPSlave {
                 connection.setPort(getPort());
                 connection.connect();
                 ((ModbusTCPTransaction) transaction).setConnection(connection);
-                ((ModbusTCPTransaction) transaction).setReconnecting(false);
+                // We want to close connection after every transaction since some modbus tcp servers
+                // can accept only single connection at a time. If we would keep the connection open,
+                // the server would be blocked for other users.
+                ((ModbusTCPTransaction) transaction).setReconnecting(true);
             } catch (Exception e) {
                 logger.debug("ModbusSlave: Error connecting to master: {}", e.getMessage());
                 return false;


### PR DESCRIPTION
We want to close connection after every transaction since some modbus
tcp servers can accept only single connection at a time. If we
would keep the connection open, the server would be blocked for other
users.

Fixes #3818