### PR TITLE
ExecUtil: fixed incorrect exitValue configuration.

### DIFF
--- a/bundles/io/org.openhab.io.net/src/main/java/org/openhab/io/net/exec/ExecUtil.java
+++ b/bundles/io/org.openhab.io.net/src/main/java/org/openhab/io/net/exec/ExecUtil.java
@@ -112,7 +112,7 @@ public class ExecUtil {
         ByteArrayOutputStream stdout = new ByteArrayOutputStream();
         PumpStreamHandler streamHandler = new PumpStreamHandler(stdout);
 
-        executor.setExitValue(1);
+        executor.setExitValues(null);
         executor.setStreamHandler(streamHandler);
         executor.setWatchdog(watchdog);
 


### PR DESCRIPTION
Issue #3821. 
Forum [topic](https://community.openhab.org/t/openhab-1-8-and-2-0-beta1-release-is-out/6025/27).