### PR TITLE
[exec binding] Allow all item types to be updated

### DIFF
--- a/bundles/binding/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/ExecBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/ExecBindingProvider.java
@@ -11,8 +11,8 @@ package org.openhab.binding.exec;
 import java.util.List;
 
 import org.openhab.core.binding.BindingProvider;
-import org.openhab.core.items.Item;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
 
 /**
  * This interface is implemented by classes that can provide mapping information
@@ -28,25 +28,25 @@ import org.openhab.core.types.Command;
 public interface ExecBindingProvider extends BindingProvider {
 
     /**
-     * Returns the Type of the Item identified by {@code itemName}
-     * 
+     * Returns the list of acceptedDataTypes of the Item identified by {@code itemName}
+     *
      * @param itemName
-     *            the name of the item to find the type for
-     * @return the type of the Item identified by {@code itemName}
+     *            the name of the item to find the list of accepted data types for
+     * @return the list of data types accepted by the Item identified by {@code itemName}
      */
-    Class<? extends Item> getItemType(String itemName);
+    List<Class<? extends State>> getAcceptedDataTypes(String itemName);
 
     /**
      * Returns the commandLine to execute according to <code>itemName</code> and
      * <code>command</code>. If there is no direct match a second attempt with
      * command <code>*</code> is triggered.
-     * 
-     * 
+     *
+     *
      * @param itemName
      *            the item for which to find a commandLine
      * @param command
      *            the openHAB command for which to find a commandLine
-     * 
+     *
      * @return the matching commandLine or <code>null</code> if no matching
      *         commandLine could be found.
      */
@@ -54,10 +54,10 @@ public interface ExecBindingProvider extends BindingProvider {
 
     /**
      * Returns the commandLine to execute according to <code>itemName</code>.
-     * 
+     *
      * @param itemName
      *            the item for which to find a commandLine
-     * 
+     *
      * @return the matching commandLine or <code>null</code> if no matching
      *         commandLine could be found.
      */
@@ -66,10 +66,10 @@ public interface ExecBindingProvider extends BindingProvider {
     /**
      * Returns the refresh interval to use according to <code>itemName</code>.
      * Is used by In-Binding.
-     * 
+     *
      * @param itemName
      *            the item for which to find a refresh interval
-     * 
+     *
      * @return the matching refresh interval or <code>null</code> if no matching
      *         refresh interval could be found.
      */
@@ -78,10 +78,10 @@ public interface ExecBindingProvider extends BindingProvider {
     /**
      * Returns the transformation rule to use according to <code>itemName</code>
      * . Is used by In-Binding.
-     * 
+     *
      * @param itemName
      *            the item for which to find a transformation rule
-     * 
+     *
      * @return the matching transformation rule or <code>null</code> if no
      *         matching transformation rule could be found.
      */
@@ -89,7 +89,7 @@ public interface ExecBindingProvider extends BindingProvider {
 
     /**
      * Returns all items which are mapped to a Exec-In-Binding
-     * 
+     *
      * @return item which are mapped to a Exec-In-Binding
      */
     List<String> getInBindingItemNames();

--- a/bundles/binding/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/internal/ExecGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.exec/src/main/java/org/openhab/binding/exec/internal/ExecGenericBindingProvider.java
@@ -20,6 +20,7 @@ import org.openhab.core.binding.BindingConfig;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
 import org.openhab.core.types.TypeParser;
 import org.openhab.model.item.binding.AbstractGenericBindingProvider;
 import org.openhab.model.item.binding.BindingConfigParseException;
@@ -105,7 +106,7 @@ public class ExecGenericBindingProvider extends AbstractGenericBindingProvider i
         super.processBindingConfiguration(context, item, bindingConfig);
 
         ExecBindingConfig config = new ExecBindingConfig();
-        config.itemType = item.getClass();
+        config.acceptedDataTypes = new ArrayList<Class<? extends State>>(item.getAcceptedDataTypes());
 
         Matcher matcher = BASE_CONFIG_PATTERN.matcher(bindingConfig);
 
@@ -235,16 +236,16 @@ public class ExecGenericBindingProvider extends AbstractGenericBindingProvider i
      * Creates a {@link Command} out of the given <code>commandAsString</code>
      * taking the special Commands "CHANGED" and "*" into account and incorporating
      * the {@link TypeParser}.
-     * 
+     *
      * @param item
      * @param commandAsString
-     * 
+     *
      * @return an appropriate Command (see {@link TypeParser} for more
      *         information
-     * 
+     *
      * @throws BindingConfigParseException if the {@link TypeParser} couldn't
      *             create a command appropriately
-     * 
+     *
      * @see {@link TypeParser}
      */
     private Command createCommandFromString(Item item, String commandAsString) throws BindingConfigParseException {
@@ -268,9 +269,9 @@ public class ExecGenericBindingProvider extends AbstractGenericBindingProvider i
      * @{inheritDoc}
      */
     @Override
-    public Class<? extends Item> getItemType(String itemName) {
+    public List<Class<? extends State>> getAcceptedDataTypes(String itemName) {
         ExecBindingConfig config = (ExecBindingConfig) bindingConfigs.get(itemName);
-        return config != null ? config.itemType : null;
+        return config != null ? config.acceptedDataTypes : null;
     }
 
     /**
@@ -337,7 +338,7 @@ public class ExecGenericBindingProvider extends AbstractGenericBindingProvider i
 
         /** generated serialVersion UID */
         private static final long serialVersionUID = 6164971643530954095L;
-        Class<? extends Item> itemType;
+        List<Class<? extends State>> acceptedDataTypes;
     }
 
     /**


### PR DESCRIPTION
The existing exec binding contains a hardcoded list of item types that it can update: Number, Contact, Switch, Rollershutter, String (default case).  However openHAB 1.x and ESH have more item types than that, and there is no reason that the output of a commandLine (optionally transformed) should not be suitable for any type of item.  The goal and outcome is similar to #3504.

This PR addresses issue #3823.

This PR removes the binding's knowledge of specific item types, but instead uses the item's acceptedDataTypes list and the TypeParser.  I tested this change with the following items:
```
Group Test (All)
String ExecString "ExecString [%s]" (Test) { exec="<[echo I am a String:60000:REGEX((.*?))]" }
Number ExecNumber "ExecNumber [%.1f]" (Test) { exec="<[echo -12345.432145663:50000:REGEX((.*?))]" }
Location ExecLocation "ExecLocation [%s]" (Test) { exec="<[echo 52.6406981,-9.503447:40000:REGEX((.*?))]" }
Switch ExecSwitch "ExecSwitch [%s]" (Test) { exec="<[echo ON:30000:REGEX((.*?))]" }
Contact ExecContact "ExecContact [%s]" (Test) { exec="<[echo OPEN:20000:REGEX((.*?))]" }
Rollershutter ExecRollershutter "ExecRollershutter [%d %%]" (Test) { exec="<[echo 60:10000:REGEX((.*?))]" }
Dimmer ExecDimmer "ExecDimmer [%d %%]" (Test) { exec="<[echo 30:70000:REGEX((.*?))]" }
DateTime ExecDateTime "ExecDateTime [%1$tH:%1$tM:%1$tS]" (Test) { exec="<[/tmp/printdate.sh:80000:REGEX((.*?))]" }
```
