### PR TITLE
add maven-bundle-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,65 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <prerequisites>
         <maven>3.0</maven>
     </prerequisites>
-    
+
     <groupId>org.openhab</groupId>
     <artifactId>openhab</artifactId>
     <version>1.9.0-SNAPSHOT</version>
     <name>openHAB</name>
-    
+
     <organization>
         <name>openHAB.org</name>
         <url>http://www.openhab.org</url>
     </organization>
-    
+
     <licenses>
         <license>
             <name>Eclipse Public License</name>
             <url>http://www.eclipse.org/legal/epl-v10.html</url>
         </license>
     </licenses>
-    
+
     <scm>
         <connection>scm:git:https://github.com/openhab/openhab.git</connection>
         <developerConnection>scm:git:https://github.com/openhab/openhab.git</developerConnection>
         <url>https://github.com/openhab/openhab</url>
     </scm>
-        
+
     <issueManagement>
         <url>https://github.com/openhab/openhab/issues</url>
         <system>Github</system>
     </issueManagement>
-    
+
     <description>This is the open Home Automation Bus (openHAB)</description>
-    
+
     <properties>
         <tp-version>2.0.0.b1</tp-version>
-        
+
         <jdeb-version>1.4</jdeb-version>
-        
+
         <tycho-version>0.24.0</tycho-version>
         <tycho-groupid>org.eclipse.tycho</tycho-groupid>
-        
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <wagon.version>1.0-beta-2</wagon.version>
-        
+
         <deb.maintainer>openHAB &lt;admin@openhab.org&gt;</deb.maintainer>
         <deb.section>misc</deb.section>
         <deb.distribution>development</deb.distribution>
         <deb.depends>openhab-runtime</deb.depends>
-        
+
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        
+
         <repo.url>https://api.bintray.com/maven/openhab/mvn/openhab</repo.url>
     </properties>
-    
+
     <packaging>pom</packaging>
-    
+
     <modules>
         <module>bundles</module>
         <module>features</module>
@@ -122,7 +122,7 @@
                 </configuration>
             </plugin>
         </plugins>
-        
+
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -175,11 +175,24 @@
                     <artifactId>tycho-versions-plugin</artifactId>
                     <version>${tycho-version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>3.0.1</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <supportedProjectTypes>
+                            <supportedProjectType>jar</supportedProjectType>
+                            <supportedProjectType>bundle</supportedProjectType>
+                            <supportedProjectType>eclipse-plugin</supportedProjectType>
+                        </supportedProjectTypes>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
-    
-	<repositories>
+
+    <repositories>
         <repository>
             <id>jcenter</id>
             <name>JCenter Repository</name>
@@ -198,8 +211,8 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-	</repositories>
-    
+    </repositories>
+
     <profiles>
         <profile>
             <id>prepare-release</id>
@@ -222,7 +235,7 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>deploy</id>
             <distributionManagement>
@@ -254,7 +267,7 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>prepare-next-snapshot</id>
             <build>
@@ -277,5 +290,5 @@
             </build>
         </profile>
     </profiles>
-    
+
 </project>


### PR DESCRIPTION
The configuration has been added, so we could a manual manifest
generation. The generated manifest could be used by developers to
identify missing imports.
The manifest generation could be triggered by:
mvn bundle:manifest -DniceManifest=true
The "nice manifest" option will e.g. add line breaks after every
imported package.
Now you can have a look at the manifest that would be generated by the
bndtool using:
cat target/classes/META-INF/MANIFEST.MF