### PR TITLE
MiOS: Work-around issue where update() called before config loaded (openHAB 2.0)

### DIFF
--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosBinding.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosBinding.java
@@ -98,7 +98,7 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider>implements 
 
     /**
      * Invoked by OSGi Framework, once per instance, during the Binding activation process.
-     * 
+     *
      * OSGi is configured to do this in OSGI-INF/activebinding.xml
      */
     @Override
@@ -109,9 +109,9 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider>implements 
 
     /**
      * Invoked by the OSGi Framework, once per instance, during the Binding deactivation process.
-     * 
+     *
      * Internally this is used to close out any resources used by the MiOS Binding.
-     * 
+     *
      * OSGi is configured to do this in OSGI-INF/activebinding.xml
      */
     @Override
@@ -325,8 +325,14 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider>implements 
 
         Map<String, MiosUnit> units = new HashMap<String, MiosUnit>();
 
-        Enumeration<String> keys = properties.keys();
+        // Under openHAB 2.0, we get called shortly after activate(), but mios.cfg
+        // hasn't yet been loaded, so we're passed a null properties object.
+        // We're called again later, so it'll get established correctly at that point.
+        if (properties == null) {
+            return;
+        }
 
+        Enumeration<String> keys = properties.keys();
         while (keys.hasMoreElements()) {
             String key = keys.nextElement();
 
@@ -403,7 +409,7 @@ public class MiosBinding extends AbstractBinding<MiosBindingProvider>implements 
      * <li>{@code Boolean} -> {@code StringType} (true == ON, false == OFF)
      * <li>{@code Calendar} -> {@code DateTimeType}
      * </ul>
-     * 
+     *
      * @param property
      *            the MiOS Property name
      * @param value

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/DeviceBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/DeviceBindingConfig.java
@@ -236,7 +236,7 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 
     /**
      * Map Aliased Service names into their "formal" UPnP-style format.
-     * 
+     *
      * @param source
      *            the original Service name to be mapped
      * @return the mapped UPnP-style Service name, if an alias mapping exists, or the original source value.
@@ -249,7 +249,7 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 
     /**
      * Static constructor-method.
-     * 
+     *
      * @return an initialized MiOS Device Binding Configuration object.
      */
     public static final MiosBindingConfig create(String context, String itemName, String unitName, int id,
@@ -260,7 +260,6 @@ public class DeviceBindingConfig extends MiosBindingConfig {
             // outgoing stuff.
             String newInStuff = inStuff;
 
-            String tmp;
             Matcher matcher;
 
             // Extract and Map the inbound names.
@@ -384,7 +383,7 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 
     /**
      * Returns the value "<code>device</code>".
-     * 
+     *
      * @return the value "<code>device</code>"
      */
     @Override


### PR DESCRIPTION
Under openHAB 2.0, the `update()` method is called before the corresponding `config.cfg/mios.cfg` file is loaded.

We're called again, after these are correctly loaded, so we'll skip over the call if the properties are passed as `null`.

Also removed an unused variable that Eclipse highlighted.

Signed-off-by: Mark Clark <mr.guessed@gmail.com>