### PR TITLE
Testers wanted - Better support for GreenWave devices

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/greenwave/np210.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/greenwave/np210.xml
@@ -3,19 +3,19 @@
 	<Model>NP210</Model>
 	<Label lang="en">Smart PowerNode</Label>
 	<CommandClasses>
-		<Class><id>0x20</id></Class>
-		<Class><id>0x25</id></Class>
-		<Class><id>0x27</id></Class>
-		<Class><id>0x32</id></Class>
-		<Class><id>0x56</id></Class>
-		<Class><id>0x60</id></Class>
-		<Class><id>0x70</id></Class>
-		<Class><id>0x71</id></Class>
-		<Class><id>0x72</id></Class>
-		<Class><id>0x75</id></Class>
-		<Class><id>0x85</id></Class>
-		<Class><id>0x86</id></Class>
-		<Class><id>0x87</id></Class>
+		<Class><id>0x20</id></Class><!-- COMMAND_CLASS_BASIC -->
+		<Class><id>0x25</id></Class><!-- COMMAND_CLASS_SWITCH_BINARY -->
+		<Class><id>0x27</id></Class><!-- COMMAND_CLASS_SWITCH_ALL -->
+		<Class><id>0x32</id></Class><!-- COMMAND_CLASS_METER_V2 -->
+		<Class><id>0x56</id></Class><!-- COMMAND_CLASS_CRC_16_ENCAP -->
+		<Class><id>0x60</id></Class><!-- COMMAND_CLASS_MULTI_CHANNEL_V3 -->
+		<Class><id>0x70</id></Class><!-- COMMAND_CLASS_CONFIGURATION -->
+		<Class><id>0x71</id></Class><!-- COMMAND_CLASS_ALARM -->
+		<Class><id>0x72</id></Class><!-- COMMAND_CLASS_MANUFACTURER_SPECIFIC_V2 -->
+		<Class><id>0x75</id></Class><!-- COMMAND_CLASS_PROTECTION_V2 -->
+		<Class><id>0x85</id></Class><!-- COMMAND_CLASS_ASSOCIATION -->
+		<Class><id>0x86</id></Class><!-- COMMAND_CLASS_VERSION -->
+		<Class><id>0x87</id></Class><!-- COMMAND_CLASS_INDICATOR -->
 	</CommandClasses>
 	
 	
@@ -23,8 +23,9 @@
 		<Parameter>
 			<Index>0</Index>
 			<Type>byte</Type>
-			<Minimum>0</Minimum>
+			<Minimum>1</Minimum>
 			<Maximum>100</Maximum>
+			<Default>10</Default>
 			<Size>1</Size>
 			<Label lang="en">Min. variation of load current</Label>
 			<Help lang="en">Minimum variation in load current before a message is sent. Value in percent (30 => 30%)</Help>
@@ -33,6 +34,8 @@
 		<Parameter>
 			<Index>1</Index>
 			<Type>byte</Type>
+			<Minimum>1</Minimum>
+			<Maximum>255</Maximum>
 			<Default>2</Default>
 			<Size>1</Size>
 			<Label lang="en">No communication light</Label>
@@ -88,6 +91,44 @@
 
 			<Label lang="en">Room color</Label>
 			<Help lang="en">The room color (Corner wheel color) on the GreenWave device</Help>
+		</Parameter>
+		
+		<Parameter>
+			<Index>3</Index>
+			<Type>list</Type>
+			<Default>2</Default>
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">Off</Label>
+			</Item>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">Last state</Label>
+			</Item>
+			<Item>
+				<Value>2</Value>
+				<Label lang="en">On</Label>
+			</Item>
+			<Size>1</Size>
+			<Label lang="en">Power-on state</Label>
+			<Help lang="en">Default state after power loss</Help>
+		</Parameter>
+		
+		<Parameter>
+			<Index>4</Index>
+			<Type>list</Type>
+			<Default>0</Default>
+			<Size>1</Size>
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">LED flash off</Label>
+			</Item>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">LED flash on</Label>
+			</Item>
+			<Label lang="en">Network error</Label>
+			<Help lang="en">If the LED should indicate a network error by flashing or not</Help>
 		</Parameter>
 	</Configuration>
 

--- a/bundles/binding/org.openhab.binding.zwave/database/greenwave/np310.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/greenwave/np310.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Product>
-	<Model>NP210</Model>
+	<Model>NP310</Model>
 	<Label lang="en">Smart PowerNode</Label>
 	<CommandClasses>
 		<Class><id>0x20</id></Class>
@@ -46,48 +46,86 @@
 			<Size>1</Size>
 			<ReadOnly>true</ReadOnly>
 			<Item>
-				<Value>128</Value>
+				<Value>-128</Value>
 				<Label lang="en">Black</Label>
 			</Item>
 			<Item>
-				<Value>129</Value>
-				<Label lang="en">Green</Label>
+				<Value>-127</Value>
+				<Label lang="en">Green (1)</Label>
 			</Item>
 			<Item>
-				<Value>130</Value>
-				<Label lang="en">Dark Blue</Label>
+				<Value>-126</Value>
+				<Label lang="en">Dark Blue (2)</Label>
 			</Item>
 			<Item>
-				<Value>131</Value>
-				<Label lang="en">Red</Label>
+				<Value>-125</Value>
+				<Label lang="en">Red (3)</Label>
 			</Item>
 			<Item>
-				<Value>132</Value>
-				<Label lang="en">Yellow</Label>
+				<Value>-124</Value>
+				<Label lang="en">Yellow (4)</Label>
 			</Item>
 			<Item>
-				<Value>133</Value>
-				<Label lang="en">Purple</Label>
+				<Value>-123</Value>
+				<Label lang="en">Purple (5)</Label>
 			</Item>
 			<Item>
-				<Value>134</Value>
-				<Label lang="en">Orange</Label>
+				<Value>-122</Value>
+				<Label lang="en">Orange (6)</Label>
 			</Item>
 			<Item>
-				<Value>135</Value>
-				<Label lang="en">Light Blue</Label>
+				<Value>-121</Value>
+				<Label lang="en">Light Blue (7)</Label>
 			</Item>
 			<Item>
-				<Value>136</Value>
-				<Label lang="en">Pink</Label>
+				<Value>-120</Value>
+				<Label lang="en">Pink (8)</Label>
 			</Item>
 			<Item>
-				<Value>137</Value>
+				<Value>-119</Value>
 				<Label lang="en">Locked</Label>
 			</Item>
 
-			<Label lang="en">Room color</Label>
-			<Help lang="en">The room color (Corner wheel color) on the GreenWave device</Help>
+			<Label lang="en">Wheel position</Label>
+			<Help lang="en">Wheel position on the GreenWave device (read-only)</Help>
+		</Parameter>
+
+		<Parameter>
+			<Index>3</Index>
+			<Type>list</Type>
+			<Default>2</Default>
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">Off</Label>
+			</Item>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">Last state</Label>
+			</Item>
+			<Item>
+				<Value>2</Value>
+				<Label lang="en">On</Label>
+			</Item>
+			<Size>1</Size>
+			<Label lang="en">Power-on state</Label>
+			<Help lang="en">Default state after power loss</Help>
+		</Parameter>
+
+		<Parameter>
+			<Index>4</Index>
+			<Type>list</Type>
+			<Default>0</Default>
+			<Size>1</Size>
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">LED flash on</Label>
+			</Item>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">LED flash off</Label>
+			</Item>
+			<Label lang="en">Network error</Label>
+			<Help lang="en">If the LED should indicate a network error by flashing or not</Help>
 		</Parameter>
 	</Configuration>
 

--- a/bundles/binding/org.openhab.binding.zwave/database/greenwave/np310.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/greenwave/np310.xml
@@ -3,19 +3,19 @@
 	<Model>NP310</Model>
 	<Label lang="en">Smart PowerNode</Label>
 	<CommandClasses>
-		<Class><id>0x20</id></Class>
-		<Class><id>0x25</id></Class>
-		<Class><id>0x27</id></Class>
-		<Class><id>0x32</id></Class>
-		<Class><id>0x56</id></Class>
-		<Class><id>0x60</id></Class>
-		<Class><id>0x70</id></Class>
-		<Class><id>0x71</id></Class>
-		<Class><id>0x72</id></Class>
-		<Class><id>0x75</id></Class>
-		<Class><id>0x85</id></Class>
-		<Class><id>0x86</id></Class>
-		<Class><id>0x87</id></Class>
+		<Class><id>0x20</id></Class><!-- COMMAND_CLASS_BASIC -->
+		<Class><id>0x25</id></Class><!-- COMMAND_CLASS_SWITCH_BINARY -->
+		<Class><id>0x27</id></Class><!-- COMMAND_CLASS_SWITCH_ALL -->
+		<Class><id>0x32</id></Class><!-- COMMAND_CLASS_METER_V2 -->
+		<Class><id>0x56</id></Class><!-- COMMAND_CLASS_CRC_16_ENCAP -->
+		<Class><id>0x60</id></Class><!-- COMMAND_CLASS_MULTI_CHANNEL_V3 -->
+		<Class><id>0x70</id></Class><!-- COMMAND_CLASS_CONFIGURATION -->
+		<Class><id>0x71</id></Class><!-- COMMAND_CLASS_ALARM -->
+		<Class><id>0x72</id></Class><!-- COMMAND_CLASS_MANUFACTURER_SPECIFIC_V2 -->
+		<Class><id>0x75</id></Class><!-- COMMAND_CLASS_PROTECTION_V2 -->
+		<Class><id>0x85</id></Class><!-- COMMAND_CLASS_ASSOCIATION -->
+		<Class><id>0x86</id></Class><!-- COMMAND_CLASS_VERSION -->
+		<Class><id>0x87</id></Class><!-- COMMAND_CLASS_INDICATOR -->
 	</CommandClasses>
 	
 	
@@ -23,8 +23,9 @@
 		<Parameter>
 			<Index>0</Index>
 			<Type>byte</Type>
-			<Minimum>0</Minimum>
+			<Minimum>1</Minimum>
 			<Maximum>100</Maximum>
+			<Default>10</Default>
 			<Size>1</Size>
 			<Label lang="en">Min. variation of load current</Label>
 			<Help lang="en">Minimum variation in load current before a message is sent. Value in percent (30 => 30%)</Help>
@@ -33,6 +34,8 @@
 		<Parameter>
 			<Index>1</Index>
 			<Type>byte</Type>
+			<Minimum>1</Minimum>
+			<Maximum>255</Maximum>
 			<Default>2</Default>
 			<Size>1</Size>
 			<Label lang="en">No communication light</Label>
@@ -118,11 +121,11 @@
 			<Size>1</Size>
 			<Item>
 				<Value>0</Value>
-				<Label lang="en">LED flash on</Label>
+				<Label lang="en">LED flash off</Label>
 			</Item>
 			<Item>
 				<Value>1</Value>
-				<Label lang="en">LED flash off</Label>
+				<Label lang="en">LED flash on</Label>
 			</Item>
 			<Label lang="en">Network error</Label>
 			<Help lang="en">If the LED should indicate a network error by flashing or not</Help>

--- a/bundles/binding/org.openhab.binding.zwave/database/greenwave/ns210.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/greenwave/ns210.xml
@@ -19,6 +19,16 @@
 	
 	<Configuration>
 		<Parameter>
+			<Index>0</Index>
+			<Type>byte</Type>
+			<Minimum>0</Minimum>
+			<Maximum>100</Maximum>
+			<Size>1</Size>
+			<Label lang="en">Min. variation of load current</Label>
+			<Help lang="en">Minimum variation in load current before a message is sent. Value in percent (30 => 30%)</Help>
+		</Parameter>
+
+		<Parameter>
 			<Index>1</Index>
 			<Type>byte</Type>
 			<Default>2</Default>
@@ -32,6 +42,7 @@
 			<Type>list</Type>
 			<Default>0</Default>
 			<Size>1</Size>
+			<ReadOnly>true</ReadOnly>
 			<Item>
 				<Value>128</Value>
 				<Label lang="en">Black</Label>
@@ -77,6 +88,30 @@
 			<Help lang="en">The room color (Corner wheel color) on the GreenWave device</Help>
 		</Parameter>
 	</Configuration>
+
+	<Associations>
+		<Group>
+			<Index>1</Index>
+			<Maximum>1</Maximum>
+			<Label lang="en">Wheel position change</Label>
+		</Group>
+		<Group>
+			<Index>2</Index>
+			<Maximum>1</Maximum>
+			<Label lang="en">Current leakage on relay</Label>
+		</Group>
+		<Group>
+			<Index>3</Index>
+			<Maximum>1</Maximum>
+			<Label lang="en">Power level change</Label>
+			<Help lang="en">The new power reading is sent if the delta of the change is greater than the defined minimum variation</Help>
+		</Group>
+		<Group>
+			<Index>4</Index>
+			<Maximum>1</Maximum>
+			<Label lang="en">Over-current detection</Label>
+		</Group>
+	</Associations>
 
 </Product>
 

--- a/bundles/binding/org.openhab.binding.zwave/database/greenwave/ns210.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/greenwave/ns210.xml
@@ -3,26 +3,27 @@
 	<Model>NS210</Model>
 	<Label lang="en">Smart PowerNode</Label>
 	<CommandClasses>
-		<Class><id>0x20</id></Class>
-		<Class><id>0x25</id></Class>
-		<Class><id>0x27</id></Class>
-		<Class><id>0x32</id></Class>
-		<Class><id>0x56</id></Class>
-		<Class><id>0x70</id></Class>
-		<Class><id>0x71</id></Class>
-		<Class><id>0x72</id></Class>
-		<Class><id>0x75</id></Class>
-		<Class><id>0x85</id></Class>
-		<Class><id>0x86</id></Class>
-		<Class><id>0x87</id></Class>
+		<Class><id>0x20</id></Class><!-- COMMAND_CLASS_BASIC -->
+		<Class><id>0x25</id></Class><!-- COMMAND_CLASS_SWITCH_BINARY -->
+		<Class><id>0x27</id></Class><!-- COMMAND_CLASS_SWITCH_ALL -->
+		<Class><id>0x32</id></Class><!-- COMMAND_CLASS_METER_V2 -->
+		<Class><id>0x56</id></Class><!-- COMMAND_CLASS_CRC_16_ENCAP -->
+		<Class><id>0x70</id></Class><!-- COMMAND_CLASS_CONFIGURATION -->
+		<Class><id>0x71</id></Class><!-- COMMAND_CLASS_ALARM -->
+		<Class><id>0x72</id></Class><!-- COMMAND_CLASS_MANUFACTURER_SPECIFIC_V2 -->
+		<Class><id>0x75</id></Class><!-- COMMAND_CLASS_PROTECTION_V2 -->
+		<Class><id>0x85</id></Class><!-- COMMAND_CLASS_ASSOCIATION -->
+		<Class><id>0x86</id></Class><!-- COMMAND_CLASS_VERSION -->
+		<Class><id>0x87</id></Class><!-- COMMAND_CLASS_INDICATOR -->
 	</CommandClasses>
 	
 	<Configuration>
 		<Parameter>
 			<Index>0</Index>
 			<Type>byte</Type>
-			<Minimum>0</Minimum>
+			<Minimum>1</Minimum>
 			<Maximum>100</Maximum>
+			<Default>10</Default>
 			<Size>1</Size>
 			<Label lang="en">Min. variation of load current</Label>
 			<Help lang="en">Minimum variation in load current before a message is sent. Value in percent (30 => 30%)</Help>
@@ -31,6 +32,8 @@
 		<Parameter>
 			<Index>1</Index>
 			<Type>byte</Type>
+			<Minimum>1</Minimum>
+			<Maximum>255</Maximum>
 			<Default>2</Default>
 			<Size>1</Size>
 			<Label lang="en">No communication light</Label>
@@ -86,6 +89,44 @@
 
 			<Label lang="en">Room color</Label>
 			<Help lang="en">The room color (Corner wheel color) on the GreenWave device</Help>
+		</Parameter>
+
+		<Parameter>
+			<Index>3</Index>
+			<Type>list</Type>
+			<Default>2</Default>
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">Off</Label>
+			</Item>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">Last state</Label>
+			</Item>
+			<Item>
+				<Value>2</Value>
+				<Label lang="en">On</Label>
+			</Item>
+			<Size>1</Size>
+			<Label lang="en">Power-on state</Label>
+			<Help lang="en">Default state after power loss</Help>
+		</Parameter>
+		
+		<Parameter>
+			<Index>4</Index>
+			<Type>list</Type>
+			<Default>0</Default>
+			<Size>1</Size>
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">LED flash off</Label>
+			</Item>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">LED flash on</Label>
+			</Item>
+			<Label lang="en">Network error</Label>
+			<Help lang="en">If the LED should indicate a network error by flashing or not</Help>
 		</Parameter>
 	</Configuration>
 

--- a/bundles/binding/org.openhab.binding.zwave/database/greenwave/ns310.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/greenwave/ns310.xml
@@ -3,26 +3,27 @@
 	<Model>NS310</Model>
 	<Label lang="en">Smart PowerNode</Label>
 	<CommandClasses>
-		<Class><id>0x20</id></Class>
-		<Class><id>0x25</id></Class>
-		<Class><id>0x27</id></Class>
-		<Class><id>0x32</id></Class>
-		<Class><id>0x56</id></Class>
-		<Class><id>0x70</id></Class>
-		<Class><id>0x71</id></Class>
-		<Class><id>0x72</id></Class>
-		<Class><id>0x75</id></Class>
-		<Class><id>0x85</id></Class>
-		<Class><id>0x86</id></Class>
-		<Class><id>0x87</id></Class>
+		<Class><id>0x20</id></Class><!-- COMMAND_CLASS_BASIC -->
+		<Class><id>0x25</id></Class><!-- COMMAND_CLASS_SWITCH_BINARY -->
+		<Class><id>0x27</id></Class><!-- COMMAND_CLASS_SWITCH_ALL -->
+		<Class><id>0x32</id></Class><!-- COMMAND_CLASS_METER_V2 -->
+		<Class><id>0x56</id></Class><!-- COMMAND_CLASS_CRC_16_ENCAP -->
+		<Class><id>0x70</id></Class><!-- COMMAND_CLASS_CONFIGURATION -->
+		<Class><id>0x71</id></Class><!-- COMMAND_CLASS_ALARM -->
+		<Class><id>0x72</id></Class><!-- COMMAND_CLASS_MANUFACTURER_SPECIFIC_V2 -->
+		<Class><id>0x75</id></Class><!-- COMMAND_CLASS_PROTECTION_V2 -->
+		<Class><id>0x85</id></Class><!-- COMMAND_CLASS_ASSOCIATION -->
+		<Class><id>0x86</id></Class><!-- COMMAND_CLASS_VERSION -->
+		<Class><id>0x87</id></Class><!-- COMMAND_CLASS_INDICATOR -->
 	</CommandClasses>
 	
 	<Configuration>
 		<Parameter>
 			<Index>0</Index>
-			<Type>int</Type>
-			<Minimum>0</Minimum>
+			<Type>byte</Type>
+			<Minimum>1</Minimum>
 			<Maximum>100</Maximum>
+			<Default>10</Default>
 			<Size>1</Size>
 			<Label lang="en">Min. variation of load current</Label>
 			<Help lang="en">Minimum variation in load current before a message is sent. Value in percent (30 => 30%)</Help>
@@ -30,10 +31,10 @@
 	
 		<Parameter>
 			<Index>1</Index>
-			<Type>int</Type>
+			<Type>byte</Type>
+			<Minimum>1</Minimum>
+			<Maximum>255</Maximum>
 			<Default>2</Default>
-			<Minimum>-1</Minimum>
-			<Maximum>127</Maximum>
 			<Size>1</Size>
 			<Label lang="en">No communication light</Label>
 			<Help lang="en">After how many minutes the GreenWave device should start flashing if the controller didn't communicate with this device</Help>
@@ -118,11 +119,11 @@
 			<Size>1</Size>
 			<Item>
 				<Value>0</Value>
-				<Label lang="en">LED flash on</Label>
+				<Label lang="en">LED flash off</Label>
 			</Item>
 			<Item>
 				<Value>1</Value>
-				<Label lang="en">LED flash off</Label>
+				<Label lang="en">LED flash on</Label>
 			</Item>
 			<Label lang="en">Network error</Label>
 			<Help lang="en">If the LED should indicate a network error by flashing or not</Help>

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -1261,17 +1261,18 @@
 				<Type>0003</Type>
 				<Id>0003</Id>
 			</Reference>
-			<Model>NP210</Model>
-			<Label lang="en">Smart PowerNode</Label>
-			<ConfigFile>greenwave/np210.xml</ConfigFile>
+			<Model>NP210/NP310</Model>
+			<Label lang="en">Smart PowerNode (6x)</Label>
+			<ConfigFile VersionMax="3">greenwave/np210.xml</ConfigFile>
+			<ConfigFile VersionMin="4">greenwave/np310.xml</ConfigFile>
 		</Product>
 		<Product>
 			<Reference>
 				<Type>0002</Type>
 				<Id>0002</Id>
 			</Reference>
-			<Model>NS210</Model>
-			<Label lang="en">Smart PowerNode</Label>
+			<Model>NS210/NS310</Model>
+			<Label lang="en">Smart PowerNode (single)</Label>
 			<ConfigFile VersionMax="3">greenwave/ns210.xml</ConfigFile>
 			<ConfigFile VersionMin="4">greenwave/ns310.xml</ConfigFile>
 		</Product>


### PR DESCRIPTION
- Create config for NP310
- Copy [improvements done by dominicdesu](https://github.com/openhab/openhab/pull/3603) to all greenwave products 

I have only a NP310, I need your help to test on NP210 and NS210

Fixes/improvement:
- the color wheel display is now correct on my NP310
- I receive new meter value without polling

Bugs:
- The meter received by notifications are not attached to the right socket

Not tested:
- State after power loss
- over-current related stuff