### PR TITLE
Several Z-Wave database fixes

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/vision/zd2102.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/vision/zd2102.xml
@@ -6,6 +6,7 @@
 	<CommandClasses>
 		<Class><id>0x20</id></Class>
 		<Class><id>0x30</id></Class>
+		<Class><id>0x70</id></Class>
 		<Class><id>0x71</id></Class>
 		<Class><id>0x72</id></Class>
 		<Class><id>0x80</id></Class>
@@ -14,23 +15,23 @@
 		<Class><id>0x86</id></Class>
 	</CommandClasses>
 	<Configuration>
-        <Parameter>
-            <Index>1</Index>
-                <Type>list</Type>
-                    <Default>0</Default>
-                    <Size>1</Size>
-                    <Item>
-                        <Value>0</Value>
-                        <Label lang="en">DISABLED</Label>
-                    </Item>
-                    <Item>
-                        <Value>255</Value>
-                        <Label lang="en">ENABLED</Label>
-                    </Item>
-                    <Label lang="en">External switch</Label>
-                    <Help lang="en">Determines if external switch can be used.</Help>
-        </Parameter>
-    </Configuration>
+		<Parameter>
+			<Index>1</Index>
+			<Type>list</Type>
+			<Default>0</Default>
+			<Size>1</Size>
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">DISABLED</Label>
+			</Item>
+			<Item>
+				<Value>255</Value>
+				<Label lang="en">ENABLED</Label>
+			</Item>
+			<Label lang="en">External switch</Label>
+			<Help lang="en">Determines if external switch can be used.</Help>
+		</Parameter>
+  </Configuration>
 	<Associations>
 		<Group>
 			<Index>1</Index>

--- a/bundles/binding/org.openhab.binding.zwave/database/zwaveme/zme_ft11.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/zwaveme/zme_ft11.xml
@@ -66,7 +66,7 @@
 			<Item>
 				<Value>4</Value>
 				<Label lang="en">Switch on/off relay directly (only if Thermostat Mode is in Off state)</Label>
-			<Help lang="en"><![CDATA[]]></Help>
+			</Item>
 		</Parameter>
 		<Parameter>
 			<Index>4</Index>

--- a/bundles/binding/org.openhab.binding.zwave/database/zwaveme/zme_ft13.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/zwaveme/zme_ft13.xml
@@ -67,7 +67,7 @@
 			<Item>
 				<Value>4</Value>
 				<Label lang="en">Switch on/off relay directly (only if Thermostat Mode is in Off state)</Label>
-			<Help lang="en"><![CDATA[]]></Help>
+			</Item>
 		</Parameter>
 		<Parameter>
 			<Index>4</Index>

--- a/bundles/binding/org.openhab.binding.zwave/database/zwaveme/zme_ft14.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/zwaveme/zme_ft14.xml
@@ -67,7 +67,7 @@
 			<Item>
 				<Value>4</Value>
 				<Label lang="en">Switch on/off relay directly (only if Thermostat Mode is in Off state)</Label>
-			<Help lang="en"><![CDATA[]]></Help>
+			</Item>
 		</Parameter>
 		<Parameter>
 			<Index>4</Index>


### PR DESCRIPTION
These two commits fix several issues in the Z-Wave database:

1. Vision Security ZD2012 missed configuration command class
2. Vision Security ZD2012 configuration was badly aligned
3. Several Z-Wave.Me products had non-well-formed XML, at the same time removed empty help strings

Furthermore, I found about half a dozen other products not having the configuration command class, but having configuration items in their XML file. Is this an issue? If so, I'd fix them. I found this using a very basic automated check over all XML files, and I could easily add some further verification (and even automatic cleanup) if interested.