### PR TITLE
Bugfix in frontiersiliconradio: volume update posted from value on bus.

### DIFF
--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioBinding.java
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/src/main/java/org/openhab/binding/frontiersiliconradio/internal/FrontierSiliconRadioBinding.java
@@ -150,10 +150,11 @@ public class FrontierSiliconRadioBinding extends AbstractActiveBinding<FrontierS
                             if (stateChanged(deviceId, property, volume)) {
                                 final int percent = radio.convertVolumeToPercent(volume);
                                 logger.debug("volume changed to " + volume + " (" + percent + "%)");
+                                // based on the item type, either set absolue value or percent value
                                 if (provider.getItemType(itemName) == DimmerItem.class) {
                                     eventPublisher.postUpdate(itemName, new PercentType(percent));
                                 } else {
-                                    eventPublisher.postUpdate(itemName, new DecimalType(percent));
+                                    eventPublisher.postUpdate(itemName, new DecimalType(volume));
                                 }
                             }
                             break;


### PR DESCRIPTION
When the volume changes, updates of decimal typed items did contain the percentage of the volume, not the absolute value. Consequently, the volume was set to an absolute value way too high.