### PR TITLE
Update project name for OH1 ZWave binding

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/.project
+++ b/bundles/binding/org.openhab.binding.zwave/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.binding.zwave</name>
+	<name>org.openhab.binding.zwave1</name>
 	<comment>This is the ZWave binding of the open Home Automation Bus (openHAB)</comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
I would like to propose to change the project name of the OH1 ZWave binding to avoid workspace conflicts with the OH2 binding. 

@kaikreuzer Is there any downside to this? If not, it seems it would avoid problems...
