### PR TITLE
MiOS: Externalize Binding to openHAB 2.0

### DIFF
--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -54,6 +54,7 @@
                                 <artifact><file>src/main/resources/conf/mail.cfg</file><type>cfg</type><classifier>mail</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/marytts.cfg</file><type>cfg</type><classifier>marytts</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/milight.cfg</file><type>cfg</type><classifier>milight</classifier></artifact>
+                                <artifact><file>src/main/resources/conf/mios.cfg</file><type>cfg</type><classifier>mios</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/modbus.cfg</file><type>cfg</type><classifier>modbus</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/mysql.cfg</file><type>cfg</type><classifier>mysql</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/nest.cfg</file><type>cfg</type><classifier>nest</classifier></artifact>

--- a/features/openhab-addons-external/src/main/resources/conf/mios.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/mios.cfg
@@ -1,0 +1,32 @@
+################################ MiOS Binding #######################################
+#
+# MiOS Binding Configuration settings allow for multiple MiOS Units,
+# and take the form:
+#
+#   <unit>.<parameter>=<value>
+#
+# Where:
+# * <unit> = a friendly, alpha-numeric, MiOS Unit name used in Item Definitions.
+# * <parameter> is a named parameter, outlined below.
+#
+# The only required parameter is <host>, all others default.  The <unit> name in the
+# example below defaults to "house", but can be any value.
+#
+# IP Address/DNS Name of the MiOS Unit (required, no default)
+#house.host=
+
+# TCP Port (optional, defaults to 3480)
+#house.port=3480
+
+# Timeout time (ms) used to compute MiOS Unit timeouts (optional, defaults to 60000)
+#house.timeout=60000
+
+# Wait time (ms) for MiOS Unit to bundle changes together (optional, defaults to 0)
+#house.minimumDelay=0
+
+# Number of incremental cycles before a full cycle occurs. (optional, defaults to 0)
+#house.refreshCount=0
+
+# Number of communication errors to force a full cycle load (optional, defaults to 1)
+#house.errorCount=1
+

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -28,6 +28,14 @@
         <configfile finalname="${openhab.conf}/services/mail.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/mail</configfile>
     </feature>
 
+    <feature name="openhab-action-mios" description="MiOS Action" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>openhab-runtime-compat1x</feature>
+        <feature>openhab-binding-mios</feature>
+        <bundle start-level="80">mvn:org.openhab.action/org.openhab.action.mios/${project.version}</bundle>
+        <configfile finalname="${openhab.conf}/services/mios.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/mios</configfile>
+    </feature>
+
     <feature name="openhab-action-pushover" description="Pushover Action" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-runtime-compat1x</feature>
@@ -222,6 +230,13 @@
         <feature>openhab-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.milight/${project.version}</bundle>
         <configfile finalname="${openhab.conf}/services/milight.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/milight</configfile>
+    </feature>
+
+    <feature name="openhab-binding-mios" description="MiOS Binding" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>openhab-runtime-compat1x</feature>
+        <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.mios/${project.version}</bundle>
+        <configfile finalname="${openhab.conf}/services/mios.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/mios</configfile>
     </feature>
 
     <feature name="openhab-binding-modbus" description="Modbus Binding" version="${project.version}">


### PR DESCRIPTION
Expose the MiOS Binding to openHAB 2, add a default configuration file (`mios.cfg`), and extern the `feature.xml` entry.

See:
* https://community.openhab.org/t/mios-binding-1-8-not-working-in-openhab2/6439

Signed-off-by: Mark Clark <mr.guessed@gmail.com>