### PR TITLE
[weather] workaround for #3860

### DIFF
--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/common/LocationConfig.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/common/LocationConfig.java
@@ -23,6 +23,7 @@ public class LocationConfig {
     private String language = "en";
     private Double latitude;
     private Double longitude;
+    private String woeid;
     private Integer updateInterval;
     private String locationId;
     private String name;
@@ -67,6 +68,20 @@ public class LocationConfig {
      */
     public void setLongitude(Double longitude) {
         this.longitude = longitude;
+    }
+
+    /**
+     * Returns the woeid.
+     */
+    public String getWoeid() {
+        return woeid;
+    }
+
+    /**
+     * Sets the woeid.
+     */
+    public void setWoeid(String woeid) {
+        this.woeid = woeid;
     }
 
     /**
@@ -129,8 +144,13 @@ public class LocationConfig {
      * Returns true, if this config is valid.
      */
     public boolean isValid() {
-        return providerName != null && language != null && updateInterval != null && latitude != null
-                && longitude != null && locationId != null;
+        boolean valid = providerName != null && language != null && updateInterval != null && locationId != null;
+        if (providerName == ProviderName.YAHOO) {
+            valid = valid && woeid != null;
+        } else {
+            valid = valid && latitude != null && longitude != null;
+        }
+        return valid;
     }
 
     /**
@@ -140,7 +160,8 @@ public class LocationConfig {
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("providerName", providerName)
                 .append("language", language).append("updateInterval", updateInterval).append("latitude", latitude)
-                .append("longitude", longitude).append("locationId", locationId).append("name", name).toString();
+                .append("longitude", longitude).append("woeid", woeid).append("locationId", locationId)
+                .append("name", name).toString();
     }
 
 }

--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/common/WeatherConfig.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/common/WeatherConfig.java
@@ -37,15 +37,17 @@ import org.slf4j.LoggerFactory;
  * #weather:apikey2.Hamweather=
  *
  * # location configuration, you can specify multiple locations
- * #weather:location.<locationId1>.latitude=
- * #weather:location.<locationId1>.longitude=
+ * #weather:location.<locationId1>.latitude=   (not required for Yahoo provider)
+ * #weather:location.<locationId1>.longitude=  (not required for Yahoo provider)
  * #weather:location.<locationId1>.provider=
+ * #weather:location.<locationId1>.woeid=      (required for Yahoo provider)
  * #weather:location.<locationId1>.language=
  * #weather:location.<locationId1>.updateInterval=
  *
- * #weather:location.<locationId2>.latitude=
- * #weather:location.<locationId2>.longitude=
+ * #weather:location.<locationId2>.latitude=   (not required for Yahoo provider)
+ * #weather:location.<locationId2>.longitude=  (not required for Yahoo provider)
  * #weather:location.<locationId2>.provider=
+ * #weather:location.<locationId2>.woeid=      (required for Yahoo provider)
  * #weather:location.<locationId2>.language=
  * #weather:location.<locationId2>.updateInterval=
  * </pre>
@@ -133,6 +135,8 @@ public class WeatherConfig {
             lc.setLatitude(parseNumber(key, value));
         } else if (StringUtils.equalsIgnoreCase(keyId, "longitude")) {
             lc.setLongitude(parseNumber(key, value));
+        } else if (StringUtils.equalsIgnoreCase(keyId, "woeid")) {
+            lc.setWoeid(value);
         } else if (StringUtils.equalsIgnoreCase(keyId, "language")) {
             lc.setLanguage(value);
         } else if (StringUtils.equalsIgnoreCase(keyId, "name")) {

--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/AbstractWeatherProvider.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/AbstractWeatherProvider.java
@@ -90,9 +90,14 @@ public abstract class AbstractWeatherProvider implements WeatherProvider {
             url = StringUtils.replace(url, "[API_KEY]", providerConfig.getApiKey());
             url = StringUtils.replace(url, "[API_KEY_2]", providerConfig.getApiKey2());
         }
-        url = StringUtils.replace(url, "[LATITUDE]", locationConfig.getLatitude().toString());
-        url = StringUtils.replace(url, "[LONGITUDE]", locationConfig.getLongitude().toString());
+        if (locationConfig.getLatitude() != null) {
+            url = StringUtils.replace(url, "[LATITUDE]", locationConfig.getLatitude().toString());
+        }
+        if (locationConfig.getLongitude() != null) {
+            url = StringUtils.replace(url, "[LONGITUDE]", locationConfig.getLongitude().toString());
+        }
         url = StringUtils.replace(url, "[LANGUAGE]", locationConfig.getLanguage());
+        url = StringUtils.replace(url, "[WOEID]", locationConfig.getWoeid());
         return url;
     }
 

--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/YahooProvider.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/provider/YahooProvider.java
@@ -18,9 +18,8 @@ import org.openhab.binding.weather.internal.parser.JsonWeatherParser;
  * @since 1.6.0
  */
 public class YahooProvider extends AbstractWeatherProvider {
-    // SELECT * FROM weather.forecast WHERE woeid in (SELECT woeid FROM geo.placefinder WHERE
-    // text='[LATITUDE],[LONGITUDE]' and gflags='R')
-    private static final String URL = "http://query.yahooapis.com/v1/public/yql?format=json&q=SELECT%20*%20FROM%20weather.forecast%20WHERE%20u%3D'c'%20AND%20woeid%20in%20(SELECT%20woeid%20FROM%20geo.placefinder%20WHERE%20text%3D'[LATITUDE]%2C[LONGITUDE]'%20and%20gflags%3D'R')";
+    // SELECT * FROM weather.forecast WHERE woeid='[WOEID]'
+    private static final String URL = "http://query.yahooapis.com/v1/public/yql?format=json&q=SELECT%20*%20FROM%20weather.forecast%20WHERE%20u%3D'c'%20AND%20woeid%20%3D%20'[WOEID]'";
 
     public YahooProvider() {
         super(new JsonWeatherParser());

--- a/features/openhab-addons-external/src/main/resources/conf/weather.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/weather.cfg
@@ -9,15 +9,17 @@
 
 # location configuration, you can specify multiple locations
 #location.<locationId1>.name=
-#location.<locationId1>.latitude=
-#location.<locationId1>.longitude=
+#location.<locationId1>.latitude=   (not required for Yahoo provider)
+#location.<locationId1>.longitude=  (not required for Yahoo provider)
+#location.<locationId1>.woeid=      (required for Yahoo provider)
 #location.<locationId1>.provider=
 #location.<locationId1>.language=
 #location.<locationId1>.updateInterval=
 
 #location.<locationId2>.name=
-#location.<locationId2>.latitude=
-#location.<locationId2>.longitude=
+#location.<locationId2>.latitude=   (not required for Yahoo provider)
+#location.<locationId2>.longitude=  (not required for Yahoo provider)
+#location.<locationId2>.woeid=      (required for Yahoo provider)
 #location.<locationId2>.provider=
 #location.<locationId2>.language=
 #location.<locationId2>.updateInterval=


### PR DESCRIPTION
The Yahoo weather provider now requires a `woeid` location config parameter in openhab.cfg, since the [geo.placefinder service was discontinued by Yahoo](https://developer.yahoo.com/forums/#/discussion/7838/tahoo-geo-placefinder-does-not-work%3D%3D%3D%3D) in January, 2016.

@gerrieg, could you comment on this PR?

This PR addresses #3860.