### PR TITLE
[xbmc] Missing cfg file on Install

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -2314,3 +2314,20 @@ tcp:refreshinterval=250
 # Password for the module
 #sallegra:livingroom.password=admin
 #sallegra:bedroom.password=admin
+
+################################# XBMC Binding ######################################
+
+# Hostname / IP address of your XBMC host (required). Example:
+#xbmc:livingRoom.host=192.168.1.6
+
+# Port number for the json rpc service (optional, defaults to 8080). Example:
+#xbmc:livingRoom.rsPort=8080
+
+# Port number for the web socket service (optional, defaults to 9090). Example:
+#xbmc:livingRoom.wsPort=9090
+
+# Username to connect to XBMC. (optional, defaults to none). Example:
+#xbmc:livingRoom.username=xbmc
+
+# Password to connect to XBMC. (optional, defaults to none). Example:
+#xbmc:livingRoom.password=xbmc

--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -79,6 +79,7 @@
                                 <artifact><file>src/main/resources/conf/tinkerforge.cfg</file><type>cfg</type><classifier>tinkerforge</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/urtsi.cfg</file><type>cfg</type><classifier>urtsi</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/weather.cfg</file><type>cfg</type><classifier>weather</classifier></artifact>
+                                <artifact><file>src/main/resources/conf/xbmc.cfg</file><type>cfg</type><classifier>xbmc</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/xmpp.cfg</file><type>cfg</type><classifier>xmpp</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/zwave.cfg</file><type>cfg</type><classifier>zwave</classifier></artifact>
                             </artifacts>

--- a/features/openhab-addons-external/src/main/resources/conf/xbmc.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/xbmc.cfg
@@ -1,0 +1,15 @@
+# Hostname / IP address of your XBMC host (required). Example:
+#livingRoom.host=192.168.1.6
+
+# Port number for the json rpc service (optional, defaults to 8080). Example:
+#livingRoom.rsPort=8080
+
+# Port number for the web socket service (optional, defaults to 9090). Example:
+#livingRoom.wsPort=9090
+
+# Username to connect to XBMC. (optional, defaults to none). Example:
+#livingRoom.username=xbmc
+
+# Password to connect to XBMC. (optional, defaults to none). Example:
+#livingRoom.password=xbmc
+


### PR DESCRIPTION
Closes #3904

[Discussion on forum](https://community.openhab.org/t/xbmc-binding/6747).

Renaming to Kodi is for another day, and so as to not break existing user configurations.

Signed-off-by: John Cocula <john@cocula.com>