### PR TITLE
[myq] externalize binding to OH2

### DIFF
--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -56,6 +56,7 @@
                                 <artifact><file>src/main/resources/conf/milight.cfg</file><type>cfg</type><classifier>milight</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/mios.cfg</file><type>cfg</type><classifier>mios</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/modbus.cfg</file><type>cfg</type><classifier>modbus</classifier></artifact>
+                                <artifact><file>src/main/resources/conf/myq.cfg</file><type>cfg</type><classifier>myq</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/mysql.cfg</file><type>cfg</type><classifier>mysql</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/nest.cfg</file><type>cfg</type><classifier>nest</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/netatmo.cfg</file><type>cfg</type><classifier>netatmo</classifier></artifact>

--- a/features/openhab-addons-external/src/main/resources/conf/myq.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/myq.cfg
@@ -1,0 +1,12 @@
+# Data refresh interval in ms (optional, defaults to 60000)
+#refresh=60000
+
+# Timeout for HTTP requests (optional, defaults to 5000)
+#timeout=5000
+
+# Chamberlain MyQ Username and Password
+#username=
+#password=
+
+# Application ID for the MyQ API (optional, only recommended if existing ID ceases to work)
+#appId=JVM/G9Nwih5BwKgNCjLxiFUQxQijAebyyg8QUHr7JOrP+tuPb8iHfRHKwTmDzHOu

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -247,6 +247,14 @@
         <configfile finalname="${openhab.conf}/services/modbus.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/modbus</configfile>
     </feature>
 
+    <feature name="openhab-binding-myq" description="Chamberlain MyQ Binding" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>openhab-runtime-compat1x</feature>
+        <feature>shk-apache-httpclient</feature>
+        <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.myq/${project.version}</bundle>
+        <configfile finalname="${openhab.conf}/services/myq.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/myq</configfile>
+    </feature>
+
     <feature name="openhab-binding-nest" description="Nest Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-runtime-compat1x</feature>


### PR DESCRIPTION
Based on [report](https://community.openhab.org/t/chamberlain-myq-binding-in-openhab2/6894/2?u=watou) that the Chamberlain MyQ binding is working under recent OH2 build.

Signed-off-by: John Cocula <john@cocula.com>