### PR TITLE
XBMC-Binding - Log.debug if Player is PVR

### DIFF
--- a/bundles/binding/org.openhab.binding.xbmc/src/main/java/org/openhab/binding/xbmc/rpc/XbmcConnector.java
+++ b/bundles/binding/org.openhab.binding.xbmc/src/main/java/org/openhab/binding/xbmc/rpc/XbmcConnector.java
@@ -563,7 +563,7 @@ public class XbmcConnector {
     private void requestPlayerUpdate(int playerId, boolean updatePolledPropertiesOnly) {
         // CRIT: if a PVR recording is played in XBMC the playerId is reported as -1
         if (playerId == -1) {
-            logger.warn(
+            logger.debug(
                     "[{}]: Invalid playerId ({}) - assume this is a PVR recording playback and update playerId -> 1 (video player)",
                     xbmc.getHostname(), playerId);
             playerId = 1;


### PR DESCRIPTION
Changed logging from info to debug, if playerID == -1 (PVR).

Forum Thread: https://community.openhab.org/t/xbmc-binding-logging-info-if-playerid-is-1-pvr/6879