### PR TITLE
Reverted timing back to fix reliability.

### DIFF
--- a/bundles/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/MilightBinding.java
+++ b/bundles/binding/org.openhab.binding.milight/src/main/java/org/openhab/binding/milight/internal/MilightBinding.java
@@ -178,8 +178,7 @@ public class MilightBinding extends AbstractBinding<MilightBindingProvider>imple
                     } else {
                         sendColor(command, bridgeId, bulb);
                     }
-                }
-                if (command instanceof PercentType) {
+                } else if (command instanceof PercentType) {
                     sendPercent(bulb, rgbwSteps, bridgeId, (PercentType) command, BindingType.brightness);
                 }
             }
@@ -219,7 +218,7 @@ public class MilightBinding extends AbstractBinding<MilightBindingProvider>imple
                         command.toString(), repeatCount);
                 if (command.compareTo(oldPercent) > 0) {
                     for (int i = 0; i < repeatCount; i++) {
-                        Thread.sleep(50);
+                        Thread.sleep(100);
                         if (BindingType.brightness.equals(type)) {
                             sendIncrease(bulb, rgbwSteps, bridgeId);
                         } else if (BindingType.colorTemperature.equals(type)) {
@@ -228,7 +227,7 @@ public class MilightBinding extends AbstractBinding<MilightBindingProvider>imple
                     }
                 } else if (command.compareTo(oldPercent) < 0) {
                     for (int i = 0; i < repeatCount; i++) {
-                        Thread.sleep(50);
+                        Thread.sleep(100);
                         if (BindingType.brightness.equals(type)) {
                             sendDecrease(bulb, rgbwSteps, bridgeId);
                         } else if (BindingType.colorTemperature.equals(type)) {
@@ -716,7 +715,7 @@ public class MilightBinding extends AbstractBinding<MilightBindingProvider>imple
             for (int i = 0; i < 10; i++) {
                 sendDecrease(bulb, 27, bridgeId);
                 try {
-                    Thread.sleep(50);
+                    Thread.sleep(100);
                 } catch (InterruptedException e) {
                 }
             }
@@ -739,7 +738,7 @@ public class MilightBinding extends AbstractBinding<MilightBindingProvider>imple
             }
             if (bulb > 5) {
                 sendOn(bulb, bridgeId);
-                Thread.sleep(50);
+                Thread.sleep(100);
                 String messageBytes = "40:" + Integer.toHexString(milightColorNo) + ":55";
                 sendMessage(messageBytes, bridgeId);
             }
@@ -801,7 +800,7 @@ public class MilightBinding extends AbstractBinding<MilightBindingProvider>imple
 
     /**
      * Lookup of the configuration of the named item.
-     * 
+     *
      * @param itemName
      *            The name of the item.
      * @return The configuration, null otherwise.


### PR DESCRIPTION
From my commit 6f8fd06 on May 9, 2015 I had decreased the latency. Unfortunately, over time it's become clear to me with my lights that this decreased the reliability. The lights do need 100 msec, so I have rolled them back to the 100 msec timing to undo what I did then. 