### PR TITLE
[homematic] add add/removeBindingProvider methods

### DIFF
--- a/bundles/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/bus/HomematicBinding.java
+++ b/bundles/binding/org.openhab.binding.homematic/src/main/java/org/openhab/binding/homematic/internal/bus/HomematicBinding.java
@@ -104,6 +104,14 @@ public class HomematicBinding extends AbstractActiveBinding<HomematicBindingProv
         }
     }
 
+    protected void addBindingProvider(HomematicBindingProvider bindingProvider) {
+        super.addBindingProvider(bindingProvider);
+    }
+
+    protected void removeBindingProvider(HomematicBindingProvider bindingProvider) {
+        super.removeBindingProvider(bindingProvider);
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -137,7 +145,7 @@ public class HomematicBinding extends AbstractActiveBinding<HomematicBindingProv
     /**
      * Schedules a job with a short delay to populate changed items to openHAB
      * after startup or an item reload.
-     * 
+     *
      * @see BindingChangedDelayedExecutor
      */
     private void informCommunicator(HomematicBindingProvider hmProvider, String itemName) {


### PR DESCRIPTION
no longer log messages about missing methods; `bundle:list` shows active
```
169 | Active   |  80 | 1.9.0.201601301304    | openHAB homematic Binding
```
Signed-off-by: John Cocula <john@cocula.com>