### PR TITLE
[comfoair] add/removeBindingProvider

### DIFF
--- a/bundles/binding/org.openhab.binding.comfoair/src/main/java/org/openhab/binding/comfoair/internal/ComfoAirBinding.java
+++ b/bundles/binding/org.openhab.binding.comfoair/src/main/java/org/openhab/binding/comfoair/internal/ComfoAirBinding.java
@@ -133,7 +133,7 @@ public class ComfoAirBinding extends AbstractActiveBinding<ComfoAirBindingProvid
     /**
      * send a command and send additional command which are affected by the
      * first command
-     * 
+     *
      * @param command
      */
     private void sendCommand(ComfoAirCommand command) {
@@ -195,6 +195,14 @@ public class ComfoAirBinding extends AbstractActiveBinding<ComfoAirBindingProvid
                 setProperlyConfigured(true);
             }
         }
+    }
+
+    protected void addBindingProvider(ComfoAirBindingProvider bindingProvider) {
+        super.addBindingProvider(bindingProvider);
+    }
+
+    protected void removeBindingProvider(ComfoAirBindingProvider bindingProvider) {
+        super.removeBindingProvider(bindingProvider);
     }
 
     private class AffectedItemsUpdateThread extends Thread {


### PR DESCRIPTION
Note for next PR that this binding depends on openhab-transport-serial.

Signed-off-by: John Cocula <john@cocula.com>