### PR TITLE
[mqtt] Make installable in OH2

### DIFF
--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -56,6 +56,9 @@
                                 <artifact><file>src/main/resources/conf/milight.cfg</file><type>cfg</type><classifier>milight</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/mios.cfg</file><type>cfg</type><classifier>mios</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/modbus.cfg</file><type>cfg</type><classifier>modbus</classifier></artifact>
+                                <artifact><file>src/main/resources/conf/mqtt.cfg</file><type>cfg</type><classifier>mqtt</classifier></artifact>
+                                <artifact><file>src/main/resources/conf/mqtt-eventbus.cfg</file><type>cfg</type><classifier>mqtt-eventbus</classifier></artifact>
+                                <artifact><file>src/main/resources/conf/mqtt-persistence.cfg</file><type>cfg</type><classifier>mqtt-persistence</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/myq.cfg</file><type>cfg</type><classifier>myq</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/mysql.cfg</file><type>cfg</type><classifier>mysql</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/nest.cfg</file><type>cfg</type><classifier>nest</classifier></artifact>

--- a/features/openhab-addons-external/src/main/resources/conf/mqtt-eventbus.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/mqtt-eventbus.cfg
@@ -1,0 +1,20 @@
+# Name of the broker as it is defined in the openhab.cfg. If this property is not available, no event bus MQTT binding will be created.
+#broker=
+
+# When available, all status updates which occur on the openHAB event bus are published to the provided topic. The message content will 
+# be the status. The variable ${item} will be replaced during publishing with the item name for which the state was received.
+#statePublishTopic=
+
+# When available, all commands which occur on the openHAB event bus are published to the provided topic. The message content will be the 
+# command. The variable ${item} will be replaced during publishing with the item name for which the command was received.
+#commandPublishTopic=
+
+# When available, all status updates received on this topic will be posted to the openHAB event bus. The message content is assumed to be 
+# a string representation of the status. The topic should include the variable ${item} to indicate which part of the topic contains the 
+# item name which can be used for posting the received value to the event bus.
+#stateSubscribeTopic=
+
+# When available, all commands received on this topic will be posted to the openHAB event bus. The message content is assumed to be a 
+# string representation of the command. The topic should include the variable ${item} to indicate which part of the topic contains the 
+# item name which can be used for posting the received value to the event bus.
+#commandSubscribeTopic=

--- a/features/openhab-addons-external/src/main/resources/conf/mqtt-persistence.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/mqtt-persistence.cfg
@@ -1,0 +1,8 @@
+# Name of the broker as defined in mqtt.cfg
+#broker=
+
+# The MQTT topic to which the persistence messages should be sent.
+#topic=
+
+# A string representing the persistence message content.
+#message=

--- a/features/openhab-addons-external/src/main/resources/conf/mqtt.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/mqtt.cfg
@@ -1,0 +1,34 @@
+#
+# Define your MQTT broker connections here for use in the MQTT Binding or MQTT
+# Persistence bundles. Replace <broker> with an ID you choose.
+#
+
+# URL to the MQTT broker, e.g. tcp://localhost:1883 or ssl://localhost:8883
+#<broker>.url=tcp://<host>:1883
+
+# Optional. Client id (max 23 chars) to use when connecting to the broker.
+# If not provided a default one is generated.
+#<broker>.clientId=<clientId>
+
+# Optional. User id to authenticate with the broker.
+#<broker>.user=<user>
+
+# Optional. Password to authenticate with the broker.
+#<broker>.pwd=<password>
+
+# Optional. Set the quality of service level for sending messages to this broker.
+# Possible values are 0 (Deliver at most once),1 (Deliver at least once) or 2
+# (Deliver exactly once). Defaults to 0.
+#<broker>.qos=<qos>
+
+# Optional. True or false. Defines if the broker should retain the messages sent to
+# it. Defaults to false.
+#<broker>.retain=<retain>
+
+# Optional. True or false. Defines if messages are published asynchronously or
+# synchronously. Defaults to true.
+#<broker>.async=<async>
+
+# Optional. Defines the last will and testament that is sent when this client goes offline
+# Format: topic:message:qos:retained <br/>
+#<broker>.lwt=<last will definition>

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -247,6 +247,15 @@
         <configfile finalname="${openhab.conf}/services/modbus.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/modbus</configfile>
     </feature>
 
+    <feature name="openhab-binding-mqtt" description="MQTT Binding" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>openhab-runtime-compat1x</feature>
+        <bundle start-level="80">mvn:org.openhab.io/org.openhab.io.transport.mqtt/${project.version}</bundle>
+        <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.mqtt/${project.version}</bundle>
+        <configfile finalname="${openhab.conf}/services/mqtt.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/mqtt</configfile>
+        <configfile finalname="${openhab.conf}/services/mqtt-eventbus.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/mqtt-eventbus</configfile>
+    </feature>
+
     <feature name="openhab-binding-myq" description="Chamberlain MyQ Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-runtime-compat1x</feature>
@@ -412,6 +421,15 @@
         <feature>openhab-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.rrd4j/${project.version}</bundle>
         <configfile finalname="${openhab.conf}/services/rrd4j.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/rrd4j</configfile>
+    </feature>
+
+    <feature name="openhab-persistence-mqtt" description="MQTT Persistence" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>openhab-runtime-compat1x</feature>
+        <bundle start-level="80">mvn:org.openhab.io/org.openhab.io.transport.mqtt/${project.version}</bundle>
+        <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.mqtt/${project.version}</bundle>
+        <configfile finalname="${openhab.conf}/services/mqtt.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/mqtt</configfile>
+        <configfile finalname="${openhab.conf}/services/mqtt-persistence.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/mqtt-persistence</configfile>
     </feature>
 
     <feature name="openhab-persistence-mysql" description="MySQL Persistence" version="${project.version}">


### PR DESCRIPTION
Addresses #3925

@kaikreuzer, this PR fails on feature verification:

> [WARNING] Feature resolution failed for [openhab-persistence-mqtt/1.9.0.SNAPSHOT]
Message: Unable to resolve root: missing requirement [root] osgi.identity; osgi.identity=openhab-persistence-mqtt; type=karaf.feature; version=1.9.0.SNAPSHOT; filter:="(&(osgi.identity=openhab-persistence-mqtt)(type=karaf.feature)(version>=1.9.0.SNAPSHOT))" [caused by: Unable to resolve openhab-persistence-mqtt/1.9.0.SNAPSHOT: missing requirement [openhab-persistence-mqtt/1.9.0.SNAPSHOT] osgi.identity; osgi.identity=org.openhab.persistence.mqtt; type=osgi.bundle; version="[1.9.0.201601301547,1.9.0.201601301547]"; resolution:=mandatory [caused by: Unable to resolve org.openhab.persistence.mqtt/1.9.0.201601301547: missing requirement [org.openhab.persistence.mqtt/1.9.0.201601301547] osgi.wiring.package; filter:="(osgi.wiring.package=org.openhab.io.transport.mqtt)"]]

Is the feature openhab-transport-mqtt available here?  Do I need to delete my .m2 directory or something?

Signed-off-by: John Cocula <john@cocula.com>