### PR TITLE
Fix UI image and chart refresh per #1584

### DIFF
--- a/bundles/ui/org.openhab.ui.webapp/snippets/main.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/main.html
@@ -50,8 +50,8 @@
         search = search + "sitemap=%sitemap%&w=" + hash.substring(2) + "&poll=true";
         url = path + search;
         WA.Request(url, null, -1, true, null); 
-        OH.images.refresh = OH.images.countOnPage;
-        OH.images.countOnPage = 0;
+        OH.imageRefresh = OH.imagesToRefreshOnPage;
+        OH.imagesToRefreshOnPage = 0;
       });
 
       WA.AddEventListener("load", function () {
@@ -106,13 +106,11 @@
       };
 
       // Functions for image refresh
-      OH.images = {
-        refresh: 0,
-        countOnPage: 0
-      };
+      OH.imageRefresh = 0;
+      OH.imagesToRefreshOnPage = 0;
 
       OH.reloadImage = function reloadImage(url, id) {
-        if (OH.images.refresh) {
+        if (OH.imageRefresh) {
           document.getElementById(id).src = url + new Date().getMilliseconds();
         }
       };

--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/ChartRenderer.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/ChartRenderer.java
@@ -61,8 +61,8 @@ public class ChartRenderer extends AbstractWidgetRenderer {
 			String snippet = getSnippet("image");			
 
 			if(chart.getRefresh()>0) {
-				snippet = StringUtils.replace(snippet, "%setrefresh%", "<script type=\"text/javascript\">imagesToRefreshOnPage=1</script>");
-				snippet = StringUtils.replace(snippet, "%refresh%", "id=\"%id%\" onload=\"setTimeout('reloadImage(\\'%url%\\', \\'%id%\\')', " + chart.getRefresh() + ")\"");
+				snippet = StringUtils.replace(snippet, "%setrefresh%", "<script type=\"text/javascript\">OH.imagesToRefreshOnPage=1</script>");
+				snippet = StringUtils.replace(snippet, "%refresh%", "id=\"%id%\" onload=\"setTimeout('OH.reloadImage(\\'%url%\\', \\'%id%\\')', " + chart.getRefresh() + ")\"");
 			} else {
 				snippet = StringUtils.replace(snippet, "%setrefresh%", "");
 				snippet = StringUtils.replace(snippet, "%refresh%", "");

--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/ImageRenderer.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/ImageRenderer.java
@@ -43,8 +43,8 @@ public class ImageRenderer extends AbstractWidgetRenderer {
 				getSnippet("image_link") : getSnippet("image");			
 
 		if(image.getRefresh()>0) {
-			snippet = StringUtils.replace(snippet, "%setrefresh%", "<script type=\"text/javascript\">imagesToRefreshOnPage=1</script>");
-			snippet = StringUtils.replace(snippet, "%refresh%", "id=\"%id%\" onload=\"setTimeout('reloadImage(\\'%url%\\', \\'%id%\\')', " + image.getRefresh() + ")\"");
+			snippet = StringUtils.replace(snippet, "%setrefresh%", "<script type=\"text/javascript\">OH.imagesToRefreshOnPage=1</script>");
+			snippet = StringUtils.replace(snippet, "%refresh%", "id=\"%id%\" onload=\"setTimeout('OH.reloadImage(\\'%url%\\', \\'%id%\\')', " + image.getRefresh() + ")\"");
 		} else {
 			snippet = StringUtils.replace(snippet, "%setrefresh%", "");
 			snippet = StringUtils.replace(snippet, "%refresh%", "");


### PR DESCRIPTION
Users in issue #1584 recommend these changes to fix #1584.  I would like to see image and chart refresh in the 1.8 Classic UI as well, but not before verifying that this fix has no regressions.  Please comment here if you are willing to test this change and report results.  It's possible this won't be the fix.