### PR TITLE
MiOS Action - sendMiosAction() API non-functional under openHAB 2 compat

### DIFF
--- a/bundles/action/org.openhab.action.mios/src/main/java/org/openhab/action/mios/internal/MiosAction.java
+++ b/bundles/action/org.openhab.action.mios/src/main/java/org/openhab/action/mios/internal/MiosAction.java
@@ -8,6 +8,7 @@
  */
 package org.openhab.action.mios.internal;
 
+import java.lang.reflect.Method;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +16,6 @@ import java.util.Map.Entry;
 
 import org.eclipse.xtext.xbase.lib.Pair;
 import org.openhab.binding.mios.MiosActionProvider;
-import org.openhab.core.items.Item;
 import org.openhab.core.scriptengine.action.ActionDoc;
 import org.openhab.core.scriptengine.action.ParamDoc;
 import org.slf4j.Logger;
@@ -36,10 +36,21 @@ public class MiosAction {
      */
     @ActionDoc(text = "Sends an Action invocation to a Device at a MiOS Unit, without parameters.")
     public static boolean sendMiosAction(
-            @ParamDoc(name = "item", text = "The Item used to determine the MiOS Unit Address information for sending the Action call.") Item item,
+            @ParamDoc(name = "item", text = "The Item used to determine the MiOS Unit Address information for sending the Action call.") Object item,
             @ParamDoc(name = "action", text = "The Action string to be remotely invoked on the MiOS Unit.") String actionName) {
 
-        return sendMiosActionInternal(item.getName(), actionName, null);
+        return sendMiosActionInternal(item, actionName, null);
+    }
+
+    /**
+     * Sends an Action invocation to a Device at a MiOS Unit, without parameters.
+     */
+    @ActionDoc(text = "Sends an Action invocation to a Device at a MiOS Unit, without parameters.")
+    public static boolean sendMiosAction(
+            @ParamDoc(name = "item", text = "The Item used to determine the MiOS Unit Address information for sending the Action call.") String itemName,
+            @ParamDoc(name = "action", text = "The Action string to be remotely invoked on the MiOS Unit.") String actionName) {
+
+        return sendMiosActionInternal(itemName, actionName, null);
     }
 
     /**
@@ -47,11 +58,23 @@ public class MiosAction {
      */
     @ActionDoc(text = "Sends an Action invocation to a Device at a MiOS Unit, with parameters.")
     public static boolean sendMiosAction(
-            @ParamDoc(name = "item", text = "The Item used to determine the MiOS Unit Address information for sending the Action call.") Item item,
+            @ParamDoc(name = "item", text = "The Item used to determine the MiOS Unit Address information for sending the Action call.") Object item,
             @ParamDoc(name = "actionName", text = "The Action string to be remotely invoked on the MiOS Unit.") String actionName,
             @ParamDoc(name = "params", text = "The list of Action Parameters.") List<Pair> params) {
 
-        return sendMiosActionInternal(item.getName(), actionName, params);
+        return sendMiosActionInternal(item, actionName, params);
+    }
+
+    /**
+     * Sends an Action invocation to a Device at a MiOS Unit, with parameters.
+     */
+    @ActionDoc(text = "Sends an Action invocation to a Device at a MiOS Unit, with parameters.")
+    public static boolean sendMiosAction(
+            @ParamDoc(name = "item", text = "The Item used to determine the MiOS Unit Address information for sending the Action call.") String itemName,
+            @ParamDoc(name = "actionName", text = "The Action string to be remotely invoked on the MiOS Unit.") String actionName,
+            @ParamDoc(name = "params", text = "The list of Action Parameters.") List<Pair> params) {
+
+        return sendMiosActionInternal(itemName, actionName, params);
     }
 
     /**
@@ -59,9 +82,19 @@ public class MiosAction {
      */
     @ActionDoc(text = "Sends a Scene invocation to a MiOS Unit.")
     public static boolean sendMiosScene(
-            @ParamDoc(name = "item", text = "The Item used to determine the MiOS Unit Address information for sending the Action call.") Item item) {
+            @ParamDoc(name = "item", text = "The Item used to determine the MiOS Unit Address information for sending the Action call.") Object item) {
 
-        return sendMiosSceneInternal(item.getName());
+        return sendMiosSceneInternal(item);
+    }
+
+    /**
+     * Sends a Scene invocation to a MiOS Unit.
+     */
+    @ActionDoc(text = "Sends a Scene invocation to a MiOS Unit.")
+    public static boolean sendMiosScene(
+            @ParamDoc(name = "item", text = "The Item used to determine the MiOS Unit Address information for sending the Action call.") String itemName) {
+
+        return sendMiosSceneInternal(itemName);
     }
 
     private static MiosActionProvider getActionProviderInternal(String itemName) throws Exception {
@@ -78,6 +111,21 @@ public class MiosAction {
         }
 
         return actionProvider;
+    }
+
+    private static String getName(Object item) throws Exception {
+        Method method = item.getClass().getMethod("getName");
+        return (String) method.invoke(item);
+    }
+
+    private static boolean sendMiosActionInternal(Object item, String actionName, List<Pair> params) {
+        try {
+            // Both OH 1 and ESH have a "getName" method.
+            return sendMiosActionInternal(getName(item), actionName, params);
+        } catch (Exception e) {
+            logger.error("An unexpected error occurred using sendMiosAction: {}", e);
+            return false;
+        }
     }
 
     private static boolean sendMiosActionInternal(String itemName, String actionName, List<Pair> params) {
@@ -103,6 +151,16 @@ public class MiosAction {
             return actionProvider.invokeMiosAction(itemName, actionName, paramList);
         } catch (Exception ex) {
             logger.error(ex.getMessage(), ex);
+            return false;
+        }
+    }
+
+    private static boolean sendMiosSceneInternal(Object item) {
+        try {
+            // Both OH 1 and ESH have a "getName" method.
+            return sendMiosSceneInternal(getName(item));
+        } catch (Exception e) {
+            logger.error("An unexpected error occurred using sendMiosScene: {}", e);
             return false;
         }
     }


### PR DESCRIPTION
The MiOS Action binding uses a Rule API with an Item as the first parameter. This breaks under openHAB 2.x/ESH because they won't resolve to the ESH Item equivalent.

This change moves to declaring the first parameter as Object, and then dynamically calling getName() on this parameter, which resolves correctly in both OH 1.x and ESH.

This PR is to fix issue #3929 

Signed-off-by: Mark Clark <mr.guessed@gmail.com>