### PR TITLE
MiOS Binding - Dimming controls not working in openHAB2 #3926

### DIFF
--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/DeviceBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/DeviceBindingConfig.java
@@ -443,7 +443,7 @@ public class DeviceBindingConfig extends MiosBindingConfig {
 
             // If we don't have a transform, look for a special one called
             // "_default".
-            if (result == null || "".equals(result)) {
+            if (result == null || "".equals(result) || key.equals(result)) {
                 result = ts.transform(getCommandTransformParam(), DEFAULT_COMMAND_TRANSFORM);
             }
         } else {


### PR DESCRIPTION
Under openHAB 1.x, the `MAP` Transform returns `""` or `null`, when no transformation is performed.
Under the compat1x layer, the `MAP` Transform returns the input/source value.

This change addresses issue #3926, and ensures the MiOS Binding handles either type of result.

Signed-off-by: Mark Clark <mr.guessed@gmail.com>