### PR TITLE
[ihc] add/removeBindingProvider

### DIFF
--- a/bundles/binding/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/IhcBinding.java
+++ b/bundles/binding/org.openhab.binding.ihc/src/main/java/org/openhab/binding/ihc/internal/IhcBinding.java
@@ -145,7 +145,7 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 
     /**
      * Initialize IHC client and open connection to IHC / ELKO LS controller.
-     * 
+     *
      */
     public void connect() throws IhcExecption {
 
@@ -170,7 +170,7 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 
     /**
      * Disconnect connection to IHC / ELKO LS controller.
-     * 
+     *
      */
     public void disconnect() {
         if (ihc != null) {
@@ -272,6 +272,14 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 
     }
 
+    protected void addBindingProvider(IhcBindingProvider bindingProvider) {
+        super.addBindingProvider(bindingProvider);
+    }
+
+    protected void removeBindingProvider(IhcBindingProvider bindingProvider) {
+        super.removeBindingProvider(bindingProvider);
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -283,7 +291,7 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      */
     @Override
     public void bindingChanged(BindingProvider provider, String itemName) {
@@ -493,9 +501,9 @@ public class IhcBinding extends AbstractActiveBinding<IhcBindingProvider>
     /**
      * Find the first matching {@link IhcBindingProvider} according to
      * <code>itemName</code> and <code>command</code>.
-     * 
+     *
      * @param itemName
-     * 
+     *
      * @return the matching binding provider or <code>null</code> if no binding
      *         provider could be found
      */


### PR DESCRIPTION
Fixes common issue in 1.x addons needed in 2.0, as reported [here](https://community.openhab.org/t/ihc-binding-in-2-beta/6793).

Please try a [test JAR here](https://dl.dropboxusercontent.com/u/4286376/ihc-addBindingProvider/org.openhab.binding.ihc-1.9.0-SNAPSHOT.jar).