### PR TITLE
RFXCOM Add binding support for 10 sensor types

### DIFF
--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComValueSelector.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComValueSelector.java
@@ -13,6 +13,7 @@ import java.io.InvalidClassException;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.ContactItem;
 import org.openhab.core.library.items.DimmerItem;
+import org.openhab.core.library.items.DateTimeItem;
 import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.items.RollershutterItem;
 import org.openhab.core.library.items.StringItem;
@@ -39,7 +40,7 @@ public enum RFXComValueSelector {
     CHIME_SOUND("ChimeSound", NumberItem.class),
     BATTERY_LEVEL("BatteryLevel", NumberItem.class),
     PRESSURE("Pressure", NumberItem.class),
-    FORECAST("Forecast", NumberItem.class),
+    FORECAST("Forecast", StringItem.class),
     RAIN_RATE("RainRate", NumberItem.class),
     RAIN_TOTAL("RainTotal", NumberItem.class),
     WIND_DIRECTION("WindDirection", NumberItem.class),
@@ -52,14 +53,19 @@ public enum RFXComValueSelector {
     TOTAL_USAGE("TotalUsage", NumberItem.class),
     INSTANT_AMPS("InstantAmps", NumberItem.class),
     TOTAL_AMP_HOURS("TotalAmpHours", NumberItem.class),
+    INSTANT_ENERGY("InstantEnergy", NumberItem.class),
     CHANNEL1_AMPS("Channel1Amps", NumberItem.class),
     CHANNEL2_AMPS("Channel2Amps", NumberItem.class),
     CHANNEL3_AMPS("Channel3Amps", NumberItem.class),
+    POWER_FACTOR("PowerFactor", NumberItem.class),
     STATUS("Status", StringItem.class),
+    WEIGHT("Weight", NumberItem.class),
     MOTION("Motion", SwitchItem.class),
     CONTACT("Contact", ContactItem.class),
     VOLTAGE("Voltage", NumberItem.class),
-    SET_POINT("SetPoint", NumberItem.class);
+    SET_POINT("SetPoint", NumberItem.class),
+    DATE_TIME("DateTime", DateTimeItem.class),
+    FREQUENCY("Frequency", NumberItem.class);
 
     private final String text;
     private Class<? extends Item> itemClass;

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessage.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComCurrentEnergyMessage.java
@@ -1,0 +1,266 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.RFXComException;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
+import org.openhab.core.types.UnDefType;
+
+/**
+ * RFXCOM data class for Current and Energy message.
+ *
+ * @author Damien Servant
+ * @since 1.9.0
+ */
+ public class RFXComCurrentEnergyMessage extends RFXComBaseMessage {
+
+    /*
+     * Current packet layout (length 19) - ELEC4 - OWL - CM180i
+	 * packetlength = 0
+	 * packettype = 1
+	 * subtype = 2
+	 * seqnbr = 3
+	 * id1 = 4
+	 * id2 = 5
+	 * count = 6
+	 * ch1h = 7
+	 * ch1l = 8
+	 * ch2h = 9
+	 * ch2l = 10
+	 * ch3h = 11
+	 * ch3l = 12
+	 * total1 = 13
+	 * total2 = 14
+	 * total3 = 15
+	 * total4 = 16
+	 * total5 = 17
+	 * total6 = 18
+	 * battery_level : 19 //bits 3-0
+	 * signal_level : 19 //bits 7-4
+     */
+	 
+    private static float TOTAL_USAGE_CONVERSION_FACTOR = 223.666F;
+
+    public enum SubType {
+        ELEC4(1), //OWL - CM180i
+
+        UNKNOWN(255);
+
+        private final int subType;
+
+        SubType(int subType) {
+            this.subType = subType;
+        }
+
+        SubType(byte subType) {
+            this.subType = subType;
+        }
+
+        public byte toByte() {
+            return (byte) subType;
+        }
+    }
+
+    private final static List<RFXComValueSelector> supportedValueSelectors = Arrays.asList(RFXComValueSelector.RAW_DATA,
+            RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.BATTERY_LEVEL, RFXComValueSelector.CHANNEL1_AMPS,
+            RFXComValueSelector.CHANNEL2_AMPS, RFXComValueSelector.CHANNEL3_AMPS, RFXComValueSelector.TOTAL_USAGE );
+
+    public SubType subType = SubType.ELEC4;
+    public int sensorId = 0;
+    public byte count = 0;
+    public double channel1Amps = 0.0;
+    public double channel2Amps = 0.0;
+    public double channel3Amps = 0.0;
+    public double totalUsage = 0.0;
+    public byte signalLevel = 0;
+    public byte batteryLevel = 0;
+
+    public RFXComCurrentEnergyMessage() {
+        packetType = PacketType.CURRENT_ENERGY;
+    }
+
+    public RFXComCurrentEnergyMessage(byte[] data) {
+        encodeMessage(data);
+    }
+
+    @Override
+    public String toString() {
+        String str = "";
+
+        str += super.toString();
+        str += "\n - Sub type = " + subType;
+        str += "\n - Id = " + sensorId;
+        str += "\n - Count = " + count;
+        str += "\n - Channel1 Amps = " + channel1Amps;
+        str += "\n - Channel2 Amps = " + channel2Amps;
+        str += "\n - Channel3 Amps = " + channel3Amps;
+        str += "\n - Total Usage = " + totalUsage;
+        str += "\n - Signal level = " + signalLevel;
+        str += "\n - Battery level = " + batteryLevel;
+
+        return str;
+    }
+
+    @Override
+    public void encodeMessage(byte[] data) {
+
+        super.encodeMessage(data);
+
+        try {
+            subType = SubType.values()[super.subType];
+        } catch (Exception e) {
+            subType = SubType.UNKNOWN;
+        }
+
+        sensorId = (data[4] & 0xFF) << 8 | (data[5] & 0xFF);
+        count = data[6];
+
+        // Current = Field / 10
+        channel1Amps = ((data[7] & 0xFF) << 8 | (data[8] & 0xFF)) / 10.0;
+        channel2Amps = ((data[9] & 0xFF) << 8 | (data[10] & 0xFF)) / 10.0;
+        channel3Amps = ((data[11] & 0xFF) << 8 | (data[12] & 0xFF)) / 10.0;
+		
+        totalUsage = ((data[13] & 0xFF) << 40 | (data[14] & 0xFF) << 32 | (data[15] & 0xFF) << 24
+                | (data[16] & 0xFF) << 16 | (data[17] & 0xFF) << 8 | (data[18] & 0xFF));
+        totalUsage = totalUsage / TOTAL_USAGE_CONVERSION_FACTOR;
+
+        signalLevel = (byte) ((data[19] & 0xF0) >> 4);
+        batteryLevel = (byte) (data[19] & 0x0F);
+    }
+
+    @Override
+    public byte[] decodeMessage() {
+        byte[] data = new byte[19];
+
+        data[0] = 0x13;
+        data[1] = RFXComBaseMessage.PacketType.CURRENT_ENERGY.toByte();
+        data[2] = subType.toByte();
+        data[3] = seqNbr;
+
+        data[4] = (byte) ((sensorId & 0xFF00) >> 8);
+        data[5] = (byte) (sensorId & 0x00FF);
+        data[6] = count;
+
+        data[7] = (byte) (((int) (channel1Amps * 10.0) >> 8) & 0xFF);
+        data[8] = (byte) ((int) (channel1Amps * 10.0) & 0xFF);
+        data[9] = (byte) (((int) (channel2Amps * 10.0) >> 8) & 0xFF);
+        data[10] = (byte) ((int) (channel2Amps * 10.0) & 0xFF);
+        data[11] = (byte) (((int) (channel3Amps * 10.0) >> 8) & 0xFF);
+        data[12] = (byte) ((int) (channel3Amps * 10.0) & 0xFF);
+
+        long totalUsageLoc = Double.doubleToRawLongBits(totalUsage * TOTAL_USAGE_CONVERSION_FACTOR);
+
+        data[13] = (byte) ((totalUsageLoc >> 40) & 0xFF);
+        data[14] = (byte) ((totalUsageLoc >> 32) & 0xFF);
+        data[15] = (byte) ((totalUsageLoc >> 24) & 0xFF);
+        data[16] = (byte) ((totalUsageLoc >> 16) & 0xFF);
+        data[17] = (byte) ((totalUsageLoc >> 8) & 0xFF);
+        data[18] = (byte) (totalUsageLoc & 0xFF);
+		
+        data[19] = (byte) (((signalLevel & 0x0F) << 4) | (batteryLevel & 0x0F));
+
+        return data;
+    }
+
+    @Override
+    public String generateDeviceId() {
+        return String.valueOf(sensorId);
+    }
+
+    @Override
+    public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
+
+        org.openhab.core.types.State state = UnDefType.UNDEF;
+
+        if (valueSelector.getItemClass() == NumberItem.class) {
+
+            if (valueSelector == RFXComValueSelector.SIGNAL_LEVEL) {
+
+                state = new DecimalType(signalLevel);
+
+            } else if (valueSelector == RFXComValueSelector.BATTERY_LEVEL) {
+
+                state = new DecimalType(batteryLevel);
+
+            } else if (valueSelector == RFXComValueSelector.CHANNEL1_AMPS) {
+
+                state = new DecimalType(channel1Amps);
+
+            } else if (valueSelector == RFXComValueSelector.CHANNEL2_AMPS) {
+
+                state = new DecimalType(channel2Amps);
+
+            } else if (valueSelector == RFXComValueSelector.CHANNEL3_AMPS) {
+
+                state = new DecimalType(channel3Amps);
+
+            } else if (valueSelector == RFXComValueSelector.TOTAL_USAGE) {
+
+                state = new DecimalType(totalUsage);
+
+            } else {
+
+                throw new RFXComException("Can't convert " + valueSelector + " to NumberItem");
+
+            }
+
+        } else if (valueSelector.getItemClass() == StringItem.class) {
+
+            if (valueSelector == RFXComValueSelector.RAW_DATA) {
+
+                state = new StringType(DatatypeConverter.printHexBinary(rawMessage));
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to StringItem");
+            }
+        } else {
+
+            throw new RFXComException("Can't convert " + valueSelector + " to " + valueSelector.getItemClass());
+
+        }
+
+        return state;
+    }
+
+    @Override
+    public void convertFromState(RFXComValueSelector valueSelector, String id, Object subType, Type type,
+            byte seqNumber) throws RFXComException {
+
+        throw new RFXComException("Not supported");
+
+    }
+
+    @Override
+    public Object convertSubType(String subType) throws RFXComException {
+
+        for (SubType s : SubType.values()) {
+            if (s.toString().equals(subType)) {
+                return s;
+            }
+        }
+
+        throw new RFXComException("Unknown sub type " + subType);
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedValueSelectors() throws RFXComException {
+        return supportedValueSelectors;
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessage.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComDateTimeMessage.java
@@ -1,0 +1,262 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.RFXComException;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.items.DateTimeItem;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
+import org.openhab.core.types.UnDefType;
+
+/**
+ * RFXCOM data class for Date and Time message.
+ *
+ * @author Damien Servant
+ * @since 1.9.0
+ */
+public class RFXComDateTimeMessage extends RFXComBaseMessage {
+
+    /*
+     * Current packet layout (length 13) - RTGR328N
+	*     packetlength = 0
+	*     packettype = 1
+	*     subtype = 2
+	*     seqnbr = 3
+	*     id1 = 4
+	*     id2 = 5
+	*     yy = 6
+	*     mm = 7
+	*     dd = 8
+	*     dow = 9
+	*     hr = 10
+	*     Min = 11
+	*     sec = 12
+	*     battery_level = 13  'bits 3-0
+	*     rssi = 13           'bits 7-4
+	*/
+    public enum SubType {
+        UNDEF(0),
+        RTGR328N(1),
+
+        UNKNOWN(255);
+
+        private final int subType;
+
+        SubType(int subType) {
+            this.subType = subType;
+        }
+
+        SubType(byte subType) {
+            this.subType = subType;
+        }
+
+        public byte toByte() {
+            return (byte) subType;
+        }
+    }
+
+    private final static List<RFXComValueSelector> supportedValueSelectors = Arrays.asList(RFXComValueSelector.RAW_DATA,
+            RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.BATTERY_LEVEL, RFXComValueSelector.DATE_TIME);
+
+    public SubType subType = SubType.RTGR328N;
+    public int sensorId = 0;
+    public String dateTime = "yyyy-MM-dd'T'HH:mm:ss";
+    public int yy = 0;
+    public int MM = 0;
+    public int dd = 0;
+    public int dow = 0;
+    public int HH = 0;
+    public int mm = 0;
+    public int ss = 0;
+    
+    public byte signalLevel = 0;
+    public byte batteryLevel = 0;
+
+    public RFXComDateTimeMessage() {
+        packetType = PacketType.DATE_TIME;
+    }
+
+    public RFXComDateTimeMessage(byte[] data) {
+        encodeMessage(data);
+    }
+
+    @Override
+    public String toString() {
+        String str = "";
+
+        str += super.toString();
+        str += "\n - Sub type = " + subType;
+        str += "\n - Id = " + sensorId;
+        str += "\n - Date Time = " + dateTime;
+        str += "\n - Signal level = " + signalLevel;
+        str += "\n - Battery level = " + batteryLevel;
+
+        return str;
+    }
+
+    @Override
+    public void encodeMessage(byte[] data) {
+
+        super.encodeMessage(data);
+
+        try {
+            subType = SubType.values()[super.subType];
+        } catch (Exception e) {
+            subType = SubType.UNKNOWN;
+        }
+    /*
+     * Current packet layout (length 13) - RTGR328N
+	*     packetlength = 0
+	*     packettype = 1
+	*     subtype = 2
+	*     seqnbr = 3
+	*     id1 = 4
+	*     id2 = 5
+	*     yy = 6
+	*     mm = 7
+	*     dd = 8
+	*     dow = 9
+	*     hr = 10
+	*     Min = 11
+	*     sec = 12
+	*     battery_level = 13  'bits 3-0
+	*     rssi = 13           'bits 7-4
+	*/
+        sensorId = (data[4] & 0xFF) << 8 | (data[5] & 0xFF);
+
+		//dateTime = "yyyy-MM-dd'T'HH:mm:ss";
+        yy = (int)(data[6] & 0xFF);
+        MM = (int)(data[7] & 0xFF);
+        dd = (int)(data[8] & 0xFF);
+        dow = (int)(data[9] & 0xFF);
+        HH = (int)(data[10] & 0xFF);
+        mm = (int)(data[11] & 0xFF);
+        ss = (int)(data[12] & 0xFF);
+               
+		dateTime = "20" + yy;
+		dateTime += "-" + MM;
+		dateTime += "-" + dd;
+		dateTime += "T" + HH;
+		dateTime += ":" + mm;
+		dateTime += ":" + ss;
+
+        signalLevel = (byte) ((data[13] & 0xF0) >> 4);
+        batteryLevel = (byte) (data[13] & 0x0F);
+    }
+
+    @Override
+    public byte[] decodeMessage() {
+        byte[] data = new byte[13];
+
+        data[0] = 0x0D;
+        data[1] = RFXComBaseMessage.PacketType.DATE_TIME.toByte();
+        data[2] = subType.toByte();
+        data[3] = seqNbr;
+        data[4] = (byte) ((sensorId & 0xFF00) >> 8);
+        data[5] = (byte) (sensorId & 0x00FF);
+        data[6] = (byte) (yy & 0x00FF);
+        data[7] = (byte) (MM & 0x00FF);
+        data[8] = (byte) (dd & 0x00FF);
+        data[9] = (byte) (dow & 0x00FF);
+        data[10] = (byte) (HH & 0x00FF);
+        data[11] = (byte) (mm & 0x00FF);
+        data[12] = (byte) (ss & 0x00FF);
+        data[13] = (byte) (((signalLevel & 0x0F) << 4) | (batteryLevel & 0x0F));
+
+        return data;
+    }
+
+    @Override
+    public String generateDeviceId() {
+        return String.valueOf(sensorId);
+    }
+
+    @Override
+    public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
+
+        org.openhab.core.types.State state = UnDefType.UNDEF;
+
+        if (valueSelector.getItemClass() == NumberItem.class) {
+
+            if (valueSelector == RFXComValueSelector.SIGNAL_LEVEL) {
+
+                state = new DecimalType(signalLevel);
+
+            } else if (valueSelector == RFXComValueSelector.BATTERY_LEVEL) {
+
+                state = new DecimalType(batteryLevel);
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to NumberItem");
+            }
+
+        } else if (valueSelector.getItemClass() == DateTimeItem.class) {
+
+            if (valueSelector == RFXComValueSelector.DATE_TIME) {
+
+                state = new DateTimeType(dateTime);
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to StringItem");
+            }
+
+        } else if (valueSelector.getItemClass() == StringItem.class) {
+
+            if (valueSelector == RFXComValueSelector.RAW_DATA) {
+
+                state = new StringType(DatatypeConverter.printHexBinary(rawMessage));
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to StringItem");
+            }
+        } else {
+
+            throw new RFXComException("Can't convert " + valueSelector + " to " + valueSelector.getItemClass());
+
+        }
+
+        return state;
+    }
+
+    @Override
+    public void convertFromState(RFXComValueSelector valueSelector, String id, Object subType, Type type,
+            byte seqNumber) throws RFXComException {
+
+        throw new RFXComException("Not supported");
+    }
+
+    @Override
+    public Object convertSubType(String subType) throws RFXComException {
+
+        for (SubType s : SubType.values()) {
+            if (s.toString().equals(subType)) {
+                return s;
+            }
+        }
+
+        throw new RFXComException("Unknown sub type " + subType);
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedValueSelectors() throws RFXComException {
+        return supportedValueSelectors;
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanMessage.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComFanMessage.java
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.RFXComException;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
+import org.openhab.core.types.UnDefType;
+
+/**
+ * RFXCOM data class for Fan message.
+ *
+ * @author Damien Servant
+ * @since 1.9.0
+ *
+ */
+public class RFXComFanMessage extends RFXComBaseMessage {
+
+    /*
+     * Energy packet layout (length 17)
+
+	 * packetlength = 0
+	 * packettype = 1
+	 * subtype = 2
+	 * seqnbr = 3
+	 * id1 = 4
+	 * id2 = 5
+	 * id3 = 6
+	 * cmnd = 7
+     * battery_level = 8 //bits 3-0
+     * signal_level = 8  //bits 7-4
+     */
+
+    public enum SubType {
+        SIEMENSSF01(0),
+        ITHO_CVT_RFT(1),
+        LUCCI_AIR_FAN(2),
+        UNKNOWN(255);
+
+        private final int subType;
+
+        SubType(int subType) {
+            this.subType = subType;
+        }
+
+        SubType(byte subType) {
+            this.subType = subType;
+        }
+
+        public byte toByte() {
+            return (byte) subType;
+        }
+    }
+
+    public enum Commands {
+		TIMER(1),
+		MIN(2),
+		LEARN(3),
+		PLUS(4),
+		CONFIRM(5),
+		LIGHT(6),		
+		
+        UNKNOWN(255);
+
+        private final int command;
+
+        Commands(int command) {
+            this.command = command;
+        }
+
+        Commands(byte command) {
+            this.command = command;
+        }
+
+        public byte toByte() {
+            return (byte) command;
+        }
+    }
+
+    private final static List<RFXComValueSelector> supportedValueSelectors = Arrays.asList(RFXComValueSelector.RAW_DATA,
+            RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.COMMAND);
+
+    public SubType subType = SubType.SIEMENSSF01;
+    public int sensorId = 0;
+    public Commands command = Commands.MIN;
+    public int commandId = 0;
+    public byte signalLevel = 0;
+
+    public RFXComFanMessage() {
+        packetType = PacketType.FAN;
+    }
+
+    public RFXComFanMessage(byte[] data) {
+        encodeMessage(data);
+    }
+
+    @Override
+    public String toString() {
+        String str = "";
+
+        str += super.toString();
+        str += "\n - Sub type = " + subType;
+        str += "\n - Id = " + sensorId;
+        str += "\n - Command = " + command + "(" + commandId + ")";
+        str += "\n - Signal level = " + signalLevel;
+
+        return str;
+    }
+
+    @Override
+    public void encodeMessage(byte[] data) {
+
+        super.encodeMessage(data);
+
+        try {
+            subType = SubType.values()[super.subType];
+        } catch (Exception e) {
+            subType = SubType.UNKNOWN;
+        }
+
+        sensorId = (data[4] & 0xFF) << 16 | (data[5] & 0xFF) << 8 | (data[6] & 0xFF) << 0;
+		
+        commandId = data[7];
+
+        command = Commands.UNKNOWN;
+        for (Commands loCmd : Commands.values()) {
+            if (loCmd.toByte() == commandId) {
+                command = loCmd;
+                break;
+            }
+        }		
+
+        signalLevel = (byte) ((data[8] & 0xF0) >> 4);
+    }
+
+	
+    @Override
+    public byte[] decodeMessage() {
+        byte[] data = new byte[9];
+
+        data[0] = 0x08;
+        data[1] = RFXComBaseMessage.PacketType.FAN.toByte();
+        data[2] = subType.toByte();
+        data[3] = seqNbr;
+		
+        // SENSORID
+        data[4] = (byte) ((sensorId >> 16) & 0xFF);
+        data[5] = (byte) ((sensorId >> 8) & 0xFF);
+        data[6] = (byte) (sensorId & 0xFF);
+		
+        data[7] = (byte) commandId;
+        data[8] = (byte) (((signalLevel & 0x0F) << 4));
+
+        return data;
+    }
+
+    @Override
+    public String generateDeviceId() {
+        return String.valueOf(sensorId);
+    }
+
+    @Override
+    public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
+
+        org.openhab.core.types.State state = UnDefType.UNDEF;
+
+        if (valueSelector.getItemClass() == NumberItem.class) {
+
+            if (valueSelector == RFXComValueSelector.SIGNAL_LEVEL) {
+
+                state = new DecimalType(signalLevel);
+
+            } else if (valueSelector == RFXComValueSelector.COMMAND) {
+
+                state = new DecimalType(commandId);
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to NumberItem");
+            }
+
+        } else if (valueSelector.getItemClass() == StringItem.class) {
+
+            if (valueSelector == RFXComValueSelector.RAW_DATA) {
+
+                state = new StringType(DatatypeConverter.printHexBinary(rawMessage));
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to StringItem");
+            }
+
+        } else {
+
+            throw new RFXComException("Can't convert " + valueSelector + " to " + valueSelector.getItemClass());
+
+        }
+
+        return state;
+    }
+
+    @Override
+    public void convertFromState(RFXComValueSelector valueSelector, String id, Object subType, Type type,
+            byte seqNumber) throws RFXComException {
+
+        this.subType = ((SubType) subType);
+        seqNbr = seqNumber;
+        String[] ids = id.split("\\.");
+        sensorId = Integer.parseInt(ids[0]);
+
+        switch (valueSelector) {
+            case COMMAND:
+                if (type instanceof DecimalType) {
+                    commandId = (int) ((DecimalType) type).intValue();
+                } else {
+                    throw new RFXComException("Can't convert " + type + " to command");
+                }
+                break;
+
+            default:
+                throw new RFXComException("Can't convert " + type + " to " + valueSelector);
+        }
+    }
+
+    @Override
+    public Object convertSubType(String subType) throws RFXComException {
+
+        for (SubType s : SubType.values()) {
+            if (s.toString().equals(subType)) {
+                return s;
+            }
+        }
+
+        throw new RFXComException("Unknown sub type " + subType);
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedValueSelectors() throws RFXComException {
+        return supportedValueSelectors;
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting3Message.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting3Message.java
@@ -1,0 +1,381 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.RFXComException;
+import org.openhab.core.library.items.ContactItem;
+import org.openhab.core.library.items.DimmerItem;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.RollershutterItem;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.items.SwitchItem;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.IncreaseDecreaseType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
+import org.openhab.core.types.UnDefType;
+
+/**
+ * RFXCOM data class for lighting3 message.
+ *
+ * @author Damien Servant
+ * @since 1.9.0
+ */
+public class RFXComLighting3Message extends RFXComBaseMessage {
+
+    /*
+     * Lighting3 packet layout (length 10)
+
+	 * packetlength = 0
+	 * packettype = 1
+	 * subtype = 2
+	 * seqnbr = 3
+	 * system = 4
+	 * channel8_1 = 5
+	 * channel10_9 = 6
+	 * cmnd = 7
+	 * filler = 8  'bits 3-0
+	 * rssi = 8    'bits 7-4
+	*/
+    public enum SubType {
+        KOPPLA(0),
+
+        UNKNOWN(255);
+
+        private final int subType;
+
+        SubType(int subType) {
+            this.subType = subType;
+        }
+
+        SubType(byte subType) {
+            this.subType = subType;
+        }
+
+        public byte toByte() {
+            return (byte) subType;
+        }
+    }
+
+    public enum Commands {
+		BRIGHT(0),
+		DIM(8),
+		ON(16),
+		LEVEL1(17),
+		LEVEL2(18),
+		LEVEL3(19),
+		LEVEL4(20),
+		LEVEL5(21),
+		LEVEL6(22),
+		LEVEL7(23),
+		LEVEL8(24),
+		LEVEL9(25),
+		OFF(26),
+		PROGRAM(27),
+		
+        UNKNOWN(255);
+
+        private final int command;
+
+        Commands(int command) {
+            this.command = command;
+        }
+
+        Commands(byte command) {
+            this.command = command;
+        }
+
+        public byte toByte() {
+            return (byte) command;
+        }
+    }
+
+    private final static List<RFXComValueSelector> supportedValueSelectors = Arrays.asList(RFXComValueSelector.RAW_DATA,
+            RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.COMMAND, RFXComValueSelector.DIMMING_LEVEL);
+
+    public SubType subType = SubType.KOPPLA;
+    public Commands command = Commands.OFF;
+    public int commandId = 0;
+    public byte dimmingLevel = 0;
+    public byte signalLevel = 0;
+
+    public RFXComLighting3Message() {
+        packetType = PacketType.LIGHTING3;
+    }
+
+    public RFXComLighting3Message(byte[] data) {
+        encodeMessage(data);
+    }
+
+    @Override
+    public String toString() {
+        String str = "";
+
+        str += super.toString();
+        str += "\n - Sub type = " + subType;
+        str += "\n - Command = " + command;
+        str += "\n - Dim level = " + dimmingLevel;
+        str += "\n - Signal level = " + signalLevel;
+
+        return str;
+    }
+
+    @Override
+    public void encodeMessage(byte[] data) {
+
+        super.encodeMessage(data);
+
+        try {
+            subType = SubType.values()[super.subType];
+        } catch (Exception e) {
+            subType = SubType.UNKNOWN;
+        }
+
+        dimmingLevel = data[6];
+
+        commandId = data[7];
+
+        command = Commands.UNKNOWN;
+        for (Commands loCmd : Commands.values()) {
+            if (loCmd.toByte() == commandId) {
+                command = loCmd;
+                break;
+            }
+        }		
+        signalLevel = (byte) ((data[11] & 0xF0) >> 4);
+    }
+
+    @Override
+    public byte[] decodeMessage() {
+
+        byte[] data = new byte[9];
+
+        data[0] = 0x09;
+        data[1] = RFXComBaseMessage.PacketType.LIGHTING3.toByte();
+        data[2] = subType.toByte();
+        data[3] = seqNbr;
+        data[4] = 0; //system (unused ?)
+        data[5] = 0; //channel8_1 (unused ?)
+        data[6] = dimmingLevel;
+        data[7] = command.toByte();
+        data[8] = (byte) ((signalLevel & 0x0F) << 4);
+
+        return data;
+    }
+
+    @Override
+    public String generateDeviceId() {
+        return "";
+    }
+
+    /**
+     * Convert a 0-15 scale value to a percent type.
+     * 
+     * @param pt
+     *            percent type to convert
+     * @return converted value 0-15
+     */
+    public static int getDimLevelFromPercentType(PercentType pt) {
+        return pt.toBigDecimal().multiply(BigDecimal.valueOf(15))
+                .divide(PercentType.HUNDRED.toBigDecimal(), 0, BigDecimal.ROUND_UP).intValue();
+    }
+
+    /**
+     * Convert a 0-15 scale value to a percent type.
+     * 
+     * @param pt
+     *            percent type to convert
+     * @return converted value 0-15
+     */
+    public static PercentType getPercentTypeFromDimLevel(int value) {
+        value = Math.min(value, 15);
+
+        return new PercentType(BigDecimal.valueOf(value).multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(15), 0, BigDecimal.ROUND_UP).intValue());
+    }
+
+    @Override
+    public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
+
+        org.openhab.core.types.State state = UnDefType.UNDEF;
+
+        if (valueSelector.getItemClass() == NumberItem.class) {
+
+            if (valueSelector == RFXComValueSelector.SIGNAL_LEVEL) {
+
+                state = new DecimalType(signalLevel);
+
+            } else if (valueSelector == RFXComValueSelector.DIMMING_LEVEL) {
+
+                state = new DecimalType(dimmingLevel);
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to NumberItem");
+            }
+
+        } else if (valueSelector.getItemClass() == DimmerItem.class
+                || valueSelector.getItemClass() == RollershutterItem.class) {
+
+            if (valueSelector == RFXComValueSelector.DIMMING_LEVEL) {
+                state = RFXComLighting3Message.getPercentTypeFromDimLevel(dimmingLevel);
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to DimmerItem/RollershutterItem");
+            }
+
+        } else if (valueSelector.getItemClass() == SwitchItem.class) {
+
+            if (valueSelector == RFXComValueSelector.COMMAND) {
+
+                switch (command) {
+                    case OFF:
+                        state = OnOffType.OFF;
+                        break;
+
+                    case ON:
+                    case BRIGHT:
+                    case DIM:
+                        state = OnOffType.ON;
+                        break;
+
+                    default:
+                        throw new RFXComException("Can't convert " + command + " to SwitchItem");
+                }
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to SwitchItem");
+            }
+
+        } else if (valueSelector.getItemClass() == ContactItem.class) {
+
+            if (valueSelector == RFXComValueSelector.CONTACT) {
+
+                switch (command) {
+                    case OFF:
+                        state = OpenClosedType.CLOSED;
+                        break;
+
+                    case ON:
+					case BRIGHT:
+					case DIM:
+                       state = OpenClosedType.OPEN;
+                        break;
+
+                    default:
+                        throw new RFXComException("Can't convert " + command + " to ContactItem");
+                }
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to ContactItem");
+            }
+
+        } else if (valueSelector.getItemClass() == StringItem.class) {
+
+            if (valueSelector == RFXComValueSelector.RAW_DATA) {
+
+                state = new StringType(DatatypeConverter.printHexBinary(rawMessage));
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to StringItem");
+            }
+
+        } else {
+
+            throw new RFXComException("Can't convert " + valueSelector + " to " + valueSelector.getItemClass());
+
+        }
+
+        return state;
+    }
+
+    @Override
+    public void convertFromState(RFXComValueSelector valueSelector, String id, Object subType, Type type,
+            byte seqNumber) throws RFXComException {
+
+        this.subType = ((SubType) subType);
+        seqNbr = seqNumber;
+
+        switch (valueSelector) {
+            case COMMAND:
+                if (type instanceof OnOffType) {
+                    command = (type == OnOffType.ON ? Commands.ON : Commands.OFF);
+                    dimmingLevel = 0;
+                }
+                else if (type instanceof DecimalType) {
+                    commandId = (int) ((DecimalType) type).intValue();
+                    command = Commands.UNKNOWN;
+                    for (Commands loCmd : Commands.values()) {
+                        if (loCmd.toByte() == commandId) {
+                            command = loCmd;
+                            break;
+                        }
+                    }		                    
+                    dimmingLevel = 0;
+                } else {
+                    throw new RFXComException("Can't convert " + type + " to Command");
+                }
+                break;
+
+            case DIMMING_LEVEL:
+                if (type instanceof OnOffType) {
+                    command = (type == OnOffType.ON ? Commands.ON : Commands.OFF);
+                    dimmingLevel = 0;
+                } else if (type instanceof PercentType) {
+                    command = Commands.DIM;
+                    dimmingLevel = (byte) getDimLevelFromPercentType((PercentType) type);
+
+                    if (dimmingLevel == 0) {
+                        command = Commands.OFF;
+                    }
+
+                } else if (type instanceof IncreaseDecreaseType) {
+                    command = Commands.DIM;
+                    // Evert: I do not know how to get previous object state...
+                    dimmingLevel = 5;
+
+                } else {
+                    throw new RFXComException("Can't convert " + type + " to Command");
+                }
+                break;
+
+            default:
+                throw new RFXComException("Can't convert " + type + " to " + valueSelector);
+
+        }
+    }
+
+    @Override
+    public Object convertSubType(String subType) throws RFXComException {
+
+        for (SubType s : SubType.values()) {
+            if (s.toString().equals(subType)) {
+                return s;
+            }
+        }
+
+        throw new RFXComException("Unknown sub type " + subType);
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedValueSelectors() throws RFXComException {
+        return supportedValueSelectors;
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComPowerMessage.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComPowerMessage.java
@@ -1,0 +1,265 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.RFXComException;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
+import org.openhab.core.types.UnDefType;
+
+/**
+ * RFXCOM data class for power message.
+ *
+ * @author Damien Servant
+ * @since 1.9.0
+ */
+ public class RFXComPowerMessage extends RFXComBaseMessage {
+
+    /*
+     * Power packet layout (length 16) - ELEC5
+     * 
+	 * packetlength = 0
+	 * packettype = 1
+	 * subtype = 2
+	 * seqnbr = 3
+	 * id1 = 4
+	 * id2 = 5
+	 * voltage = 6
+	 * currentH = 7
+	 * currentL = 8
+	 * powerH = 9
+	 * powerL = 10
+	 * energyH = 11
+	 * energyL = 12
+	 * pf = 13
+	 * freq = 14
+     * battery_level = 15 //bits 3-0
+     * signal_level = 15 //bits 7-4
+     */
+
+    public enum SubType {
+        ELEC5(1), // Revolt
+
+        UNKNOWN(255);
+
+        private final int subType;
+
+        SubType(int subType) {
+            this.subType = subType;
+        }
+
+        SubType(byte subType) {
+            this.subType = subType;
+        }
+
+        public byte toByte() {
+            return (byte) subType;
+        }
+    }
+
+    private final static List<RFXComValueSelector> supportedValueSelectors = Arrays.asList(RFXComValueSelector.RAW_DATA,
+			RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.BATTERY_LEVEL, RFXComValueSelector.VOLTAGE,
+			RFXComValueSelector.INSTANT_AMPS, RFXComValueSelector.INSTANT_POWER, RFXComValueSelector.INSTANT_ENERGY,
+			RFXComValueSelector.POWER_FACTOR, RFXComValueSelector.FREQUENCY);
+
+    public SubType subType = SubType.ELEC5;
+    public int sensorId = 0;
+    public byte count = 0;
+    public int voltage = 0;
+    public double instantAmps = 0;
+    public double instantPower = 0;
+    public double instantEnergy = 0;
+    public double powerFactor = 0;
+    public int frequency = 0;
+    public byte signalLevel = 0;
+    public byte batteryLevel = 0;
+
+    public RFXComPowerMessage() {
+        packetType = PacketType.POWER;
+    }
+
+    public RFXComPowerMessage(byte[] data) {
+        encodeMessage(data);
+    }
+
+    @Override
+    public String toString() {
+        String str = "";
+
+        str += super.toString();
+        str += "\n - Sub type = " + subType;
+        str += "\n - Id = " + sensorId;
+        str += "\n - Count = " + count;
+        str += "\n - Voltage = " + voltage;
+        str += "\n - Instant Amps = " + instantAmps;
+        str += "\n - Instant Power = " + instantPower;
+        str += "\n - Instant Energy = " + instantEnergy;
+        str += "\n - Power Factor = " + powerFactor;
+        str += "\n - Frequency = " + frequency;
+        str += "\n - Signal level = " + signalLevel;
+        str += "\n - Battery level = " + batteryLevel;
+
+        return str;
+    }
+
+
+    @Override
+    public void encodeMessage(byte[] data) {
+
+        super.encodeMessage(data);
+
+        try {
+            subType = SubType.values()[super.subType];
+        } catch (Exception e) {
+            subType = SubType.UNKNOWN;
+        }
+
+        sensorId = (data[4] & 0xFF) << 8 | (data[5] & 0xFF);
+        voltage = data[6];
+
+        instantAmps= ((data[7] & 0xFF) << 8 | (data[8] & 0xFF)) / 100.0; 		// Current = Field / 100
+        instantPower = ((data[9] & 0xFF) << 8 | (data[10] & 0xFF)) / 10.0; 		// Watt
+        instantEnergy = ((data[11] & 0xFF) << 8 | (data[12] & 0xFF)) / 100.0; 	// kWh
+        powerFactor = data[13] / 100.0;
+        frequency = data[14];
+
+        signalLevel = (byte) ((data[15] & 0xF0) >> 4);
+        batteryLevel = (byte) (data[15] & 0x0F);
+    }
+
+    @Override
+    public byte[] decodeMessage() {
+        byte[] data = new byte[16];
+
+        data[0] = 0x0F;
+        data[1] = RFXComBaseMessage.PacketType.POWER.toByte();
+        data[2] = subType.toByte();
+        data[3] = seqNbr;
+
+        data[4] = (byte) ((sensorId & 0xFF00) >> 8);
+        data[5] = (byte) (sensorId & 0x00FF);
+
+        data[6] = (byte) voltage;
+        data[7] = (byte) (((int) (instantAmps * 100.0) >> 8) & 0xFF);
+        data[8] = (byte) ((int) (instantAmps * 100.0) & 0xFF);
+        data[9] = (byte) (((int) (instantPower * 10.0) >> 8) & 0xFF);
+        data[10] = (byte) ((int) (instantPower * 10.0) & 0xFF);
+        data[11] = (byte) (((int) (instantEnergy * 100.0) >> 8) & 0xFF);
+        data[12] = (byte) ((int) (instantEnergy * 100.0) & 0xFF);
+        data[13] = (byte) ((int) (powerFactor * 100.0) & 0xFF);
+        data[14] = (byte) frequency;
+
+        data[15] = (byte) (((signalLevel & 0x0F) << 4) | (batteryLevel & 0x0F));
+
+        return data;
+    }
+
+    @Override
+    public String generateDeviceId() {
+        return String.valueOf(sensorId);
+    }
+
+    @Override
+    public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
+
+        org.openhab.core.types.State state = UnDefType.UNDEF;
+
+        if (valueSelector.getItemClass() == NumberItem.class) {
+
+            if (valueSelector == RFXComValueSelector.SIGNAL_LEVEL) {
+
+                state = new DecimalType(signalLevel);
+
+            } else if (valueSelector == RFXComValueSelector.BATTERY_LEVEL) {
+
+                state = new DecimalType(batteryLevel);
+
+            } else if (valueSelector == RFXComValueSelector.VOLTAGE) {
+
+                state = new DecimalType(voltage);
+
+            } else if (valueSelector == RFXComValueSelector.INSTANT_AMPS) {
+
+                state = new DecimalType(instantAmps);
+
+            } else if (valueSelector == RFXComValueSelector.INSTANT_POWER) {
+
+                state = new DecimalType(instantPower);
+
+            } else if (valueSelector == RFXComValueSelector.INSTANT_ENERGY) {
+
+                state = new DecimalType(instantEnergy);
+
+            } else if (valueSelector == RFXComValueSelector.POWER_FACTOR) {
+
+                state = new DecimalType(powerFactor);
+
+            } else if (valueSelector == RFXComValueSelector.FREQUENCY) {
+
+                state = new DecimalType(frequency);
+
+            } else {
+
+                throw new RFXComException("Can't convert " + valueSelector + " to NumberItem");
+
+            }
+
+        } else if (valueSelector.getItemClass() == StringItem.class) {
+
+            if (valueSelector == RFXComValueSelector.RAW_DATA) {
+
+                state = new StringType(DatatypeConverter.printHexBinary(rawMessage));
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to StringItem");
+            }
+        } else {
+
+            throw new RFXComException("Can't convert " + valueSelector + " to " + valueSelector.getItemClass());
+
+        }
+
+        return state;
+    }
+
+    @Override
+    public void convertFromState(RFXComValueSelector valueSelector, String id, Object subType, Type type,
+            byte seqNumber) throws RFXComException {
+
+        throw new RFXComException("Not supported");
+
+    }
+
+    @Override
+    public Object convertSubType(String subType) throws RFXComException {
+
+        for (SubType s : SubType.values()) {
+            if (s.toString().equals(subType)) {
+                return s;
+            }
+        }
+
+        throw new RFXComException("Unknown sub type " + subType);
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedValueSelectors() throws RFXComException {
+        return supportedValueSelectors;
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityBarometricMessage.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureHumidityBarometricMessage.java
@@ -1,0 +1,317 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.RFXComException;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
+import org.openhab.core.types.UnDefType;
+
+/**
+ * RFXCOM data class for temperature, humidity and barometric message.
+ *
+ * @author Damien Servant
+ * @since 1.9.0
+ */
+public class RFXComTemperatureHumidityBarometricMessage extends RFXComBaseMessage {
+	
+    /*
+    * Current packet layout (length 13) - BTHR918, BTHGN129, BTHR918N, BTHR968
+	*     packetlength = 0
+	*     packettype = 1
+	*     subtype = 2
+	*     seqnbr = 3
+	*     id1 = 4
+	*     id2 = 5
+	*     temperatureh = 6    'bits 6-0
+	*     tempsign = 6        'bit 7
+	*     temperaturel = 7
+	*     humidity = 8
+	*     humidity_status = 9
+	*     baroh = 10
+	*     barol = 11
+	*     forecast = 12
+	*     battery_level = 13  'bits 3-0
+	*     signal_level = 13   'bits 7-4
+    */
+	 
+    public enum SubType {
+        UNDEF(0),
+        BTHR918_BTHGN129(1), //BTHR918, BTHGN129
+        BTHR918N_BTHR968(2), //BTHR918N, BTHR968
+        UNKNOWN(255);
+
+        private final int subType;
+
+        SubType(int subType) {
+            this.subType = subType;
+        }
+
+        SubType(byte subType) {
+            this.subType = subType;
+        }
+
+        public byte toByte() {
+            return (byte) subType;
+        }
+    }
+
+    public enum HumidityStatus {
+        NORMAL(0),
+        COMFORT(1),
+        DRY(2),
+        WET(3),
+
+        UNKNOWN(255);
+
+        private final int humidityStatus;
+
+        HumidityStatus(int humidityStatus) {
+            this.humidityStatus = humidityStatus;
+        }
+
+        HumidityStatus(byte humidityStatus) {
+            this.humidityStatus = humidityStatus;
+        }
+
+        public byte toByte() {
+            return (byte) humidityStatus;
+        }
+    }
+
+    public enum ForecastStatus {
+        NO_INFO_AVAILABLE(0),
+        SUNNY(1),
+        PARTLY_CLOUDY(2),
+        CLOUDY(3),
+        RAIN(3),
+
+        UNKNOWN(255);
+
+        private final int forecastStatus;
+
+        ForecastStatus(int forecastStatus) {
+            this.forecastStatus = forecastStatus;
+        }
+
+        ForecastStatus(byte forecastStatus) {
+            this.forecastStatus = forecastStatus;
+        }
+
+        public byte toByte() {
+            return (byte) forecastStatus;
+        }
+    }
+	
+    private final static List<RFXComValueSelector> supportedValueSelectors = Arrays.asList(RFXComValueSelector.RAW_DATA,
+            RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.BATTERY_LEVEL, RFXComValueSelector.TEMPERATURE,
+            RFXComValueSelector.HUMIDITY, RFXComValueSelector.HUMIDITY_STATUS, RFXComValueSelector.PRESSURE, RFXComValueSelector.FORECAST);
+
+    public SubType subType = SubType.BTHR918_BTHGN129;
+    public int sensorId = 0;
+    public double temperature = 0;
+    public byte humidity = 0;
+    public HumidityStatus humidityStatus = HumidityStatus.NORMAL;
+    public double pressure = 0;
+    public ForecastStatus forecastStatus = ForecastStatus.NO_INFO_AVAILABLE;
+    public byte signalLevel = 0;
+    public byte batteryLevel = 0;
+
+    public RFXComTemperatureHumidityBarometricMessage() {
+        packetType = PacketType.TEMPERATURE_HUMIDITY_BAROMETRIC;
+    }
+
+    public RFXComTemperatureHumidityBarometricMessage(byte[] data) {
+        encodeMessage(data);
+    }
+
+    @Override
+    public String toString() {
+        String str = "";
+
+        str += super.toString();
+        str += "\n - Sub type = " + subType;
+        str += "\n - Id = " + sensorId;
+        str += "\n - Temperature = " + temperature;
+        str += "\n - Humidity = " + humidity;
+        str += "\n - Humidity status = " + humidityStatus;
+        str += "\n - Pressure = " + pressure;
+        str += "\n - Forecast = " + forecastStatus;
+        str += "\n - Signal level = " + signalLevel;
+        str += "\n - Battery level = " + batteryLevel;
+
+        return str;
+    }
+
+    @Override
+    public void encodeMessage(byte[] data) {
+
+        super.encodeMessage(data);
+
+        try {
+            subType = SubType.values()[super.subType];
+        } catch (Exception e) {
+            subType = SubType.UNKNOWN;
+        }
+        sensorId = (data[4] & 0xFF) << 8 | (data[5] & 0xFF);
+
+        temperature = (short) ((data[6] & 0x7F) << 8 | (data[7] & 0xFF)) * 0.1;
+        if ((data[6] & 0x80) != 0) {
+            temperature = -temperature;
+        }
+
+        humidity = data[8];
+
+        try {
+            humidityStatus = HumidityStatus.values()[data[9]];
+        } catch (Exception e) {
+            humidityStatus = HumidityStatus.UNKNOWN;
+        }
+
+        pressure = (data[10] & 0xFF) << 8 | (data[11] & 0xFF);
+		
+        try {
+            forecastStatus = ForecastStatus.values()[data[12]];
+        } catch (Exception e) {
+            forecastStatus = ForecastStatus.UNKNOWN;
+        }
+		
+        signalLevel = (byte) ((data[13] & 0xF0) >> 4);
+        batteryLevel = (byte) (data[13] & 0x0F);
+    }
+
+    @Override
+    public byte[] decodeMessage() {
+        byte[] data = new byte[14];
+
+        data[0] = 0x0D;
+        data[1] = RFXComBaseMessage.PacketType.TEMPERATURE_HUMIDITY_BAROMETRIC.toByte();
+        data[2] = subType.toByte();
+        data[3] = seqNbr;
+        data[4] = (byte) ((sensorId & 0xFF00) >> 8);
+        data[5] = (byte) (sensorId & 0x00FF);
+
+        short temp = (short) Math.abs(temperature * 10);
+        data[6] = (byte) ((temp >> 8) & 0xFF);
+        data[7] = (byte) (temp & 0xFF);
+        if (temperature < 0) {
+            data[6] |= 0x80;
+        }
+
+        data[8] = humidity;
+        data[9] = humidityStatus.toByte();
+		
+		temp = (short) (pressure);
+		data[10] = (byte) ((temp >> 8) & 0xFF);
+		data[11] = (byte) (temp  & 0xFF);
+		
+        data[12] = forecastStatus.toByte();
+		
+        data[13] = (byte) (((signalLevel & 0x0F) << 4) | (batteryLevel & 0x0F));
+
+        return data;
+    }
+
+    @Override
+    public String generateDeviceId() {
+        return String.valueOf(sensorId);
+    }
+
+    @Override
+    public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
+
+        org.openhab.core.types.State state = UnDefType.UNDEF;
+
+        if (valueSelector.getItemClass() == NumberItem.class) {
+
+            if (valueSelector == RFXComValueSelector.SIGNAL_LEVEL) {
+
+                state = new DecimalType(signalLevel);
+
+            } else if (valueSelector == RFXComValueSelector.BATTERY_LEVEL) {
+
+                state = new DecimalType(batteryLevel);
+
+            } else if (valueSelector == RFXComValueSelector.TEMPERATURE) {
+
+                state = new DecimalType(temperature);
+
+            } else if (valueSelector == RFXComValueSelector.HUMIDITY) {
+
+                state = new DecimalType(humidity);
+
+            } else if (valueSelector == RFXComValueSelector.PRESSURE) {
+
+                state = new DecimalType(pressure);
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to NumberItem");
+            }
+
+        } else if (valueSelector.getItemClass() == StringItem.class) {
+
+            if (valueSelector == RFXComValueSelector.RAW_DATA) {
+
+                state = new StringType(DatatypeConverter.printHexBinary(rawMessage));
+
+            } else if (valueSelector == RFXComValueSelector.HUMIDITY_STATUS) {
+
+                state = new StringType(humidityStatus.toString());
+
+            } else if (valueSelector == RFXComValueSelector.FORECAST) {
+
+                state = new StringType(forecastStatus.toString());
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to StringItem");
+            }
+        } else {
+
+            throw new RFXComException("Can't convert " + valueSelector + " to " + valueSelector.getItemClass());
+
+        }
+
+        return state;
+    }
+
+    @Override
+    public void convertFromState(RFXComValueSelector valueSelector, String id, Object subType, Type type,
+            byte seqNumber) throws RFXComException {
+
+        throw new RFXComException("Not supported");
+    }
+
+    @Override
+    public Object convertSubType(String subType) throws RFXComException {
+
+        for (SubType s : SubType.values()) {
+            if (s.toString().equals(subType)) {
+                return s;
+            }
+        }
+
+        throw new RFXComException("Unknown sub type " + subType);
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedValueSelectors() throws RFXComException {
+        return supportedValueSelectors;
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureRainMessage.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComTemperatureRainMessage.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.RFXComException;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
+import org.openhab.core.types.UnDefType;
+
+/**
+ * RFXCOM data class for Temperature and Rain message.
+ *
+ * @author Damien Servant
+ * @since 1.9.0
+ */
+public class RFXComTemperatureRainMessage extends RFXComBaseMessage {
+
+    public enum SubType {
+        UNDEF(0),
+        WS1200(1),
+        UNKNOWN(255);
+
+        private final int subType;
+
+        SubType(int subType) {
+            this.subType = subType;
+        }
+
+        SubType(byte subType) {
+            this.subType = subType;
+        }
+
+        public byte toByte() {
+            return (byte) subType;
+        }
+    }
+
+    private final static List<RFXComValueSelector> supportedValueSelectors = Arrays.asList(RFXComValueSelector.RAW_DATA,
+            RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.BATTERY_LEVEL, RFXComValueSelector.TEMPERATURE,
+            RFXComValueSelector.RAIN_TOTAL);
+
+    public SubType subType = SubType.WS1200;
+    public int sensorId = 0;
+    public double temperature = 0.0;
+    public double rainTotal = 0.0;
+    public byte signalLevel = 0;
+    public byte batteryLevel = 0;
+
+    public RFXComTemperatureRainMessage() {
+        packetType = PacketType.TEMPERATURE_RAIN;
+    }
+
+    public RFXComTemperatureRainMessage(byte[] data) {
+        encodeMessage(data);
+    }
+
+    @Override
+    public String toString() {
+        String str = "";
+
+        str += super.toString();
+        str += "\n - Sub type = " + subType;
+        str += "\n - Id = " + sensorId;
+        str += "\n - Temperature = " + temperature;
+        str += "\n - Rain total = " + rainTotal;
+        str += "\n - Signal level = " + signalLevel;
+        str += "\n - Battery level = " + batteryLevel;
+
+        return str;
+    }
+
+    @Override
+    public void encodeMessage(byte[] data) {
+
+        super.encodeMessage(data);
+
+        try {
+            subType = SubType.values()[super.subType];
+        } catch (Exception e) {
+            subType = SubType.UNKNOWN;
+        }
+        sensorId = (data[4] & 0xFF) << 8 | (data[5] & 0xFF);
+
+        temperature = (short) ((data[6] & 0x7F) << 8 | (data[7] & 0xFF)) * 0.1;
+        if ((data[6] & 0x80) != 0) {
+            temperature = -temperature;
+        }
+        rainTotal = (short) ((data[8] & 0xFF) << 8 | (data[9] & 0xFF)) * 0.1;
+        signalLevel = (byte) ((data[10] & 0xF0) >> 4);
+        batteryLevel = (byte) (data[10] & 0x0F);
+    }
+
+    @Override
+    public byte[] decodeMessage() {
+        byte[] data = new byte[10];
+
+        data[0] = 0x0B;
+        data[1] = RFXComBaseMessage.PacketType.TEMPERATURE_RAIN.toByte();
+        data[2] = subType.toByte();
+        data[3] = seqNbr;
+        data[4] = (byte) ((sensorId & 0xFF00) >> 8);
+        data[5] = (byte) (sensorId & 0x00FF);
+
+        short temp = (short) Math.abs(temperature * 10);
+        data[6] = (byte) ((temp >> 8) & 0xFF);
+        data[7] = (byte) (temp & 0xFF);
+        if (temperature < 0) {
+            data[6] |= 0x80;
+        }
+
+        short rainT = (short) Math.abs(rainTotal * 10);
+        data[8] = (byte) ((rainT >> 8) & 0xFF);
+        data[9] = (byte) (rainT & 0xFF);
+        data[10] = (byte) (((signalLevel & 0x0F) << 4) | (batteryLevel & 0x0F));
+
+        return data;
+    }
+
+    @Override
+    public String generateDeviceId() {
+        return String.valueOf(sensorId);
+    }
+
+    @Override
+    public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
+
+        org.openhab.core.types.State state = UnDefType.UNDEF;
+
+        if (valueSelector.getItemClass() == NumberItem.class) {
+
+            if (valueSelector == RFXComValueSelector.SIGNAL_LEVEL) {
+
+                state = new DecimalType(signalLevel);
+
+            } else if (valueSelector == RFXComValueSelector.BATTERY_LEVEL) {
+
+                state = new DecimalType(batteryLevel);
+
+            } else if (valueSelector == RFXComValueSelector.TEMPERATURE) {
+
+                state = new DecimalType(temperature);
+            } else if (valueSelector == RFXComValueSelector.RAIN_TOTAL) {
+
+                state = new DecimalType(rainTotal);
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to NumberItem");
+            }
+
+        } else if (valueSelector.getItemClass() == StringItem.class) {
+
+            if (valueSelector == RFXComValueSelector.RAW_DATA) {
+
+                state = new StringType(DatatypeConverter.printHexBinary(rawMessage));
+
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to StringItem");
+            }
+        } else {
+
+            throw new RFXComException("Can't convert " + valueSelector + " to " + valueSelector.getItemClass());
+
+        }
+
+        return state;
+    }
+
+    @Override
+    public void convertFromState(RFXComValueSelector valueSelector, String id, Object subType, Type type,
+            byte seqNumber) throws RFXComException {
+
+        throw new RFXComException("Not supported");
+    }
+
+    @Override
+    public Object convertSubType(String subType) throws RFXComException {
+
+        for (SubType s : SubType.values()) {
+            if (s.toString().equals(subType)) {
+                return s;
+            }
+        }
+
+        throw new RFXComException("Unknown sub type " + subType);
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedValueSelectors() throws RFXComException {
+        return supportedValueSelectors;
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat2Message.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat2Message.java
@@ -1,0 +1,278 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.RFXComException;
+import org.openhab.core.library.items.ContactItem;
+import org.openhab.core.library.items.SwitchItem;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
+import org.openhab.core.types.UnDefType;
+
+/**
+ * RFXCOM data class for thermostat2 message.
+ *
+ * @author Damien Servant
+ * @since 1.9.0
+ */
+public class RFXComThermostat2Message extends RFXComBaseMessage {
+
+    /*
+     * Thermostat2 packet layout (length 7)
+
+	 * packetlength = 0
+	 * packettype = 1
+	 * subtype = 2
+	 * seqnbr = 3
+	 * unitcode = 4
+	 * cmnd = 5
+	 * filler = 6  'bits 3-0
+	 * rssi = 6    'bits 7-4
+	 */
+
+    public enum SubType {
+        HE105(0),
+        RTS10(1),
+
+        UNKNOWN(255);
+
+        private final int subType;
+
+        SubType(int subType) {
+            this.subType = subType;
+        }
+
+        SubType(byte subType) {
+            this.subType = subType;
+        }
+
+        public byte toByte() {
+            return (byte) subType;
+        }
+    }
+ 
+    public enum Commands {
+        OFF(0),
+        ON(1),
+        PROGRAM(2),	
+		
+        UNKNOWN(255);
+
+        private final int command;
+
+        Commands(int command) {
+            this.command = command;
+        }
+
+        Commands(byte command) {
+            this.command = command;
+        }
+
+        public byte toByte() {
+            return (byte) command;
+        }
+    }
+	
+    private final static List<RFXComValueSelector> supportedValueSelectors = Arrays.asList(RFXComValueSelector.RAW_DATA,
+            RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.TEMPERATURE,
+            RFXComValueSelector.SET_POINT, RFXComValueSelector.CONTACT);
+
+    public SubType subType = SubType.HE105;
+    public byte unitcode = 0;
+    public Commands command = Commands.OFF;
+    public int commandId = 0;
+    public byte signalLevel = 0;
+
+    public RFXComThermostat2Message() {
+        packetType = PacketType.THERMOSTAT2;
+    }
+
+    public RFXComThermostat2Message(byte[] data) {
+        encodeMessage(data);
+    }
+
+    @Override
+    public String toString() {
+        String str = "";
+
+        str += super.toString();
+        str += "\n - Sub type = " + subType;
+        str += "\n - Unit code = " + unitcode;
+        str += "\n - Command = " + command + "(" + commandId + ")";
+        str += "\n - Signal level = " + signalLevel;
+
+        return str;
+    }
+
+    @Override
+    public void encodeMessage(byte[] data) {
+
+        super.encodeMessage(data);
+
+        try {
+            subType = SubType.values()[super.subType];
+        } catch (Exception e) {
+            subType = SubType.UNKNOWN;
+        }
+
+        unitcode = data[4];
+        commandId = data[5];
+
+        command = Commands.UNKNOWN;
+        for (Commands loCmd : Commands.values()) {
+            if (loCmd.toByte() == commandId) {
+                command = loCmd;
+                break;
+            }
+        }		
+
+        signalLevel = (byte) ((data[9] & 0xF0) >> 4);
+    }
+		
+    @Override
+    public byte[] decodeMessage() {
+        byte[] data = new byte[7];
+
+        data[0] = 0x07;
+        data[1] = RFXComBaseMessage.PacketType.THERMOSTAT2.toByte();
+        data[2] = subType.toByte();
+        data[3] = seqNbr;
+        data[4] = unitcode;
+        data[5] = command.toByte();
+        data[6] = (byte) (((signalLevel & 0x0F) << 4));
+
+        return data;
+    }
+
+    @Override
+    public String generateDeviceId() {
+        return String.valueOf(unitcode);
+    }
+
+    @Override
+    public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
+
+        org.openhab.core.types.State state = UnDefType.UNDEF;
+
+        if (valueSelector.getItemClass() == NumberItem.class) {
+
+            if (valueSelector == RFXComValueSelector.SIGNAL_LEVEL) {
+
+                state = new DecimalType(signalLevel);
+
+            } else if (valueSelector == RFXComValueSelector.COMMAND) {
+
+                state = new DecimalType(commandId);
+
+            } else {
+                throw new NumberFormatException("Can't convert " + valueSelector + " to NumberItem");
+            }
+
+        } else if (valueSelector.getItemClass() == StringItem.class) {
+            if (valueSelector == RFXComValueSelector.RAW_DATA) {
+
+                state = new StringType(DatatypeConverter.printHexBinary(rawMessage));
+
+            } else {
+                throw new NumberFormatException("Can't convert " + valueSelector + " to StringItem");
+            }
+
+        } else if (valueSelector.getItemClass() == ContactItem.class) {
+            if (valueSelector == RFXComValueSelector.COMMAND) {
+                switch (command) {
+                    case OFF:
+                        state = OpenClosedType.OPEN;
+                        break;
+                    case ON:
+                        state = OpenClosedType.CLOSED;
+                        break;
+                    default:
+                        break;
+                }
+            }
+			
+        } else if (valueSelector.getItemClass() == SwitchItem.class) {
+
+            if (valueSelector == RFXComValueSelector.COMMAND) {
+                switch (command) {
+                    case OFF:
+                        state = OnOffType.OFF;
+                        break;
+                    case ON:
+                        state = OnOffType.ON;
+                        break;
+                    default:
+                        break;
+                }
+			}
+        }
+
+        else {
+            throw new NumberFormatException("Can't convert " + valueSelector + " to " + valueSelector.getItemClass());
+        }
+
+        return state;
+    }
+
+    @Override
+    public void convertFromState(RFXComValueSelector valueSelector, String id, Object subType, Type type,
+            byte seqNumber) throws RFXComException {
+
+
+        this.subType = ((SubType) subType);
+        seqNbr = seqNumber;
+        String[] ids = id.split("\\.");
+        unitcode = Byte.parseByte(ids[0]);
+
+        switch (valueSelector) {
+            case COMMAND:
+                if (type instanceof OnOffType) {
+                    command = (type == OnOffType.ON ? Commands.ON : Commands.OFF);
+                } else if (type instanceof OpenClosedType) {
+                    command = (type == OpenClosedType.CLOSED ? Commands.ON : Commands.OFF);
+                } else {
+                    throw new RFXComException("Can't convert " + type + " to Command");
+                }
+                break;
+
+            default:
+                throw new RFXComException("Can't convert " + type + " to " + valueSelector);
+        }
+    }
+
+    @Override
+    public Object convertSubType(String subType) throws RFXComException {
+
+        for (SubType s : SubType.values()) {
+            if (s.toString().equals(subType)) {
+                return s;
+            }
+        }
+
+        throw new RFXComException("Unknown sub type " + subType);
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedValueSelectors() throws RFXComException {
+        return supportedValueSelectors;
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComThermostat3Message.java
@@ -1,0 +1,322 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.RFXComException;
+import org.openhab.core.library.items.ContactItem;
+import org.openhab.core.library.items.SwitchItem;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
+import org.openhab.core.types.UnDefType;
+
+/**
+ * RFXCOM data class for Thermostat3 message.
+ *
+ * @author Damien Servant
+ * @since 1.9.0
+ */
+public class RFXComThermostat3Message extends RFXComBaseMessage {
+
+    /*
+     * Thermostat3 packet layout (length 10)
+
+	 *     packetlength = 0
+	 *     packettype = 1
+	 *     subtype = 2
+	 *     seqnbr = 3
+	 *     unitcode1 = 4
+	 *     unitcode2 = 5
+	 *     unitcode3 = 6
+	 *     cmnd = 7
+	 *     filler = 9   'bits 3-0
+	 *     rssi = 9     'bits 7-4
+	 */
+
+    public enum SubType {
+        MERTIK_G6RH4T1(0), //Mertik G6R-H4T1
+        MERTIK_G6RH4TB(1), //Mertik G6R-H4TB
+        MERTIK_G6RH4TD(2), //Mertik G6R-H4TD
+        MERTIK_G6RH4S(3),  //Mertik G6R-H4S
+
+        UNKNOWN(255);
+
+        private final int subType;
+
+        SubType(int subType) {
+            this.subType = subType;
+        }
+
+        SubType(byte subType) {
+            this.subType = subType;
+        }
+
+        public byte toByte() {
+            return (byte) subType;
+        }
+    }
+ 
+    public enum Commands {
+		OFF(0),
+		ON(1),
+		UP(2),
+		DOWN(3),
+		RUNUP_OFF2ND(4),
+		RUNDOWN_ON2ND(5),
+		STOP(6),	
+		
+        UNKNOWN(255);
+
+        private final int command;
+
+        Commands(int command) {
+            this.command = command;
+        }
+
+        Commands(byte command) {
+            this.command = command;
+        }
+
+        public byte toByte() {
+            return (byte) command;
+        }
+    }
+	
+    private final static List<RFXComValueSelector> supportedValueSelectors = Arrays.asList(RFXComValueSelector.RAW_DATA,
+            RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.TEMPERATURE,
+            RFXComValueSelector.SET_POINT, RFXComValueSelector.CONTACT);
+
+    public SubType subType = SubType.MERTIK_G6RH4T1;
+    public int unitcode = 0;
+    public Commands command = Commands.OFF;
+    public int commandId = 0;
+    public byte signalLevel = 0;
+
+    public RFXComThermostat3Message() {
+        packetType = PacketType.THERMOSTAT3;
+    }
+
+    public RFXComThermostat3Message(byte[] data) {
+        encodeMessage(data);
+    }
+
+    @Override
+    public String toString() {
+        String str = "";
+
+        str += super.toString();
+        str += "\n - Sub type = " + subType;
+        str += "\n - Unit code = " + unitcode;
+        str += "\n - Command = " + command + "(" + commandId + ")";
+        str += "\n - Signal level = " + signalLevel;
+
+        return str;
+    }
+
+    @Override
+    public void encodeMessage(byte[] data) {
+
+        super.encodeMessage(data);
+
+        try {
+            subType = SubType.values()[super.subType];
+        } catch (Exception e) {
+            subType = SubType.UNKNOWN;
+        }
+
+        unitcode = (data[4] & 0xFF) << 16 | (data[5] & 0xFF) << 8 | (data[6] & 0xFF) << 0;
+        commandId = data[7];
+
+        command = Commands.UNKNOWN;
+        for (Commands loCmd : Commands.values()) {
+            if (loCmd.toByte() == commandId) {
+                command = loCmd;
+                break;
+            }
+        }		
+
+        signalLevel = (byte) ((data[8] & 0xF0) >> 4);
+    }
+		
+    @Override
+    public byte[] decodeMessage() {
+        byte[] data = new byte[9];
+
+        data[0] = 0x08;
+        data[1] = RFXComBaseMessage.PacketType.THERMOSTAT3.toByte();
+        data[2] = subType.toByte();
+        data[3] = seqNbr;
+        data[4] = (byte) ((unitcode >> 16) & 0xFF);
+        data[5] = (byte) ((unitcode >> 8) & 0xFF);
+        data[6] = (byte) (unitcode & 0xFF);
+        data[7] = command.toByte();
+        data[8] = (byte) (((signalLevel & 0x0F) << 4));
+
+        return data;
+    }
+
+    @Override
+    public String generateDeviceId() {
+        return String.valueOf(unitcode);
+    }
+
+    @Override
+    public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
+
+        org.openhab.core.types.State state = UnDefType.UNDEF;
+
+        if (valueSelector.getItemClass() == NumberItem.class) {
+
+            if (valueSelector == RFXComValueSelector.SIGNAL_LEVEL) {
+
+                state = new DecimalType(signalLevel);
+
+            } else if (valueSelector == RFXComValueSelector.COMMAND) {
+
+                state = new DecimalType(commandId);
+
+            } else {
+                throw new NumberFormatException("Can't convert " + valueSelector + " to NumberItem");
+            }
+
+        } else if (valueSelector.getItemClass() == StringItem.class) {
+            if (valueSelector == RFXComValueSelector.RAW_DATA) {
+
+                state = new StringType(DatatypeConverter.printHexBinary(rawMessage));
+
+            } else {
+                throw new NumberFormatException("Can't convert " + valueSelector + " to StringItem");
+            }
+
+        } else if (valueSelector.getItemClass() == ContactItem.class) {
+            if (valueSelector == RFXComValueSelector.COMMAND) {
+				if (subType == SubType.MERTIK_G6RH4T1) {
+					switch (command) {
+						case OFF:
+						case STOP:
+							state = OpenClosedType.OPEN;
+							break;
+						case ON:
+							state = OpenClosedType.CLOSED;
+							break;
+						default:
+							break;
+					}
+				} else {
+					switch (command) {
+						case OFF:
+						case RUNUP_OFF2ND:
+						case STOP:
+							state = OpenClosedType.CLOSED;
+							break;
+						case ON:
+						case RUNDOWN_ON2ND:
+							state = OpenClosedType.OPEN;
+							break;
+						default:
+							break;
+					}
+				}
+            }
+			
+        } else if (valueSelector.getItemClass() == SwitchItem.class) {
+
+            if (valueSelector == RFXComValueSelector.COMMAND) {
+				if (subType == SubType.MERTIK_G6RH4T1) {
+					switch (command) {
+						case OFF:
+						case STOP:
+							state = OnOffType.OFF;
+							break;
+						case ON:
+							state = OnOffType.ON;
+							break;
+						default:
+							break;
+					}
+				} else {
+					switch (command) {
+						case OFF:
+						case RUNUP_OFF2ND:
+						case STOP:
+							state = OnOffType.OFF;
+							break;
+						case ON:
+						case RUNDOWN_ON2ND:
+							state = OnOffType.ON;
+							break;
+						default:
+							break;
+					}
+				}
+			}
+        }
+
+        else {
+            throw new NumberFormatException("Can't convert " + valueSelector + " to " + valueSelector.getItemClass());
+        }
+
+        return state;
+    }
+
+    @Override
+    public void convertFromState(RFXComValueSelector valueSelector, String id, Object subType, Type type,
+            byte seqNumber) throws RFXComException {
+
+
+        this.subType = ((SubType) subType);
+        seqNbr = seqNumber;
+        String[] ids = id.split("\\.");
+        unitcode = Byte.parseByte(ids[0]);
+
+        switch (valueSelector) {
+            case COMMAND:
+                if (type instanceof OnOffType) {
+                    command = (type == OnOffType.ON ? Commands.ON : Commands.OFF);
+                } else if (type instanceof OpenClosedType) {
+                    command = (type == OpenClosedType.CLOSED ? Commands.ON : Commands.OFF);
+                } else {
+                    throw new RFXComException("Can't convert " + type + " to Command");
+                }
+                break;
+
+            default:
+                throw new RFXComException("Can't convert " + type + " to " + valueSelector);
+        }
+    }
+
+    @Override
+    public Object convertSubType(String subType) throws RFXComException {
+
+        for (SubType s : SubType.values()) {
+            if (s.toString().equals(subType)) {
+                return s;
+            }
+        }
+
+        throw new RFXComException("Unknown sub type " + subType);
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedValueSelectors() throws RFXComException {
+        return supportedValueSelectors;
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComWeightMessage.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComWeightMessage.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.rfxcom.internal.messages;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.openhab.binding.rfxcom.RFXComValueSelector;
+import org.openhab.binding.rfxcom.internal.RFXComException;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
+import org.openhab.core.types.UnDefType;
+
+/**
+ * RFXCOM data class for Weight message.
+ *
+ * @author Damien Servant
+ * @since 1.9.0
+ */
+ public class RFXComWeightMessage extends RFXComBaseMessage {
+
+    /*
+     * Weight packet layout (length 9)
+     * 
+	 *     packetlength = 0
+	 *     packettype = 1
+	 *     subtype = 2
+	 *     seqnbr = 3
+	 *     id1 = 4
+	 *     id2 = 5
+	 *     weighthigh = 6
+	 *     weightlow = 7
+	 *     filler = 8    'bits 3-0
+	 *     rssi = 8      'bits 7-4
+     */
+
+    public enum SubType {
+        BWR101_BWR102(1), // BWR101/BWR102
+        GR101(2), // GR101
+
+        UNKNOWN(255);
+
+        private final int subType;
+
+        SubType(int subType) {
+            this.subType = subType;
+        }
+
+        SubType(byte subType) {
+            this.subType = subType;
+        }
+
+        public byte toByte() {
+            return (byte) subType;
+        }
+    }
+
+    private final static List<RFXComValueSelector> supportedValueSelectors = Arrays.asList(RFXComValueSelector.RAW_DATA,
+            RFXComValueSelector.SIGNAL_LEVEL, RFXComValueSelector.BATTERY_LEVEL, RFXComValueSelector.WEIGHT);
+
+    public SubType subType = SubType.BWR101_BWR102;
+    public int sensorId = 0;
+    public double weight = 0;
+    public byte signalLevel = 0;
+    public byte batteryLevel = 0;
+
+    public RFXComWeightMessage() {
+        packetType = PacketType.WEIGHT;
+    }
+
+    public RFXComWeightMessage(byte[] data) {
+        encodeMessage(data);
+    }
+
+    @Override
+    public String toString() {
+        String str = "";
+
+        str += super.toString();
+        str += "\n - Sub type = " + subType;
+        str += "\n - Id = " + sensorId;
+        str += "\n - Weight = " + weight;
+        str += "\n - Signal level = " + signalLevel;
+        str += "\n - Battery level = " + batteryLevel;
+
+        return str;
+    }
+
+    @Override
+    public void encodeMessage(byte[] data) {
+        super.encodeMessage(data);
+
+        try {
+            subType = SubType.values()[super.subType];
+        } catch (Exception e) {
+            subType = SubType.UNKNOWN;
+        }
+
+        sensorId = (data[4] & 0xFF) << 8 | (data[5] & 0xFF);
+
+        weight = ((data[6] & 0xFF) << 8 | (data[7] & 0xFF)) / 10.0;
+
+        signalLevel = (byte) ((data[8] & 0xF0) >> 4);
+        batteryLevel = (byte) (data[8] & 0x0F);
+    }
+
+    @Override
+    public byte[] decodeMessage() {
+        byte[] data = new byte[9];
+
+        data[0] = 0x08;
+        data[1] = RFXComBaseMessage.PacketType.WEIGHT.toByte();
+        data[2] = subType.toByte();
+        data[3] = seqNbr;
+
+        data[4] = (byte) ((sensorId & 0xFF00) >> 8);
+        data[5] = (byte) (sensorId & 0x00FF);
+
+        data[6] = (byte) (((int) (weight * 10.0) >> 8) & 0xFF);
+        data[7] = (byte) ((int) (weight * 10.0) & 0xFF);
+		
+        data[8] = (byte) (((signalLevel & 0x0F) << 4) | (batteryLevel & 0x0F));
+
+        return data;
+    }
+
+    @Override
+    public String generateDeviceId() {
+        return String.valueOf(sensorId);
+    }
+
+    @Override
+    public State convertToState(RFXComValueSelector valueSelector) throws RFXComException {
+
+        org.openhab.core.types.State state = UnDefType.UNDEF;
+
+        if (valueSelector.getItemClass() == NumberItem.class) {
+
+            if (valueSelector == RFXComValueSelector.SIGNAL_LEVEL) {
+
+                state = new DecimalType(signalLevel);
+
+            } else if (valueSelector == RFXComValueSelector.BATTERY_LEVEL) {
+
+                state = new DecimalType(batteryLevel);
+
+            } else if (valueSelector == RFXComValueSelector.WEIGHT) {
+
+                state = new DecimalType(weight);
+
+            } else {
+
+                throw new RFXComException("Can't convert " + valueSelector + " to NumberItem");
+
+            }
+
+        } else if (valueSelector.getItemClass() == StringItem.class) {
+
+            if (valueSelector == RFXComValueSelector.RAW_DATA) {
+
+                state = new StringType(DatatypeConverter.printHexBinary(rawMessage));
+            } else {
+                throw new RFXComException("Can't convert " + valueSelector + " to StringItem");
+            }
+        } else {
+
+            throw new RFXComException("Can't convert " + valueSelector + " to " + valueSelector.getItemClass());
+
+        }
+
+        return state;
+    }
+
+    @Override
+    public void convertFromState(RFXComValueSelector valueSelector, String id, Object subType, Type type,
+            byte seqNumber) throws RFXComException {
+
+        throw new RFXComException("Not supported");
+
+    }
+
+    @Override
+    public Object convertSubType(String subType) throws RFXComException {
+
+        for (SubType s : SubType.values()) {
+            if (s.toString().equals(subType)) {
+                return s;
+            }
+        }
+
+        throw new RFXComException("Unknown sub type " + subType);
+    }
+
+    @Override
+    public List<RFXComValueSelector> getSupportedValueSelectors() throws RFXComException {
+        return supportedValueSelectors;
+    }
+
+}


### PR DESCRIPTION
Add binding support for the following sensor types :
- CurrentEnergy (tested in #3854)
- DateTime (*)
- Fan (*)
- Lighting3 (*)
- Power (*)
- TemperatureHumidityBarometric (tested in #2557)
- TemperatureRain (tested in #3863)
- Thermostat2 (*)
- Thermostat3 (*)
- Weight (*)

 (*) Untested sensor. Can be buggy ! But at least it gives a first draft for future fix.