### PR TITLE
MiOS Binding - Improve default MAP configuration files

### DIFF
--- a/features/openhab-addons-external/src/main/resources/transform/miosDimmerCommand.map
+++ b/features/openhab-addons-external/src/main/resources/transform/miosDimmerCommand.map
@@ -2,4 +2,6 @@ INCREASE=urn:upnp-org:serviceId:Dimming1/SetLoadLevelTarget(newLoadlevelTarget=?
 DECREASE=urn:upnp-org:serviceId:Dimming1/SetLoadLevelTarget(newLoadlevelTarget=?--)
 OFF=urn:upnp-org:serviceId:Dimming1/SetLoadLevelTarget(newLoadlevelTarget=0)
 ON=urn:upnp-org:serviceId:Dimming1/SetLoadLevelTarget(newLoadlevelTarget=100)
+0=urn:upnp-org:serviceId:Dimming1/SetLoadLevelTarget(newLoadlevelTarget=0)
+100=urn:upnp-org:serviceId:Dimming1/SetLoadLevelTarget(newLoadlevelTarget=100)
 _defaultCommand=urn:upnp-org:serviceId:Dimming1/SetLoadLevelTarget(newLoadlevelTarget=??)

--- a/features/openhab-addons-external/src/main/resources/transform/miosShutterCommand.map
+++ b/features/openhab-addons-external/src/main/resources/transform/miosShutterCommand.map
@@ -1,4 +1,6 @@
 DOWN=urn:upnp-org:serviceId:WindowCovering1/Down()
 UP=urn:upnp-org:serviceId:WindowCovering1/Up()
 STOP=urn:upnp-org:serviceId:WindowCovering1/Stop()
+0=urn:upnp-org:serviceId:Dimming1/SetLoadLevelTarget(newLoadlevelTarget=0)
+100=urn:upnp-org:serviceId:Dimming1/SetLoadLevelTarget(newLoadlevelTarget=100)
 _defaultCommand=urn:upnp-org:serviceId:Dimming1/SetLoadLevelTarget(newLoadlevelTarget=??)

--- a/features/openhab-addons-external/src/main/resources/transform/miosSwitchIn.map
+++ b/features/openhab-addons-external/src/main/resources/transform/miosSwitchIn.map
@@ -1,2 +1,10 @@
 1=ON
 0=OFF
+true=ON
+false=OFF
+TRUE=ON
+FALSE=OFF
+yes=ON
+no=OFF
+YES=ON
+NO=OFF

--- a/features/openhab-addons-external/src/main/resources/transform/miosUPnPRenderingControlVolumeCommand.map
+++ b/features/openhab-addons-external/src/main/resources/transform/miosUPnPRenderingControlVolumeCommand.map
@@ -1,3 +1,4 @@
 INCREASE=urn:upnp-org:serviceId:RenderingControl/SetVolume(DesiredVolume=?++)
 DECREASE=urn:upnp-org:serviceId:RenderingControl/SetVolume(DesiredVolume=?--)
+0=urn:upnp-org:serviceId:RenderingControl/SetVolume(DesiredVolume=0)
 _defaultCommand=urn:upnp-org:serviceId:RenderingControl/SetVolume(DesiredVolume=??)


### PR DESCRIPTION
The MiOS Binding ships with a number of `MAP` files to translate the MiOS supplied value into the equivalent openHAB value.

This change tweaks the defaults, based upon this community discussion with @lolodomo :

* https://community.openhab.org/t/fixed-mios-binding-1-8-not-working-in-openhab2/6439/36

Signed-off-by: Mark Clark <mr.guessed@gmail.com> (github: mrguessed)