### PR TITLE
Fibaro RGBW Controller

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -1710,8 +1710,8 @@
 				<Id>4000</Id>
 			</Reference>
 			<Reference>
-				<Type>3000</Type>
-				<Id>0900</Id>
+				<Type>0900</Type>
+				<Id>3000</Id>
 			</Reference>
 			<Model>FGRGBW</Model>
 			<Label lang="en">Fibaro RGBW Controller</Label>


### PR DESCRIPTION
Type and ID were transposed. Now corrected.