### PR TITLE
Fix openHAB2 compatibility for RFXCOM 1.x binding

### DIFF
--- a/bundles/binding/org.openhab.binding.rfxcom/OSGI-INF/connection.xml
+++ b/bundles/binding/org.openhab.binding.rfxcom/OSGI-INF/connection.xml
@@ -9,7 +9,7 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.openhab.binding.rfxcom.connection">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" immediate="true" name="org.openhab.binding.rfxcom.connection">
    <implementation class="org.openhab.binding.rfxcom.internal.RFXComConnection"/>
    <service>
       <provide interface="org.osgi.service.cm.ManagedService"/>


### PR DESCRIPTION
This patch is a fix for the RFXCOM 1.x binding fixing compatibility with openHAB2.