### PR TITLE
Avoid unchanged items to be logged on every modbus poll

### DIFF
--- a/bundles/binding/org.openhab.binding.fritzboxtr064/pom.xml
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.8.0-SNAPSHOT</version>
+		<version>1.9.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/TACmiBinding.java
+++ b/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/TACmiBinding.java
@@ -9,10 +9,13 @@
 package org.openhab.binding.tacmi.internal;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.Map;
 
@@ -161,7 +164,7 @@ public class TACmiBinding extends AbstractActiveBinding<TACmiBindingProvider> {
         logger.trace("execute() method is called!");
         try {
             clientSocket.setBroadcast(true);
-            clientSocket.setSoTimeout(10000);
+            clientSocket.setSoTimeout(30000);
             byte[] receiveData = new byte[14];
             DatagramPacket receivePacket = new DatagramPacket(receiveData, receiveData.length);
             clientSocket.receive(receivePacket);
@@ -205,8 +208,13 @@ public class TACmiBinding extends AbstractActiveBinding<TACmiBindingProvider> {
                 }
             }
 
+        } catch (SocketTimeoutException e) {
+            logger.info("Receive Timeout on CoE socket");
         } catch (Exception e) {
+            StringWriter w = new StringWriter();
+            e.printStackTrace(new PrintWriter(w));
             logger.warn("Error in execute: {}, Message: {}", e.getClass().getName(), e.getMessage());
+            logger.warn(w.toString());
         }
         logger.trace("TACmi execute() finished");
 

--- a/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/message/AnalogValue.java
+++ b/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/message/AnalogValue.java
@@ -9,6 +9,8 @@
 package org.openhab.binding.tacmi.internal.message;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 
 import org.openhab.binding.tacmi.internal.TACmiMeasureType;
 import org.slf4j.Logger;
@@ -23,6 +25,7 @@ import org.slf4j.LoggerFactory;
 public final class AnalogValue {
     public BigDecimal value;
     public TACmiMeasureType measureType;
+    public final MathContext mc = new MathContext(6, RoundingMode.HALF_UP);
 
     private static Logger logger = LoggerFactory.getLogger(AnalogValue.class);
 
@@ -34,6 +37,7 @@ public final class AnalogValue {
             case 1:
                 measureType = TACmiMeasureType.TEMPERATURE;
                 value = new BigDecimal(rawValue / 10.0);
+                value = value.round(mc);
                 break;
             case 4:
                 measureType = TACmiMeasureType.SECONDS;

--- a/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/message/Message.java
+++ b/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/message/Message.java
@@ -41,7 +41,7 @@ public abstract class Message {
 
     /**
      * Initialize from the bytes of a received message
-     * 
+     *
      * @param raw
      */
     public Message(byte[] raw) {
@@ -53,7 +53,7 @@ public abstract class Message {
 
     /**
      * Used to create a new message with the specified CAN node and POD number
-     * 
+     *
      * @param canNode
      * @param podNumber
      */
@@ -72,7 +72,7 @@ public abstract class Message {
 
     /**
      * Get the byte array. This can be sent to the CMI.
-     * 
+     *
      * @return raw
      */
     public byte[] getRaw() {
@@ -81,7 +81,7 @@ public abstract class Message {
 
     /**
      * Set the CAN node number for this message
-     * 
+     *
      * @param canNode
      */
     public void setCanNode(int canNode) {
@@ -90,7 +90,7 @@ public abstract class Message {
 
     /**
      * Set the POD number for this message
-     * 
+     *
      * @param podNumber
      */
     public void setPodNumber(int podNumber) {
@@ -101,7 +101,7 @@ public abstract class Message {
      * Set the value at th specified index within the message and the defined
      * measure type. The measure type is only used in analog messages. Digital
      * messages always use 0 for the measure types.
-     * 
+     *
      * @param idx
      * @param value
      * @param measureType
@@ -114,17 +114,17 @@ public abstract class Message {
     /**
      * Get the value at the specified index within the message. The value will
      * be converted from thr signed short to an unsigned int.
-     * 
+     *
      * @param idx
      * @return
      */
     public int getValue(int idx) {
-        return (buffer.getShort(idx * 2 + 2)) & 0xffff;
+        return (buffer.getShort(idx * 2 + 2));
     }
 
     /**
      * Get the measure type for the specified index within the message.
-     * 
+     *
      * @param idx
      * @return
      */


### PR DESCRIPTION
Items were reported changed on every modbus poll although their value didn't change. This caused extensive logging in events.log and heavy cpu load. 

I got the changes from there:
https://groups.google.com/forum/#!topic/openhab/wKLAf5SbMCY

they worked, have it running for several days now