### PR TITLE
Plex binding: add play/pause property

### DIFF
--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnector.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnector.java
@@ -218,6 +218,8 @@ public class PlexConnector extends Thread {
             cmd = getVolumeCommand(config, command);
         } else if (property.equals(PlexProperty.PROGRESS.getName())) {
             cmd = getProgressCommand(config, command);
+        } else if (property.equals(PlexProperty.PLAYPAUSE.getName())) {
+            cmd = getPlayPauseCommand(config);
         } else {
             cmd = config.getProperty();
         }
@@ -306,6 +308,19 @@ public class PlexConnector extends Thread {
         }
 
         return url;
+    }
+
+    private String getPlayPauseCommand(PlexBindingConfig config) {
+        String command = PlexProperty.PAUSE.getName();
+
+        PlexSession session = getSessionByMachineId(config.getMachineIdentifier());
+        if (session != null) {
+            if (PlexPlayerState.Paused.equals(session.getState())) {
+                command = PlexProperty.PLAY.getName();
+            }
+        }
+
+        return command;
     }
 
     private WebSocketUpgradeHandler createWebSocketHandler() {

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexProperty.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexProperty.java
@@ -24,6 +24,7 @@ public enum PlexProperty {
     END_TIME("playback/endTime"),
     PLAY("playback/play"),
     PAUSE("playback/pause"),
+    PLAYPAUSE("playback/playpause"),
     STOP("playback/stop"),
     STEP_BACK("playback/stepBack"),
     STEP_FORWARD("playback/stepForward"),


### PR DESCRIPTION
This adds a play/pause property the to Plex binding to easily use one item for toggling between play and pause, depending on the state of the player. 