### PR TITLE
Plex binding: add cover image

### DIFF
--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnectionProperties.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnectionProperties.java
@@ -95,4 +95,8 @@ public class PlexConnectionProperties {
         this.password = password;
     }
 
+    public boolean hasToken() {
+        return !StringUtils.isBlank(getToken());
+    }
+
 }

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexProperty.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexProperty.java
@@ -22,6 +22,7 @@ public enum PlexProperty {
     TITLE("title"),
     PROGRESS("playback/progress"),
     END_TIME("playback/endTime"),
+    COVER("playback/cover"),
     PLAY("playback/play"),
     PAUSE("playback/pause"),
     STOP("playback/stop"),

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexSession.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexSession.java
@@ -57,6 +57,9 @@ public class PlexSession {
     @ItemMapping(property = END_TIME, type = DateTimeType.class)
     private Date endTime = null;
 
+    @ItemMapping(property = COVER, type = StringType.class)
+    private String cover = "";
+
     private int duration = 0;
 
     private int viewOffset = 0;
@@ -123,6 +126,14 @@ public class PlexSession {
 
     public Date getEndTime() {
         return endTime;
+    }
+
+    public String getCover() {
+        return cover;
+    }
+
+    public void setCover(String cover) {
+        this.cover = cover;
     }
 
     public int getDuration() {

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/AbstractSessionItem.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/AbstractSessionItem.java
@@ -40,6 +40,12 @@ public abstract class AbstractSessionItem {
     @XmlAttribute
     private String duration;
 
+    @XmlAttribute
+    private String grandparentThumb;
+
+    @XmlAttribute
+    private String thumb;
+
     @XmlElement(name = "Player")
     private Player player;
 
@@ -89,6 +95,22 @@ public abstract class AbstractSessionItem {
 
     public void setDuration(String duration) {
         this.duration = duration;
+    }
+
+    public String getGrandparentThumb() {
+        return grandparentThumb;
+    }
+
+    public void setGrandparentThumb(String grandparentThumb) {
+        this.grandparentThumb = grandparentThumb;
+    }
+
+    public String getThumb() {
+        return thumb;
+    }
+
+    public void setThumb(String thumb) {
+        this.thumb = thumb;
     }
 
     public Player getPlayer() {


### PR DESCRIPTION
This adds a property to the Plex binding that holds the cover image for the media that is currently playing. 