### PR TITLE
[ecobee] Change seconds back to minutes for PIN expiration

### DIFF
--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
@@ -1129,7 +1129,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider>
             logger.info("#########################################################################################");
             logger.info("# Ecobee-Integration: U S E R   I N T E R A C T I O N   R E Q U I R E D !!");
             logger.info("# 1. Login to www.ecobee.com using your '{}' account", this.userid);
-            logger.info("# 2. Enter the PIN '{}' in My Apps within the next {} seconds.", response.getEcobeePin(),
+            logger.info("# 2. Enter the PIN '{}' in My Apps within the next {} minutes.", response.getEcobeePin(),
                     response.getExpiresIn());
             logger.info("# NOTE: Any API attempts will fail in the meantime.");
             logger.info("#########################################################################################");

--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/messages/AuthorizeResponse.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/messages/AuthorizeResponse.java
@@ -65,7 +65,7 @@ public class AuthorizeResponse extends AbstractAuthResponse {
     }
 
     /**
-     * @return the number of seconds until the PIN expires. Ensure you inform the user how much time they have.
+     * @return the number of minutes until the PIN expires. Ensure you inform the user how much time they have.
      */
     @JsonProperty("expires_in")
     public Integer getExpiresIn() {


### PR DESCRIPTION
Ecobee reverted this December API change. Fixes #4006

Signed-off-by: John Cocula <john@cocula.com>