### PR TITLE
[davis] correct barometric pressure conversion

### DIFF
--- a/bundles/binding/org.openhab.binding.davis/src/main/java/org/openhab/binding/davis/datatypes/DataTypeBarometer.java
+++ b/bundles/binding/org.openhab.binding.davis/src/main/java/org/openhab/binding/davis/datatypes/DataTypeBarometer.java
@@ -28,7 +28,7 @@ public class DataTypeBarometer implements DavisDataType {
      */
     public State convertToState(byte[] data, DavisValueType valueType) {
         short value = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN).getShort(valueType.getDataOffset());
-        return new DecimalType(value * 33.86);
+        return new DecimalType(value * 0.0338638);
     }
 
 }


### PR DESCRIPTION
Treat incoming barometric pressure unit as one thousandth of an inch of mercury, not a full inch of mercury (inHg), so that the resulting decimal value is a hectopascal (hPa), not a pascal (Pa).

To address [this discussion](https://community.openhab.org/t/davis-vantage-binding/5251).