### PR TITLE
Fixed javascript that was breaking the colorpicker.

### DIFF
--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/ColorpickerRenderer.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/ColorpickerRenderer.java
@@ -64,6 +64,7 @@ public class ColorpickerRenderer extends AbstractWidgetRenderer {
 		}
 		String label = getLabel(cp);
 		String purelabel = label;
+		purelabel = purelabel.replaceAll("\\\"", "\\\\'");
 		if(label.contains("<span>")) {
 			purelabel = purelabel.substring(0, label.indexOf("<span>"));
 		}


### PR DESCRIPTION
This fixes #3864.

The code was rendering this javascript, which breaks the statement because of the double quotes in the span:
        &lt;img src="/images/colorwheel.png" width="29" height="29" border="0" 
    			onclick="OH.colorpicker.setup('Fireplace', 'Chris' Fireplace &lt;span style="">Err</span>', '#ffffff')" />

This patch changes the double quotes to escaped single quotes.
