### PR TITLE
RFXCOM clear buffer after reset command

### DIFF
--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/RFXComConnection.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/RFXComConnection.java
@@ -120,6 +120,8 @@ public class RFXComConnection implements ManagedService {
         // controller does not response immediately after reset,
         // so wait a while
         Thread.sleep(1000);
+        // Clear received buffers
+        connector.clearReceiveBuffer();        
 
         if (setMode != null) {
             try {

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComConnectorInterface.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComConnectorInterface.java
@@ -56,5 +56,9 @@ public interface RFXComConnectorInterface {
      *            Event listener instance to remove.
      */
     public void removeEventListener(RFXComEventListener listener);
-
+    
+    /**
+     * Ignore any data in the receive buffer
+     */
+    public void clearReceiveBuffer();
 }

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComSerialConnector.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComSerialConnector.java
@@ -49,6 +49,7 @@ public class RFXComSerialConnector implements RFXComConnectorInterface {
     OutputStream out = null;
     SerialPort serialPort = null;
     Thread readerThread = null;
+    private boolean ignoreReceiveBuffer = false;
 
     public RFXComSerialConnector() {
     }
@@ -172,6 +173,14 @@ public class RFXComSerialConnector implements RFXComConnectorInterface {
                     byte[] logData = Arrays.copyOf(tmpData, len);
                     logger.trace("Received data (len={}): {}", len, DatatypeConverter.printHexBinary(logData));
 
+                    if (ignoreReceiveBuffer) {
+                        // any data already in receive buffer will be ignored
+                        ignoreReceiveBuffer = false;
+                        start_found = false;
+                        if (index > 0) {
+                            logger.trace("Ignoring data in receive Buffer : " + index + " bytes");
+                        }
+                    }
                     for (int i = 0; i < len; i++) {
 
                         if (index > dataBufferMaxLen) {
@@ -242,5 +251,10 @@ public class RFXComSerialConnector implements RFXComConnectorInterface {
 
     public boolean isConnected() {
         return out != null;
+    }
+    
+    @Override
+    public void clearReceiveBuffer() {
+        ignoreReceiveBuffer = true;
     }
 }

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComTcpConnector.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/connector/RFXComTcpConnector.java
@@ -56,4 +56,9 @@ public class RFXComTcpConnector implements RFXComConnectorInterface {
         logger.error("removeEventListener not implemented");
     }
 
+    @Override
+    public void clearReceiveBuffer() {
+        logger.error("clearReceiveBuffer not implemented");
+    }
+
 }


### PR DESCRIPTION
This PR clear receiving buffer after sending reset command.
This solves problem when openhab was restated and messages are received from rfxcom during startup and the protocol becomes unsynchronized .
As the RFXCOM protocol does not have any king of start byte, any byte that is != 0 is considered as start.

Now everytime it starts in correct state.