### PR TITLE
OneWireBinding: PushButton Feature

### DIFF
--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OneWireBinding.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OneWireBinding.java
@@ -18,6 +18,7 @@ import org.openhab.binding.onewire.internal.connection.OneWireConnection;
 import org.openhab.binding.onewire.internal.control.AbstractOneWireControlBindingConfig;
 import org.openhab.binding.onewire.internal.deviceproperties.AbstractOneWireDevicePropertyBindingConfig;
 import org.openhab.binding.onewire.internal.deviceproperties.AbstractOneWireDevicePropertyWritableBindingConfig;
+import org.openhab.binding.onewire.internal.deviceproperties.InterfaceOneWireDevicePropertyExecutableBindingConfig;
 import org.openhab.binding.onewire.internal.listener.InterfaceOneWireDevicePropertyWantsUpdateListener;
 import org.openhab.binding.onewire.internal.listener.OneWireDevicePropertyWantsUpdateEvent;
 import org.openhab.binding.onewire.internal.scheduler.OneWireUpdateScheduler;
@@ -37,301 +38,334 @@ import org.slf4j.LoggerFactory;
 /**
  * The 1-wire items / device properties are scheduled and refreshed via
  * OneWireUpdateScheduler for this binding
- *
+ * 
  * @author Thomas.Eichstaedt-Engelen, Dennis Riegelbauer
  * @since 0.6.0
  */
 public class OneWireBinding extends AbstractBinding<OneWireBindingProvider>
-        implements ManagedService, InterfaceOneWireDevicePropertyWantsUpdateListener {
+		implements ManagedService,
+		InterfaceOneWireDevicePropertyWantsUpdateListener {
 
-    private static final Logger logger = LoggerFactory.getLogger(OneWireBinding.class);
+	private static final Logger logger = LoggerFactory
+			.getLogger(OneWireBinding.class);
 
-    /**
-     * Scheduler for items
-     */
-    private OneWireUpdateScheduler ivOneWireReaderScheduler;
+	/**
+	 * Scheduler for items
+	 */
+	private OneWireUpdateScheduler ivOneWireReaderScheduler;
 
-    /**
-     * Use the Cache to post only changed values for items to the eventPublisher
-     */
-    private boolean ivPostOnlyChangedValues = true;
+	/**
+	 * Use the Cache to post only changed values for items to the eventPublisher
+	 */
+	private boolean ivPostOnlyChangedValues = true;
 
-    /**
-     * Cache of item values
-     */
-    private Hashtable<String, State> ivCacheItemStates = new Hashtable<String, State>();
+	/**
+	 * Cache of item values
+	 */
+	private Hashtable<String, State> ivCacheItemStates = new Hashtable<String, State>();
 
-    public OneWireBinding() {
-        super();
-        ivOneWireReaderScheduler = new OneWireUpdateScheduler(this);
-    }
+	public OneWireBinding() {
+		super();
+		ivOneWireReaderScheduler = new OneWireUpdateScheduler(this);
+	}
 
-    @Override
-    public void activate() {
-        super.activate();
-        ivOneWireReaderScheduler.start();
-    }
+	@Override
+	public void activate() {
+		super.activate();
+		ivOneWireReaderScheduler.start();
+	}
 
-    @Override
-    public void deactivate() {
-        super.deactivate();
-        ivOneWireReaderScheduler.stop();
-    }
+	@Override
+	public void deactivate() {
+		super.deactivate();
+		ivOneWireReaderScheduler.stop();
+	}
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.osgi.service.cm.ManagedService#updated(java.util.Dictionary)
-     */
-    @Override
-    public void updated(Dictionary<String, ?> pvConfig) throws ConfigurationException {
-        if (pvConfig != null) {
-            // Basic config
-            String lvPostOnlyChangedValues = (String) pvConfig.get("post_only_changed_values");
-            if (StringUtils.isNotBlank(lvPostOnlyChangedValues)) {
-                ivPostOnlyChangedValues = Boolean.getBoolean(lvPostOnlyChangedValues);
-            }
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.osgi.service.cm.ManagedService#updated(java.util.Dictionary)
+	 */
+	public void updated(Dictionary<String, ?> pvConfig)
+			throws ConfigurationException {
+		if (pvConfig != null) {
+			// Basic config
+			String lvPostOnlyChangedValues = (String) pvConfig
+					.get("post_only_changed_values");
+			if (StringUtils.isNotBlank(lvPostOnlyChangedValues)) {
+				ivPostOnlyChangedValues = Boolean
+						.getBoolean(lvPostOnlyChangedValues);
+			}
 
-            // Connection config
-            OneWireConnection.updated(pvConfig);
-        }
+			// Connection config
+			OneWireConnection.updated(pvConfig);
+		}
 
-        for (OneWireBindingProvider lvProvider : providers) {
-            scheduleAllBindings(lvProvider);
-        }
+		for (OneWireBindingProvider lvProvider : providers) {
+			scheduleAllBindings(lvProvider);
+		}
 
-    }
+	}
 
-    @Override
-    protected void internalReceiveCommand(String pvItemName, Command pvCommand) {
-        logger.debug("received command " + pvCommand.toString() + " for item " + pvItemName);
+	@Override
+	protected void internalReceiveCommand(String pvItemName, Command pvCommand) {
+		logger.debug("received command " + pvCommand.toString() + " for item "
+				+ pvItemName);
 
-        OneWireBindingConfig lvBindigConfig = getBindingConfig(pvItemName);
+		OneWireBindingConfig lvBindigConfig = getBindingConfig(pvItemName);
 
-        if (lvBindigConfig instanceof AbstractOneWireDevicePropertyWritableBindingConfig) {
-            AbstractOneWireDevicePropertyWritableBindingConfig lvWritableBindingConfig = (AbstractOneWireDevicePropertyWritableBindingConfig) lvBindigConfig;
+		if (lvBindigConfig instanceof InterfaceOneWireDevicePropertyExecutableBindingConfig) {
+			// This Binding implements a special behavior
+			logger.debug("call execute for item " + pvItemName);
+			
+			((InterfaceOneWireDevicePropertyExecutableBindingConfig) lvBindigConfig)
+					.execute(pvCommand);
+		} else if (lvBindigConfig instanceof AbstractOneWireDevicePropertyWritableBindingConfig) {
+			logger.debug("write to item " + pvItemName);
+			
+			AbstractOneWireDevicePropertyWritableBindingConfig lvWritableBindingConfig = (AbstractOneWireDevicePropertyWritableBindingConfig) lvBindigConfig;
 
-            String lvStringValue = lvWritableBindingConfig.convertTypeToString(pvCommand);
+			// Standard Write Operation
+			String lvStringValue = lvWritableBindingConfig
+					.convertTypeToString(pvCommand);
 
-            OneWireConnection.writeToOneWire(lvWritableBindingConfig.getDevicePropertyPath(), lvStringValue);
-        } else if (lvBindigConfig instanceof AbstractOneWireControlBindingConfig) {
-            AbstractOneWireControlBindingConfig lvControlBindingConfig = (AbstractOneWireControlBindingConfig) lvBindigConfig;
-            lvControlBindingConfig.executeControl(this, pvCommand);
-        } else {
-            logger.debug("received command " + pvCommand.toString() + " for item " + pvItemName
-                    + " which is not writable or executable");
-        }
-    }
+			OneWireConnection.writeToOneWire(
+					lvWritableBindingConfig.getDevicePropertyPath(),
+					lvStringValue);
+		} else if (lvBindigConfig instanceof AbstractOneWireControlBindingConfig) {
+			logger.debug("call executeControl for item " + pvItemName);
+			
+			AbstractOneWireControlBindingConfig lvControlBindingConfig = (AbstractOneWireControlBindingConfig) lvBindigConfig;
+			lvControlBindingConfig.executeControl(this, pvCommand);
+		} else {
+			logger.debug("received command " + pvCommand.toString()
+					+ " for item " + pvItemName
+					+ " which is not writable or executable");
+		}
+	}
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * org.openhab.core.binding.AbstractBinding#allBindingsChanged(org.openhab
-     * .core.binding.BindingProvider)
-     */
-    @Override
-    public void allBindingsChanged(BindingProvider pvProvider) {
-        scheduleAllBindings(pvProvider);
-    }
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.openhab.core.binding.AbstractBinding#allBindingsChanged(org.openhab
+	 * .core.binding.BindingProvider)
+	 */
+	public void allBindingsChanged(BindingProvider pvProvider) {
+		scheduleAllBindings(pvProvider);
+	}
 
-    /**
-     * schedule All Bindings to get updated
-     * 
-     * @param pvProvider
-     */
-    private void scheduleAllBindings(BindingProvider pvProvider) {
-        if (OneWireConnection.isConnectionEstablished()) {
-            logger.debug("scheduleAllBindings");
+	/**
+	 * schedule All Bindings to get updated
+	 * 
+	 * @param pvProvider
+	 */
+	private void scheduleAllBindings(BindingProvider pvProvider) {
+		if (OneWireConnection.isConnectionEstablished()) {
+			logger.debug("scheduleAllBindings");
 
-            if (pvProvider instanceof OneWireBindingProvider) {
-                OneWireBindingProvider lvBindingProvider = (OneWireBindingProvider) pvProvider;
-                ivOneWireReaderScheduler.clear();
-                ivCacheItemStates.clear();
+			if (pvProvider instanceof OneWireBindingProvider) {
+				OneWireBindingProvider lvBindingProvider = (OneWireBindingProvider) pvProvider;
+				ivOneWireReaderScheduler.clear();
+				ivCacheItemStates.clear();
 
-                Map<String, BindingConfig> lvBindigConfigs = lvBindingProvider.getBindingConfigs();
-                for (String lvItemName : lvBindigConfigs.keySet()) {
-                    logger.debug("scheduleAllBindings, now item {}.", lvItemName);
-                    OneWireBindingConfig lvOneWireBindingConfig = (OneWireBindingConfig) lvBindigConfigs
-                            .get(lvItemName);
-                    if (lvOneWireBindingConfig instanceof AbstractOneWireDevicePropertyBindingConfig) {
-                        logger.debug("Initializing read of item {}.", lvItemName);
+				Map<String, BindingConfig> lvBindigConfigs = lvBindingProvider
+						.getBindingConfigs();
+				for (String lvItemName : lvBindigConfigs.keySet()) {
+					logger.debug("scheduleAllBindings, now item {}.",
+							lvItemName);
+					OneWireBindingConfig lvOneWireBindingConfig = (OneWireBindingConfig) lvBindigConfigs
+							.get(lvItemName);
+					if (lvOneWireBindingConfig instanceof AbstractOneWireDevicePropertyBindingConfig) {
+						logger.debug("Initializing read of item {}.",
+								lvItemName);
 
-                        AbstractOneWireDevicePropertyBindingConfig lvDevicePropertyBindingConfig = (AbstractOneWireDevicePropertyBindingConfig) lvOneWireBindingConfig;
+						AbstractOneWireDevicePropertyBindingConfig lvDevicePropertyBindingConfig = (AbstractOneWireDevicePropertyBindingConfig) lvOneWireBindingConfig;
 
-                        if (lvDevicePropertyBindingConfig != null) {
-                            int lvAutoRefreshTimeInSecs = lvDevicePropertyBindingConfig.getAutoRefreshInSecs();
-                            if (lvAutoRefreshTimeInSecs > -1) {
-                                ivOneWireReaderScheduler.updateOnce(lvItemName);
-                            }
+						if (lvDevicePropertyBindingConfig != null) {
+							int lvAutoRefreshTimeInSecs = lvDevicePropertyBindingConfig
+									.getAutoRefreshInSecs();
+							if (lvAutoRefreshTimeInSecs > -1) {
+								ivOneWireReaderScheduler.updateOnce(lvItemName);
+							}
 
-                            if (lvAutoRefreshTimeInSecs > 0) {
-                                if (!ivOneWireReaderScheduler.scheduleUpdate(lvItemName, lvAutoRefreshTimeInSecs)) {
-                                    logger.warn("Clouldn't add to OneWireUpdate scheduler",
-                                            lvDevicePropertyBindingConfig);
-                                }
-                            }
-                        }
-                    } else {
-                        logger.debug("Didn't schedule item {} because it is not an DevicePropertyBinding.", lvItemName);
-                    }
-                }
-            }
-        }
-    }
+							if (lvAutoRefreshTimeInSecs > 0) {
+								if (!ivOneWireReaderScheduler.scheduleUpdate(
+										lvItemName, lvAutoRefreshTimeInSecs)) {
+									logger.warn(
+											"Clouldn't add to OneWireUpdate scheduler",
+											lvDevicePropertyBindingConfig);
+								}
+							}
+						}
+					} else {
+						logger.debug(
+								"Didn't schedule item {} because it is not an DevicePropertyBinding.",
+								lvItemName);
+					}
+				}
+			}
+		}
+	}
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * org.openhab.core.binding.AbstractBinding#bindingChanged(org.openhab.core
-     * .binding.BindingProvider, java.lang.String)
-     */
-    @Override
-    public void bindingChanged(BindingProvider pvProvider, String pvItemName) {
-        logger.debug("bindingChanged() for item {} msg received.", pvItemName);
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.openhab.core.binding.AbstractBinding#bindingChanged(org.openhab.core
+	 * .binding.BindingProvider, java.lang.String)
+	 */
+	public void bindingChanged(BindingProvider pvProvider, String pvItemName) {
+		logger.debug("bindingChanged() for item {} msg received.", pvItemName);
 
-        if (pvProvider instanceof OneWireBindingProvider) {
-            ivCacheItemStates.remove(pvItemName);
+		if (pvProvider instanceof OneWireBindingProvider) {
+			ivCacheItemStates.remove(pvItemName);
 
-            OneWireBindingProvider lvBindingProvider = (OneWireBindingProvider) pvProvider;
+			OneWireBindingProvider lvBindingProvider = (OneWireBindingProvider) pvProvider;
 
-            OneWireBindingConfig lvBindingConfig = lvBindingProvider.getBindingConfig(pvItemName);
+			OneWireBindingConfig lvBindingConfig = lvBindingProvider
+					.getBindingConfig(pvItemName);
 
-            // Only for AbstractOneWireDevicePropertyBindingConfig, not for
-            // AbstractOneWireControlBindingConfigs
-            if (lvBindingConfig != null && lvBindingConfig instanceof AbstractOneWireDevicePropertyBindingConfig) {
-                AbstractOneWireDevicePropertyBindingConfig lvDeviceBindingConfig = (AbstractOneWireDevicePropertyBindingConfig) lvBindingConfig;
+			// Only for AbstractOneWireDevicePropertyBindingConfig, not for
+			// AbstractOneWireControlBindingConfigs
+			if (lvBindingConfig != null
+					&& lvBindingConfig instanceof AbstractOneWireDevicePropertyBindingConfig) {
+				AbstractOneWireDevicePropertyBindingConfig lvDeviceBindingConfig = (AbstractOneWireDevicePropertyBindingConfig) lvBindingConfig;
 
-                logger.debug("Initializing read of item {}.", pvItemName);
-                int lvAutoRefreshTimeInSecs = lvDeviceBindingConfig.getAutoRefreshInSecs();
+				logger.debug("Initializing read of item {}.", pvItemName);
+				int lvAutoRefreshTimeInSecs = lvDeviceBindingConfig
+						.getAutoRefreshInSecs();
 
-                if (lvAutoRefreshTimeInSecs > -1) {
-                    ivOneWireReaderScheduler.updateOnce(pvItemName);
-                }
+				if (lvAutoRefreshTimeInSecs > -1) {
+					ivOneWireReaderScheduler.updateOnce(pvItemName);
+				}
 
-                if (lvAutoRefreshTimeInSecs > 0) {
-                    if (!ivOneWireReaderScheduler.scheduleUpdate(pvItemName, lvAutoRefreshTimeInSecs)) {
-                        logger.warn("Clouldn't add to OneWireUpdate scheduler", lvDeviceBindingConfig);
-                    }
-                } else {
-                    logger.debug("Didnt't add to OneWireUpdate scheduler, because refresh is <= 0: "
-                            + lvDeviceBindingConfig.toString());
-                }
-            }
-        }
-    }
+				if (lvAutoRefreshTimeInSecs > 0) {
+					if (!ivOneWireReaderScheduler.scheduleUpdate(pvItemName,
+							lvAutoRefreshTimeInSecs)) {
+						logger.warn("Clouldn't add to OneWireUpdate scheduler",
+								lvDeviceBindingConfig);
+					}
+				} else {
+					logger.debug("Didnt't add to OneWireUpdate scheduler, because refresh is <= 0: "
+							+ lvDeviceBindingConfig.toString());
+				}
+			}
+		}
+	}
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.openhab.binding.onewire.internal.listener.
-     * InterfaceOneWireDevicePropertyWantsUpdateListener#
-     * devicePropertyWantsUpdate(org.openhab.binding.onewire.internal.listener.
-     * OneWireDevicePropertyWantsUpdateEvent)
-     */
-    @Override
-    public void devicePropertyWantsUpdate(OneWireDevicePropertyWantsUpdateEvent pvWantsUpdateEvent) {
-        String lvItemName = pvWantsUpdateEvent.getItemName();
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.openhab.binding.onewire.internal.listener.
+	 * InterfaceOneWireDevicePropertyWantsUpdateListener#
+	 * devicePropertyWantsUpdate(org.openhab.binding.onewire.internal.listener.
+	 * OneWireDevicePropertyWantsUpdateEvent)
+	 */
+	public void devicePropertyWantsUpdate(
+			OneWireDevicePropertyWantsUpdateEvent pvWantsUpdateEvent) {
+		String lvItemName = pvWantsUpdateEvent.getItemName();
 
-        logger.debug("Item " + lvItemName + " wants update!");
+		logger.debug("Item " + lvItemName + " wants update!");
 
-        updateItemFromOneWire(lvItemName);
-    }
+		updateItemFromOneWire(lvItemName);
+	}
 
-    /**
-     * 
-     * @param pvItemName
-     * @return the corresponding AbstractOneWireDevicePropertyBindingConfig to
-     *         the given <code>pvItemName</code>
-     */
-    private OneWireBindingConfig getBindingConfig(String pvItemName) {
-        for (OneWireBindingProvider lvProvider : providers) {
-            return lvProvider.getBindingConfig(pvItemName);
-        }
-        return null;
-    }
+	/**
+	 * 
+	 * @param pvItemName
+	 * @return the corresponding AbstractOneWireDevicePropertyBindingConfig to
+	 *         the given <code>pvItemName</code>
+	 */
+	private OneWireBindingConfig getBindingConfig(String pvItemName) {
+		for (OneWireBindingProvider lvProvider : providers) {
+			return lvProvider.getBindingConfig(pvItemName);
+		}
+		return null;
+	}
 
-    /**
-     * 
-     * @param pvItemName
-     * @return the corresponding Item to the given <code>pvItemName</code>
-     */
-    private Item getItem(String pvItemName) {
-        for (OneWireBindingProvider lvProvider : providers) {
-            return lvProvider.getItem(pvItemName);
-        }
-        return null;
-    }
+	/**
+	 * 
+	 * @param pvItemName
+	 * @return the corresponding Item to the given <code>pvItemName</code>
+	 */
+	private Item getItem(String pvItemName) {
+		for (OneWireBindingProvider lvProvider : providers) {
+			return lvProvider.getItem(pvItemName);
+		}
+		return null;
+	}
 
-    /**
-     * Update an item with value from 1-wire device property
-     * 
-     * @param pvItemName
-     */
-    public void updateItemFromOneWire(String pvItemName) {
-        if (OneWireConnection.getConnection() != null) {
+	/**
+	 * Update an item with value from 1-wire device property
+	 * 
+	 * @param pvItemName
+	 */
+	public void updateItemFromOneWire(String pvItemName) {
+		if (OneWireConnection.getConnection() != null) {
 
-            AbstractOneWireDevicePropertyBindingConfig pvBindingConfig = (AbstractOneWireDevicePropertyBindingConfig) getBindingConfig(
-                    pvItemName);
+			AbstractOneWireDevicePropertyBindingConfig pvBindingConfig = (AbstractOneWireDevicePropertyBindingConfig) getBindingConfig(pvItemName);
 
-            if (pvBindingConfig == null) {
-                logger.error("no bindingConfig found for itemName=" + pvItemName
-                        + " cannot update! It will be removed from scheduler");
-                ivOneWireReaderScheduler.removeItem(pvItemName);
-                return;
-            }
+			if (pvBindingConfig == null) {
+				logger.error("no bindingConfig found for itemName="
+						+ pvItemName
+						+ " cannot update! It will be removed from scheduler");
+				ivOneWireReaderScheduler.removeItem(pvItemName);
+				return;
+			}
 
-            String lvReadValue = OneWireConnection.readFromOneWire(pvBindingConfig);
+			String lvReadValue = OneWireConnection
+					.readFromOneWire(pvBindingConfig);
 
-            Item lvItem = getItem(pvItemName);
-            if (lvReadValue != null) {
-                Type lvNewType = pvBindingConfig.convertReadValueToType(lvReadValue);
-                if (lvItem != null) {
-                    postUpdate(lvItem, lvNewType);
-                } else {
-                    logger.error("There is no Item for ItemName=" + pvItemName);
-                }
-            } else {
-                String lvLogText = "Set Item for itemName=" + pvItemName
-                        + " to Undefined, because the readvalue is null";
-                if (pvBindingConfig.isIgnoreReadErrors()) {
-                    logger.debug(lvLogText);
-                } else {
-                    logger.error(lvLogText);
-                }
+			Item lvItem = getItem(pvItemName);
+			if (lvReadValue != null) {
+				Type lvNewType = pvBindingConfig
+						.convertReadValueToType(lvReadValue);
+				if (lvItem != null) {
+					postUpdate(lvItem, lvNewType);
+				} else {
+					logger.error("There is no Item for ItemName=" + pvItemName);
+				}
+			} else {
+				String lvLogText = "Set Item for itemName=" + pvItemName
+						+ " to Undefined, because the readvalue is null";
+				if (pvBindingConfig.isIgnoreReadErrors()) {
+					logger.debug(lvLogText);
+				} else {
+					logger.error(lvLogText);
+				}
 
-                postUpdate(lvItem, UnDefType.UNDEF);
-            }
-        }
-    }
+				postUpdate(lvItem, UnDefType.UNDEF);
+			}
+		}
+	}
 
-    private void postUpdate(Item pvItem, Type pvNewType) {
-        synchronized (pvItem) {
-            State lvNewState = (State) pvNewType;
-            State lvCachedState = ivCacheItemStates.get(pvItem.getName());
-            if (!ivPostOnlyChangedValues || !lvNewState.equals(lvCachedState)) {
-                ivCacheItemStates.remove(pvItem.getName());
-                ivCacheItemStates.put(pvItem.getName(), lvNewState);
-                eventPublisher.postUpdate(pvItem.getName(), lvNewState);
-            } else {
-                logger.debug("didn't post update to eventPublisher, because state did not changed for item "
-                        + pvItem.getName());
-            }
-        }
-    }
+	private void postUpdate(Item pvItem, Type pvNewType) {
+		synchronized (pvItem) {
+			State lvNewState = (State) pvNewType;
+			State lvCachedState = ivCacheItemStates.get(pvItem.getName());
+			if (!ivPostOnlyChangedValues || !lvNewState.equals(lvCachedState)) {
+				ivCacheItemStates.remove(pvItem.getName());
+				ivCacheItemStates.put(pvItem.getName(), lvNewState);
+				eventPublisher.postUpdate(pvItem.getName(), lvNewState);
+			} else {
+				logger.debug("didn't post update to eventPublisher, because state did not changed for item "
+						+ pvItem.getName());
+			}
+		}
+	}
 
-    /**
-     * Clears the Cache for ItemStates
-     */
-    public void clearCacheItemState() {
-        this.ivCacheItemStates.clear();
-    }
+	/**
+	 * Clears the Cache for ItemStates
+	 */
+	public void clearCacheItemState() {
+		this.ivCacheItemStates.clear();
+	}
 
-    /**
-     * Clears the Cache for given Item
-     */
-    public void clearCacheItemState(String pvItenName) {
-        this.ivCacheItemStates.remove(pvItenName);
-    }
+	/**
+	 * Clears the Cache for given Item
+	 */
+	public void clearCacheItemState(String pvItenName) {
+		this.ivCacheItemStates.remove(pvItenName);
+	}
 }

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OneWireBindingConfigFactory.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OneWireBindingConfigFactory.java
@@ -11,6 +11,7 @@ package org.openhab.binding.onewire.internal;
 import org.openhab.binding.onewire.internal.control.OneWireClearCacheControlBindingConfig;
 import org.openhab.binding.onewire.internal.deviceproperties.OneWireDevicePropertyContactBindingConfig;
 import org.openhab.binding.onewire.internal.deviceproperties.OneWireDevicePropertyNumberBindingConfig;
+import org.openhab.binding.onewire.internal.deviceproperties.OneWireDevicePropertyPushButtonBindingConfig;
 import org.openhab.binding.onewire.internal.deviceproperties.OneWireDevicePropertyStringBindingConfig;
 import org.openhab.binding.onewire.internal.deviceproperties.OneWireDevicePropertySwitchBindingConfig;
 import org.openhab.binding.onewire.internal.deviceproperties.OneWireDevicePropertySwitchMinMaxNumberWarningBindingConfig;
@@ -25,65 +26,71 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class provides a Factory, which creates OneWireBindingConfigs
- *
+ * 
  * @author Dennis Riegelbauer
  * @since 1.7.0
- *
+ * 
  */
 public class OneWireBindingConfigFactory {
 
-    private static final Logger logger = LoggerFactory.getLogger(OneWireBindingConfigFactory.class);
+	private static final Logger logger = LoggerFactory
+			.getLogger(OneWireBindingConfigFactory.class);
 
-    /**
-     * @param pvItem
-     * @param pvBindingConfig
-     * @return a new BindingConfig, corresponding to the given <code><pvItem/code> and <code><pvBindingConfig/code>
-     * @throws BindingConfigParseException
-     */
-    public static OneWireBindingConfig createOneWireDeviceProperty(Item pvItem, String pvBindingConfig)
-            throws BindingConfigParseException {
-        logger.debug("createOneWireDeviceProperty: " + pvItem.getName() + " - bindingConfig:" + pvBindingConfig);
+	/**
+	 * @param pvItem
+	 * @param pvBindingConfig
+	 * @return a new BindingConfig, corresponding to the given
+	 *         <code><pvItem/code> and <code><pvBindingConfig/code>
+	 * @throws BindingConfigParseException
+	 */
+	public static OneWireBindingConfig createOneWireDeviceProperty(Item pvItem, String pvBindingConfig) throws BindingConfigParseException {
+		logger.debug("createOneWireDeviceProperty: " + pvItem.getName() + " - bindingConfig:" + pvBindingConfig);
 
-        OneWireBindingConfig lvNewBindingConfig = null;
-        if (OneWireClearCacheControlBindingConfig.isBindingConfigToCreate(pvItem, pvBindingConfig)) {
-            lvNewBindingConfig = new OneWireClearCacheControlBindingConfig(pvBindingConfig);
-        } else if (OneWireDevicePropertySwitchMinMaxNumberWarningBindingConfig.isBindingConfigToCreate(pvItem,
-                pvBindingConfig)) {
-            lvNewBindingConfig = new OneWireDevicePropertySwitchMinMaxNumberWarningBindingConfig(pvBindingConfig);
-        } else if (pvItem instanceof NumberItem) {
-            lvNewBindingConfig = new OneWireDevicePropertyNumberBindingConfig(pvBindingConfig);
-        } else if (pvItem instanceof ContactItem) {
-            lvNewBindingConfig = new OneWireDevicePropertyContactBindingConfig(pvBindingConfig);
-        } else if (pvItem instanceof SwitchItem) {
-            lvNewBindingConfig = new OneWireDevicePropertySwitchBindingConfig(pvBindingConfig);
-        } else if (pvItem instanceof StringItem) {
-            lvNewBindingConfig = new OneWireDevicePropertyStringBindingConfig(pvBindingConfig);
-        } else {
-            throw new UnsupportedOperationException(
-                    "the item-type " + pvItem.getClass() + " cannot be a onewire device");
-        }
+		OneWireBindingConfig lvNewBindingConfig = null;
+		if (OneWireClearCacheControlBindingConfig.isBindingConfigToCreate(pvItem, pvBindingConfig)) {
+			lvNewBindingConfig = new OneWireClearCacheControlBindingConfig(pvBindingConfig);
+		} else if (OneWireDevicePropertyPushButtonBindingConfig.isBindingConfigToCreate(pvItem, pvBindingConfig)) {
+			lvNewBindingConfig = new OneWireDevicePropertyPushButtonBindingConfig(pvBindingConfig);
+		} else if (OneWireDevicePropertySwitchMinMaxNumberWarningBindingConfig.isBindingConfigToCreate(pvItem, pvBindingConfig)) {
+			lvNewBindingConfig = new OneWireDevicePropertySwitchMinMaxNumberWarningBindingConfig(pvBindingConfig);
+		} else if (pvItem instanceof NumberItem) {
+			lvNewBindingConfig = new OneWireDevicePropertyNumberBindingConfig(pvBindingConfig);
+		} else if (pvItem instanceof ContactItem) {
+			lvNewBindingConfig = new OneWireDevicePropertyContactBindingConfig(pvBindingConfig);
+		} else if (pvItem instanceof SwitchItem) {
+			lvNewBindingConfig = new OneWireDevicePropertySwitchBindingConfig(pvBindingConfig);
+		} else if (pvItem instanceof StringItem) {
+			lvNewBindingConfig = new OneWireDevicePropertyStringBindingConfig(pvBindingConfig);
+		} else {
+			throw new UnsupportedOperationException("the item-type " + pvItem.getClass() + " cannot be a onewire device");
+		}
 
-        logger.debug("created newBindingConfig: " + lvNewBindingConfig.toString());
+		logger.debug("created newBindingConfig: " + lvNewBindingConfig.toString());
 
-        return lvNewBindingConfig;
-    }
+		return lvNewBindingConfig;
+	}
 
-    /**
-     * 
-     * @param pvItem
-     * @param pvBindingConfig
-     * @return is the given Item a valid one, which can be used for a OneWireBinding?
-     * @throws BindingConfigParseException
-     */
-    public static boolean isValidItemType(Item pvItem, String pvBindingConfig) throws BindingConfigParseException {
-        boolean lvIsValidItem = ((pvItem instanceof NumberItem) || (pvItem instanceof ContactItem)
-                || (pvItem instanceof SwitchItem) || (pvItem instanceof StringItem));
+	/**
+	 * 
+	 * @param pvItem
+	 * @param pvBindingConfig
+	 * @return is the given Item a valid one, which can be used for a
+	 *         OneWireBinding?
+	 * @throws BindingConfigParseException
+	 */
+	public static boolean isValidItemType(Item pvItem, String pvBindingConfig)
+			throws BindingConfigParseException {
+		boolean lvIsValidItem = ((pvItem instanceof NumberItem)
+				|| (pvItem instanceof ContactItem)
+				|| (pvItem instanceof SwitchItem) || (pvItem instanceof StringItem));
 
-        if (!lvIsValidItem) {
-            logger.error("Item " + pvItem.getName() + " of type " + pvItem.getClass().getSimpleName()
-                    + " with configuration " + pvBindingConfig + " is not a valid onewire ItemType!");
-        }
+		if (!lvIsValidItem) {
+			logger.error("Item " + pvItem.getName() + " of type "
+					+ pvItem.getClass().getSimpleName()
+					+ " with configuration " + pvBindingConfig
+					+ " is not a valid onewire ItemType!");
+		}
 
-        return lvIsValidItem;
-    }
+		return lvIsValidItem;
+	}
 }

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/InterfaceOneWireDevicePropertyExecutableBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/InterfaceOneWireDevicePropertyExecutableBindingConfig.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.onewire.internal.deviceproperties;
+
+import org.openhab.core.types.Command;
+
+
+
+/**
+ * Interface to implement a special behavior for Items (like a Switch Tab)
+ * 
+ * @author Dennis Riegelbauer
+ * @since 1.7.0
+ * 
+ */
+public interface InterfaceOneWireDevicePropertyExecutableBindingConfig {
+
+	public void execute(Command pvCommand); 
+
+}

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/OneWireDevicePropertyPushButtonBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/OneWireDevicePropertyPushButtonBindingConfig.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.onewire.internal.deviceproperties;
+
+import org.openhab.binding.onewire.internal.connection.OneWireConnection;
+import org.openhab.core.items.Item;
+import org.openhab.core.library.items.SwitchItem;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.types.Command;
+import org.openhab.model.item.binding.BindingConfigParseException;
+
+/**
+ * This Class is a specialized writable BindingConfig with a special execute command. 
+ * It connects openHab Switch-Items to 1-Wire device properties and simulates a PushButton (ON-wait-OFF or OFF-wait-ON)
+ * 
+ * For Basic Configuration of the binding, see
+ * OneWireDevicePropertySwitchBindingConfig.java
+ * 
+ * Example:
+ * <ul>
+ * <li>
+ * <code>onewire="deviceId=29.66C30E000000;propertyName=sensed.0;refreshinterval=10";pushbutton=500;invert",autoupdate="false"</code>
+ * </li>
+ * </ul>
+ * 
+ * @author Dennis Riegelbauer
+ * @since 1.7.0
+ * 
+ */
+public class OneWireDevicePropertyPushButtonBindingConfig extends
+		OneWireDevicePropertySwitchBindingConfig implements
+		InterfaceOneWireDevicePropertyExecutableBindingConfig {
+
+	private int waitTime;
+	
+	public OneWireDevicePropertyPushButtonBindingConfig(String pvBindingConfig)
+			throws BindingConfigParseException {
+		super(pvBindingConfig);
+		super.parseBindingConfig(pvBindingConfig);
+		this.parsePushButtonConfig(pvBindingConfig);
+	}
+	
+	protected void parseBindingConfig(String pvBindingConfig) throws BindingConfigParseException {
+		String[] lvConfigParts = pvBindingConfig.trim().split(";");
+
+		for (String lvConfigPart : lvConfigParts) {
+			parsePushButtonConfig(lvConfigPart);
+		}
+	}
+	
+	private void parsePushButtonConfig(String pvConfigPart) {
+		String lvConfigProperty = null;
+
+		lvConfigProperty = "pushbutton=";
+		if (pvConfigPart.startsWith(lvConfigProperty)) {
+			String lvConfigValue = pvConfigPart.substring(lvConfigProperty.length());
+			this.waitTime = Integer.parseInt(lvConfigValue);
+		}
+	}
+	
+	/**
+	 * Checks, if this special binding-type matches to the given pvBindingConfig
+	 * 
+	 * @param pvItem
+	 * @param pvBindingConfig
+	 * @return boolean
+	 */
+	public static boolean isBindingConfigToCreate(Item pvItem, String pvBindingConfig) {
+		return ((pvItem instanceof SwitchItem) && (pvBindingConfig.contains("pushbutton")));
+	}
+
+	@Override
+	public void execute(Command pvCommand) {
+		if (pvCommand.equals(OnOffType.ON)) {
+			write(OnOffType.ON);
+			sleep();
+			write(OnOffType.OFF);
+		} else if (pvCommand.equals(OnOffType.OFF)) {
+			write(OnOffType.OFF);
+			sleep();
+			write(OnOffType.ON);
+		} else {
+			throw new IllegalStateException("Unknown command for this binding:"
+					+ pvCommand.toString());
+		}		
+	}
+	
+	private void sleep() {
+		try {
+			Thread.sleep(this.waitTime);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
+	private void write(Command pvCommand) {
+		OneWireConnection.writeToOneWire(this.getDevicePropertyPath(),
+				this.convertTypeToString(pvCommand));
+	}
+
+	@Override
+	public String toString() {
+		final int maxLen = 20;
+		return "OneWireDevicePropertyPushButtonBindingConfig [getDeviceId()="
+				+ getDeviceId()
+				+ ", getPropertyName()="
+				+ getPropertyName()
+				+ ", getAutoRefreshInSecs()="
+				+ getAutoRefreshInSecs()
+				+ ", getDevicePropertyPath()="
+				+ getDevicePropertyPath()
+				+ ", getTypeModifieryList()="
+				+ (getTypeModifieryList() != null ? getTypeModifieryList()
+						.subList(0,
+								Math.min(getTypeModifieryList().size(), maxLen))
+						: null) + "]";
+	}
+}


### PR DESCRIPTION
The new option makes it possible to use a relay like a pushbutton. It
is possible to do that with a rule and timer, but then you have no
control of the real time a button is pushed on slow systems.

Example:
`onewire="deviceId=29.66C30E000000;propertyName=sensed.0;refreshinterval=10";pushbutton=500;invert",autoupdate="false"`