### PR TITLE
Add jdbc Persistence to Paperui and features

### DIFF
--- a/bundles/persistence/org.openhab.persistence.jdbc/ESH-INF/config/config.xml
+++ b/bundles/persistence/org.openhab.persistence.jdbc/ESH-INF/config/config.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0
+        http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="persistence:jdbc">
+
+		<!-- 
+		# I N S T A L L   J D B C   P E R S I S T E N C E   S E R V I C E 
+		#
+		# https://github.com/openhab/openhab/wiki/JDBC-Persistence
+		#
+		# Tested databases/url-prefix: jdbc:derby, jdbc:h2, jdbc:hsqldb, jdbc:mariadb, jdbc:mysql, jdbc:postgresql, jdbc:sqlite
+		# 
+		# derby, h2, hsqldb, sqlite can be embedded, 
+		# If no database is available it will be created, for example the url 'jdbc:h2:./testH2' creates a new DB in OpenHab Folder. 
+		#
+		# Create new database, for example on a MySQL-Server use: 
+		# CREATE DATABASE 'yourDB' CHARACTER SET utf8 COLLATE utf8_general_ci;
+		 -->
+		 
+        <!--    
+                # D A T A B A S E  C O N F I G
+				# Some URL-Examples, 'service' identifies and activates internally the correct jdbc driver.
+				# required database url like 'jdbc:<service>:<host>[:<port>;<attributes>]'
+				# jdbc:url=jdbc:derby:./testDerby;create=true
+				# jdbc:url=jdbc:h2:./testH2
+				# jdbc:url=jdbc:hsqldb:./testHsqlDb
+				# jdbc:url=jdbc:mariadb://192.168.0.1:3306/testMariadb
+				# jdbc:url=jdbc:mysql://192.168.0.1:3306/testMysql
+				# jdbc:url=jdbc:postgresql://192.168.0.1:5432/testPostgresql
+				# jdbc:url=jdbc:sqlite:./testSqlite.db
+		-->
+        <parameter name="url" type="text" required="true">
+            <label>Database URL</label>
+            <description><![CDATA[Defines required database URL and optional path and parameters.<br>
+            Required database url like 'jdbc:<service>:<host>[:<port>;<attributes>]'<br>
+            Parameter 'service' is used as identifier for the selected jdbc driver.
+            URL-Examples:<br>
+            jdbc:derby:./testDerby;create=true<br>
+            jdbc:h2:./testH2<br>
+            jdbc:hsqldb:./testHsqlDb<br>
+            jdbc:mariadb://192.168.0.1:3306/testMariadb<br>
+            jdbc:mysql://192.168.0.1:3306/testMysql<br>
+            jdbc:postgresql://192.168.0.1:5432/testPostgresql<br>
+            jdbc:sqlite:./testSqlite.db]]></description>
+        </parameter>
+
+        <parameter name="user" type="text" required="true">
+            <label>Database User</label>
+            <description><![CDATA[Defines required database user.]]></description>
+        </parameter>
+        
+        <parameter name="password" type="text" required="true">
+            <label>Database Password</label>
+            <description><![CDATA[Defines required database password.]]></description>
+        </parameter>
+        
+        <!--    
+                # I T E M   O P E R A T I O N S
+		        # optional tweaking SQL datatypes
+		        # see: https://mybatis.github.io/mybatis-3/apidocs/reference/org/apache/ibatis/type/JdbcType.html   
+		        # see: http://www.h2database.com/html/datatypes.html
+		        # see: http://www.postgresql.org/docs/9.3/static/datatype.html
+		        # defaults:
+		        #sqltype.CALL          =   VARCHAR(200)
+		        #sqltype.COLOR         =   VARCHAR(70)
+		        #sqltype.CONTACT       =   VARCHAR(6)
+		        #sqltype.DATETIME      =   DATETIME
+		        #sqltype.DIMMER        =   TINYINT
+		        #sqltype.LOCATION      =   VARCHAR(30)
+		        #sqltype.NUMBER        =   DOUBLE
+		        #sqltype.ROLLERSHUTTER =   TINYINT
+		        #sqltype.STRING        =   VARCHAR(65500)
+		        #sqltype.SWITCH        =   VARCHAR(6)
+		        
+		        # For Itemtype "Number" default decimal digit count (optional, default: 3) 
+		        #numberDecimalcount=
+         -->
+        <parameter name="sqltype.CALL" type="text" required="false">
+            <label>SqlType CALL</label>
+            <description><![CDATA[Overrides used JDBC/SQL datatype for CALL <br>(optional, default: "VARCHAR(200)"). <br>
+            General about JdbcTypes/SqlTypes see: https://mybatis.github.io/mybatis-3/apidocs/reference/org/apache/ibatis/type/JdbcType.html <br> 
+            see: http://www.h2database.com/html/datatypes.html <br>
+            see: http://www.postgresql.org/docs/9.5/static/datatype.html]]></description>
+        </parameter>
+        <parameter name="sqltype.COLOR" type="text" required="false">
+            <label>SqlType COLOR</label>
+            <description><![CDATA[Overrides used JDBC/SQL datatype for COLOR <br>(optional, default: "VARCHAR(70)").]]></description>
+        </parameter>
+        <parameter name="sqltype.CONTACT" type="text" required="false">
+            <label>SqlType CONTACT</label>
+            <description><![CDATA[Overrides used JDBC/SQL datatype for CONTACT <br>(optional, default: "VARCHAR(6)").]]></description>
+        </parameter>
+        <parameter name="sqltype.DATETIME" type="text" required="false">
+            <label>SqlType DATETIME</label>
+            <description><![CDATA[Overrides used JDBC/SQL datatype for DATETIME <br>(optional, default: "DATETIME").]]></description>
+        </parameter>
+        <parameter name="sqltype.DIMMER" type="text" required="false">
+            <label>SqlType DIMMER</label>
+            <description><![CDATA[Overrides used JDBC/SQL datatype for DIMMER <br>(optional, default: "TINYINT").]]></description>
+        </parameter>
+        <parameter name="sqltype.LOCATION" type="text" required="false">
+            <label>SqlType LOCATION</label>
+            <description><![CDATA[Overrides used JDBC/SQL datatype for LOCATION <br>(optional, default: "VARCHAR(30)").]]></description>
+        </parameter>
+        <parameter name="sqltype.NUMBER" type="text" required="false">
+            <label>SqlType NUMBER</label>
+            <description><![CDATA[Overrides used JDBC/SQL datatype for NUMBER <br>(optional, default: "DOUBLE").]]></description>
+        </parameter>
+        <parameter name="sqltype.ROLLERSHUTTER" type="text" required="false">
+            <label>SqlType ROLLERSHUTTER</label>
+            <description><![CDATA[Overrides used JDBC/SQL datatype for ROLLERSHUTTER <br>(optional, default: "TINYINT").]]></description>
+        </parameter>
+        <parameter name="sqltype.STRING" type="text" required="false">
+            <label>SqlType STRING</label>
+            <description><![CDATA[Overrides used JDBC/SQL datatype for STRING <br>(optional, default: "VARCHAR(65500)").]]></description>
+        </parameter>
+        <parameter name="sqltype.SWITCH" type="text" required="false">
+            <label>SqlType SWITCH</label>
+            <description><![CDATA[Overrides used JDBC/SQL datatype for SWITCH <br>(optional, default: "VARCHAR(6)").]]></description>
+        </parameter>
+        
+        <!--    
+                # T A B L E   O P E R A T I O N S
+				# Tablename Prefix String (optional, default: "item") 
+				# for Migration from MYSQL-Bundle set to 'Item'.
+				#tableNamePrefix=Item
+
+				# Tablename Prefix generation, using Item real names or "item" (optional, default: false -> "item") 
+				# If true, 'tableNamePrefix' is ignored.
+				#tableUseRealItemNames=
+				tableUseRealItemNames=true
+				
+				# Tablename Suffix length (optional, default: 4 -> 0001-9999) 
+				# for Migration from MYSQL-Bundle set to 0.
+				#tableIdDigitCount=
+				
+				# Rename existing Tables using tableUseRealItemNames and tableIdDigitCount (optional, default: false) 
+				# USE WITH CARE! Deactivate after Renaming is done!
+				#rebuildTableNames=true
+         -->
+        <parameter name="tableNamePrefix" type="text" required="false">
+            <label>Tablename Prefix String</label>
+            <description><![CDATA[Tablename prefix string <br>(optional, default: "item"). <br>
+            For migration from MYSQL-Bundle set to 'Item'.]]></description>
+        </parameter>
+        <parameter name="tableUseRealItemNames" type="text" required="false">
+            <label>Tablename Realname Generation</label>
+            <description><![CDATA[Enables Tablename prefix generation per Items realname <br>(optional, default: disabled -> "Tablename Prefix String" is used). <br> 
+            If true, 'Tablename Prefix String' is ignored.]]></description>
+            <options>
+                <option value="true">Enable</option>
+                <option value="false">Disable</option>
+            </options>
+        </parameter>
+        <parameter name="tableIdDigitCount" type="text" required="false">
+            <label>Tablename Suffix ID Count</label>
+            <description><![CDATA[Tablename Suffix ID Count <br>(optional, default: 4 -> 0001-9999). <br>
+            For migration from MYSQL-Bundle set to 0.]]></description>
+        </parameter>
+        <parameter name="rebuildTableNames" type="text" required="false">
+            <label>Tablename Rebuild</label>
+            <description><![CDATA[Rename existing tables using 'Tablename Realname Generation' and 'Tablename Suffix ID Count', (optional, default: disabled). <br>
+            USE WITH CARE! Deactivate after renaming is done!]]></description>
+            <options>
+                <option value="true">Enable</option>
+                <option value="false">Disable</option>
+            </options>
+        </parameter>
+        
+        <!--    
+                # D A T A B A S E  C O N N E C T I O N S
+                # Some embeded Databases can handle only one Connection (optional, default: configured per database in packet org.openhab.persistence.jdbc.db.* )
+                # see: https://github.com/brettwooldridge/HikariCP/issues/256
+                # maximumPoolSize = 1
+                # minimumIdle = 1
+         -->
+        <parameter name="maximumPoolSize" type="text" required="false">
+            <label>Connections Max Pool Size</label>
+            <description><![CDATA[Overrides max pool size in database connection. <br>(optional, default: differs each Database)<br>
+            https://github.com/brettwooldridge/HikariCP/issues/256]]></description>
+        </parameter>
+        <parameter name="minimumIdle" type="text" required="false">
+            <label>Connections Min Idle</label>
+            <description><![CDATA[Overrides min idle database connections. <br>(optional, default: differs each Database)<br>
+            https://github.com/brettwooldridge/HikariCP/issues/256]]></description>
+        </parameter>
+        
+        <!--    
+                # T I M E K E E P I N G
+				# (optional, default: false) 
+				#enableLogTime=true
+         -->
+        <parameter name="enableLogTime" type="text" required="false">
+            <label>Timekeeping Enable</label>
+            <description><![CDATA[Enables a time, performance measurement. <br>(optional, default: disabled)]]></description>
+            <options>
+                <option value="true">Enable</option>
+                <option value="false">Disable</option>
+            </options>
+        </parameter>
+        
+	</config-description>
+
+</config-description:config-descriptions>

--- a/bundles/persistence/org.openhab.persistence.jdbc/OSGI-INF/jdbc.xml
+++ b/bundles/persistence/org.openhab.persistence.jdbc/OSGI-INF/jdbc.xml
@@ -16,4 +16,8 @@
       <provide interface="org.openhab.core.persistence.QueryablePersistenceService"/>
    </service>
    <reference bind="setItemRegistry" cardinality="0..1" interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry"/>
+   <property name="service.config.description.uri" type="String" value="persistence:jdbc"/>
+   <property name="service.config.label" type="String" value="JDBC Persistence"/>
+   <property name="service.config.category" type="String" value="persistence"/>
 </scr:component>
+

--- a/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
+++ b/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
@@ -235,7 +235,6 @@ public class JdbcConfiguration {
             dBDAO.databaseProps.setProperty("jdbcUrl", url);
         }
 
-        logger.warn("JDBC::updateConfig: try to load JDBC-driverClass: '{}'", dn);
         try {
             Class.forName(dn);
             logger.debug("JDBC::updateConfig: load JDBC-driverClass was successful: '{}'", dn);

--- a/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
+++ b/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcMapper.java
@@ -160,7 +160,7 @@ public class JdbcMapper {
     protected boolean openConnection() {
         logger.debug("JDBC::openConnection isDriverAvailable: {}", conf.isDriverAvailable());
         if (conf.isDriverAvailable() && !conf.isDbConnected()) {
-            logger.warn("JDBC::openConnection: setupDataSource.");
+            logger.info("JDBC::openConnection: Driver is available::Yank setupDataSource");
             Yank.setupDataSource(conf.getHikariConfiguration());
             conf.setDbConnected(true);
             return true;
@@ -187,10 +187,13 @@ public class JdbcMapper {
         // first
         boolean p = pingDB();
         if (p) {
+            logger.debug("JDBC::checkDBAcessability, first try connection: {}", p);
             return (p && !(conf.getErrReconnectThreshold() > 0 && errCnt <= conf.getErrReconnectThreshold()));
         } else {
             // second
-            return (pingDB() && !(conf.getErrReconnectThreshold() > 0 && errCnt <= conf.getErrReconnectThreshold()));
+            p = pingDB();
+            logger.debug("JDBC::checkDBAcessability, second try connection: {}", p);
+            return (p && !(conf.getErrReconnectThreshold() > 0 && errCnt <= conf.getErrReconnectThreshold()));
         }
     }
 

--- a/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcPersistenceService.java
@@ -120,7 +120,7 @@ public class JdbcPersistenceService extends JdbcMapper implements QueryablePersi
     public void store(Item item, String alias) {
         // Don not store undefined/uninitialised data
         if (item.getState() instanceof UnDefType) {
-            logger.warn("JDBC::store: ignore Item because it is UnDefType");
+            logger.warn("JDBC::store: ignore Item '{}' because it is UnDefType", item.getName());
             return;
         }
         if (!checkDBAcessability()) {

--- a/bundles/persistence/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.jdbc/pom.xml
@@ -28,13 +28,6 @@
 		<classpath.ext>lib/</classpath.ext>
 		<deb.name>openhab-addon-persistence-jdbc</deb.name>
 		<deb.description>${project.name}</deb.description>
-		<derby.version>10.11.1.1</derby.version>
-		<h2.version>1.4.189</h2.version>
-		<hsqldb.version>2.3.3</hsqldb.version>
-		<mariadb.version>1.3.4</mariadb.version>
-		<mysql.version>5.1.36</mysql.version>
-		<postgresql.version>9.4-1201-jdbc41</postgresql.version>
-		<sqlite.version>3.8.11.2</sqlite.version>
 	</properties>
 
 	<dependencies>

--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -49,6 +49,7 @@
                                 <artifact><file>src/main/resources/conf/http.cfg</file><type>cfg</type><classifier>http</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/ihc.cfg</file><type>cfg</type><classifier>ihc</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/insteonplm.cfg</file><type>cfg</type><classifier>insteonplm</classifier></artifact>
+                                <artifact><file>src/main/resources/conf/jdbc.cfg</file><type>cfg</type><classifier>jdbc</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/jpa.cfg</file><type>cfg</type><classifier>jpa</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/knx.cfg</file><type>cfg</type><classifier>knx</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/logging.cfg</file><type>cfg</type><classifier>logging</classifier></artifact>

--- a/features/openhab-addons-external/src/main/resources/conf/jdbc.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/jdbc.cfg
@@ -1,0 +1,81 @@
+############################ JDBC Persistence Service ##################################
+# I N S T A L L   J D B C   P E R S I S T E N C E   S E R V I C E 
+#
+# https://github.com/openhab/openhab/wiki/JDBC-Persistence
+#
+# Tested databases/url-prefix: jdbc:derby, jdbc:h2, jdbc:hsqldb, jdbc:mariadb, jdbc:mysql, jdbc:postgresql, jdbc:sqlite
+# 
+# derby, h2, hsqldb, sqlite can be embedded, 
+# If no database is available it will be created, for example the url 'jdbc:h2:./testH2' creates a new DB in OpenHab Folder. 
+#
+# Create new database, for example on a MySQL-Server use: 
+# CREATE DATABASE 'yourDB' CHARACTER SET utf8 COLLATE utf8_general_ci;
+
+# D A T A B A S E  C O N F I G
+# Some URL-Examples, 'service' identifies and activates internally the correct jdbc driver.
+# required database url like 'jdbc:<service>:<host>[:<port>;<attributes>]'
+# url=jdbc:derby:./testDerby;create=true
+# url=jdbc:h2:./testH2
+# url=jdbc:hsqldb:./testHsqlDb
+# url=jdbc:mariadb://192.168.0.1:3306/testMariadb
+# url=jdbc:mysql://192.168.0.1:3306/testMysql
+# url=jdbc:postgresql://192.168.0.1:5432/testPostgresql
+# url=jdbc:sqlite:./testSqlite.db
+# url=
+
+# required database user
+#user=
+
+# required database password
+#password=
+
+# E R R O R   H A N D L I N G
+# optional when Service is deactivated (optional, default: 0 -> ignore) 
+#errReconnectThreshold=
+
+# I T E M   O P E R A T I O N S
+# optional tweaking SQL datatypes
+# see: https://mybatis.github.io/mybatis-3/apidocs/reference/org/apache/ibatis/type/JdbcType.html   
+# see: http://www.h2database.com/html/datatypes.html
+# see: http://www.postgresql.org/docs/9.3/static/datatype.html
+# defaults:
+#sqltype.CALL          =   VARCHAR(200)
+#sqltype.COLOR         =   VARCHAR(70)
+#sqltype.CONTACT       =   VARCHAR(6)
+#sqltype.DATETIME      =   DATETIME
+#sqltype.DIMMER        =   TINYINT
+#sqltype.LOCATION      =   VARCHAR(30)
+#sqltype.NUMBER        =   DOUBLE
+#sqltype.ROLLERSHUTTER =   TINYINT
+#sqltype.STRING        =   VARCHAR(65500)
+#sqltype.SWITCH        =   VARCHAR(6)
+
+# For Itemtype "Number" default decimal digit count (optional, default: 3) 
+#numberDecimalcount=
+
+# T A B L E   O P E R A T I O N S
+# Tablename Prefix String (optional, default: "item") 
+# for Migration from MYSQL-Bundle set to 'Item'.
+#tableNamePrefix=Item
+
+# Tablename Prefix generation, using Item real names or "item" (optional, default: false -> "item") 
+# If true, 'tableNamePrefix' is ignored.
+#tableUseRealItemNames=
+
+# Tablename Suffix length (optional, default: 4 -> 0001-9999) 
+# for Migration from MYSQL-Bundle set to 0.
+#tableIdDigitCount=
+
+# Rename existing Tables using tableUseRealItemNames and tableIdDigitCount (optional, default: false) 
+# USE WITH CARE! Deactivate after Renaming is done!
+#rebuildTableNames=true
+
+# D A T A B A S E  C O N N E C T I O N S
+# Some embeded Databases can handle only one Connection (optional, default: configured per database in packet org.openhab.persistence.jdbc.db.* )
+# see: https://github.com/brettwooldridge/HikariCP/issues/256
+# jdbc.maximumPoolSize = 1
+# jdbc.minimumIdle = 1
+
+# T I M E K E E P I N G
+# (optional, default: false) 
+#enableLogTime=true

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -491,7 +491,64 @@
         <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.logging/${project.version}</bundle>
         <configfile finalname="${openhab.conf}/services/logging.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/logging</configfile>
     </feature>
-
+    
+    <!-- JDBC Persistence for: Apache Derby, H2, HSQLDB, MariaDB, MySQL, PostgreSQL, SQLite -->
+    <feature name="openhab-persistence-jdbc-derby" description="JDBC Persistence Apache Derby" version="${project.version}">
+        <configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jdbc</configfile>
+        <feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
+        <feature prerequisite="false" dependency="false">openhab-runtime-compat1x</feature>
+        <bundle start-level="80">mvn:org.apache.derby/derbyclient/${derby.version}</bundle>
+        <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jdbc/${project.version}</bundle>
+    </feature>
+    
+    <feature name="openhab-persistence-jdbc-h2" description="JDBC Persistence H2" version="${project.version}">
+        <configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jdbc</configfile>
+        <feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
+        <feature prerequisite="false" dependency="false">openhab-runtime-compat1x</feature>
+        <bundle start-level="80">mvn:com.h2database/h2/${h2.version}</bundle>
+        <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jdbc/${project.version}</bundle>
+    </feature>
+    
+    <feature name="openhab-persistence-jdbc-hsqldb" description="JDBC Persistence HSQLDB" version="${project.version}">
+        <configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jdbc</configfile>
+        <feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
+        <feature prerequisite="false" dependency="false">openhab-runtime-compat1x</feature>
+        <bundle start-level="80">mvn:org.hsqldb/hsqldb/${hsqldb.version}</bundle>
+        <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jdbc/${project.version}</bundle>
+    </feature>
+    
+    <feature name="openhab-persistence-jdbc-mariadb" description="JDBC Persistence MariaDB" version="${project.version}">
+        <configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jdbc</configfile>
+        <feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
+        <feature prerequisite="false" dependency="false">openhab-runtime-compat1x</feature>
+        <bundle start-level="80">mvn:org.mariadb.jdbc/mariadb-java-client/${mariadb.version}</bundle>
+        <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jdbc/${project.version}</bundle>
+    </feature>
+    
+    <feature name="openhab-persistence-jdbc-mysql" description="JDBC Persistence MySQL" version="${project.version}">
+        <configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jdbc</configfile>
+        <feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
+        <feature prerequisite="false" dependency="false">openhab-runtime-compat1x</feature>
+        <bundle start-level="80">mvn:mysql/mysql-connector-java/${mysql.version}</bundle>
+        <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jdbc/${project.version}</bundle>
+    </feature>
+    
+    <feature name="openhab-persistence-jdbc-postgresql" description="JDBC Persistence PostgreSQL" version="${project.version}">
+        <configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jdbc</configfile>
+        <feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
+        <feature prerequisite="false" dependency="false">openhab-runtime-compat1x</feature>
+        <bundle start-level="80">mvn:org.postgresql/postgresql/${postgresql.version}</bundle>
+        <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jdbc/${project.version}</bundle>
+    </feature>
+    
+    <feature name="openhab-persistence-jdbc-sqlite" description="JDBC Persistence SQLite" version="${project.version}">
+        <configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jdbc</configfile>
+        <feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
+        <feature prerequisite="false" dependency="false">openhab-runtime-compat1x</feature>
+        <bundle start-level="80">mvn:org.xerial/sqlite-jdbc/${sqlite.version}</bundle>
+        <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jdbc/${project.version}</bundle>
+    </feature>
+    
     <feature name="openhab-persistence-jpa" description="JPA Persistence" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-runtime-compat1x</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,16 @@
         <maven.compiler.target>1.7</maven.compiler.target>
 
         <repo.url>https://api.bintray.com/maven/openhab/mvn/openhab</repo.url>
+		 
+		<!-- JDBC Databasedriver Versions -->
+		<derby.version>10.12.1.1</derby.version>
+		<h2.version>1.4.191</h2.version>
+		<hsqldb.version>2.3.3</hsqldb.version>
+		<mariadb.version>1.3.5</mariadb.version>
+		<mysql.version>5.1.38</mysql.version>
+		<postgresql.version>9.4-1206-jdbc41</postgresql.version>
+		<sqlite.version>3.8.11.2</sqlite.version>
+		
     </properties>
 
     <packaging>pom</packaging>


### PR DESCRIPTION
Based on this [hints ](https://community.openhab.org/t/jdbc-persistence-heave-from-oh1-to-oh2-esh-choosing-a-namespace/7487/5)added JDBC to OH2 features and PaperUI service configuration.

The JDBC Persistence can be fully installed and configured by the PaperUI now.