### PR TITLE
Trailing whitespace fixes per new IDE setup

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingConfig.java
@@ -17,7 +17,7 @@ import org.openhab.core.binding.BindingConfig;
 /**
  * Binding Configuration class. Represents a binding configuration in
  * the items file to a Z-Wave node.
- * 
+ *
  * @author Victor Belov
  * @author Brian Crosby
  * @author Jan-Willem Spuij
@@ -26,7 +26,7 @@ import org.openhab.core.binding.BindingConfig;
 public class ZWaveBindingConfig implements BindingConfig {
     /**
      * Constructor. Creates a new instance of the ZWaveBindingConfig class.
-     * 
+     *
      * @param nodeId the NodeId the item is bound to
      * @param endpoint the end point in a multi channel node the item is bound to
      * @param arguments the arguments for the binding as a {@link HashMap} of key-value pairs
@@ -46,7 +46,7 @@ public class ZWaveBindingConfig implements BindingConfig {
 
     /**
      * Returns NodeId of bound node.
-     * 
+     *
      * @return the NodeId the item is bound to.
      */
     public int getNodeId() {
@@ -55,7 +55,7 @@ public class ZWaveBindingConfig implements BindingConfig {
 
     /**
      * Returns Multi channel Endpoint of a bound node.
-     * 
+     *
      * @return endpoint the end point in a multi channel node the item is bound to.
      */
     public int getEndpoint() {
@@ -64,7 +64,7 @@ public class ZWaveBindingConfig implements BindingConfig {
 
     /**
      * Returns the arguments entered in the binding string.
-     * 
+     *
      * @return a map of arguments
      */
     public Map<String, String> getArguments() {
@@ -75,7 +75,7 @@ public class ZWaveBindingConfig implements BindingConfig {
      * Returns the interval at which the item should be refreshed.
      * 0 (zero) indicates that the item should not be refreshed.
      * null indicates that the default should be used.
-     * 
+     *
      * @return the refreshInterval
      */
     public Integer getRefreshInterval() {
@@ -86,7 +86,7 @@ public class ZWaveBindingConfig implements BindingConfig {
      * Sets the interval at which the item should be refreshed.
      * 0 (zero) indicates that the item should not be refreshed.
      * null indicates that the default should be used.
-     * 
+     *
      * @param refreshInterval the refreshInterval to set
      */
     public void setRefreshInterval(Integer refreshInterval) {
@@ -95,7 +95,7 @@ public class ZWaveBindingConfig implements BindingConfig {
 
     /**
      * Returns the date when the item was last refreshed.
-     * 
+     *
      * @return the lastRefreshed
      */
     public Date getLastRefreshed() {
@@ -104,7 +104,7 @@ public class ZWaveBindingConfig implements BindingConfig {
 
     /**
      * Sets the date when the item was last refreshed.
-     * 
+     *
      * @param lastRefreshed the lastRefreshed to set
      */
     public void setLastRefreshed(Date lastRefreshed) {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingProvider.java
@@ -14,7 +14,7 @@ import org.openhab.core.items.Item;
 /**
  * Binding provider interface. Defines the methods
  * to interact with the binding provider.
- * 
+ *
  * @author Victor Belov
  * @since 1.3.0
  */
@@ -22,7 +22,7 @@ public interface ZWaveBindingProvider extends AutoUpdateBindingProvider {
     /**
      * Returns the binding configuration for the item with
      * this name.
-     * 
+     *
      * @param itemName the name to get the binding configuration for.
      * @return the binding configuration.
      */
@@ -31,7 +31,7 @@ public interface ZWaveBindingProvider extends AutoUpdateBindingProvider {
     /**
      * Returns the {@link Item} with the specified item name. Returns null
      * if the item was not found.
-     * 
+     *
      * @param itemName the name of the item.
      * @return the item.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveActivator.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveActivator.java
@@ -28,7 +28,7 @@ public final class ZWaveActivator implements BundleActivator {
 
     /**
      * Called whenever the OSGi framework starts our bundle
-     * 
+     *
      * @param bc the bundle's execution context within the framework
      */
     @Override
@@ -39,7 +39,7 @@ public final class ZWaveActivator implements BundleActivator {
 
     /**
      * Called whenever the OSGi framework stops our bundle
-     * 
+     *
      * @param bc the bundle's execution context within the framework
      */
     @Override
@@ -50,7 +50,7 @@ public final class ZWaveActivator implements BundleActivator {
 
     /**
      * Returns the bundle context of this bundle
-     * 
+     *
      * @return the bundle context
      */
     public static BundleContext getContext() {
@@ -59,7 +59,7 @@ public final class ZWaveActivator implements BundleActivator {
 
     /**
      * Returns the current version of the bundle.
-     * 
+     *
      * @return the current version of the bundle.
      */
     public static Version getVersion() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveGenericBindingProvider.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class is responsible for parsing the binding configuration.
- * 
+ *
  * @author Victor Belov
  * @author Brian Crosby
  * @author Chris Jackson
@@ -125,7 +125,7 @@ public class ZWaveGenericBindingProvider extends AbstractGenericBindingProvider 
 
     /**
      * Returns the binding configuration for a string.
-     * 
+     *
      * @return the binding configuration.
      */
     @Override

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveNetworkMonitor.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveNetworkMonitor.java
@@ -132,7 +132,7 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 
     /**
      * Set the hour that a daily network heal is performed
-     * 
+     *
      * @param time
      *            the hour of the heal (0-23)
      */
@@ -162,7 +162,7 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
     /**
      * Sets the polling period (in milliseconds) between each network health
      * ping.
-     * 
+     *
      * @param time period in seconds
      */
     public void setPollPeriod(Integer time) {
@@ -176,7 +176,7 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 
     /**
      * Configures the binding to perform a soft reset during the heal
-     * 
+     *
      * @param doReset true to enable performing a soft reset on error or heal
      */
     public void resetOnError(boolean doReset) {
@@ -212,7 +212,7 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
     /**
      * Returns true if the node is currently in a healing state or scheduled for
      * a heal.
-     * 
+     *
      * @param nodeId
      *            node to check
      * @return true if healing is ongoing. false if waiting or failed.
@@ -238,7 +238,7 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 
     /**
      * Perform an immediate heal on the specified node
-     * 
+     *
      * @param nodeId
      *            Node to perform the heal on
      * @return true if the heal is scheduled
@@ -282,7 +282,7 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
 
     /**
      * Start a full network heal manually.
-     * 
+     *
      * @return true if the heal is started otherwise false
      */
     public boolean rescheduleHeal() {
@@ -410,7 +410,7 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
      * retries. Each time through the loop it increments the retry counter. If
      * the max retries is exceeded then the failed state is saved and we return
      * to allow other nodes to continue.
-     * 
+     *
      * @param healing
      *            The node on which to perform the heal
      */
@@ -602,7 +602,7 @@ public final class ZWaveNetworkMonitor implements ZWaveEventListener {
     /**
      * Calculates the time (milliseconds) to start the next network
      * heal
-     * 
+     *
      * @return time in milliseconds for next heal.
      */
     private long calculateNextHeal() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/OpenHABConfigurationRecord.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/OpenHABConfigurationRecord.java
@@ -65,7 +65,7 @@ public class OpenHABConfigurationRecord {
 
     /**
      * Constructor for a record.
-     * 
+     *
      * @param domain
      *            Domain in which this record sits. The domain allows the system
      *            to identify a record in a multitierd array. If the domain
@@ -88,7 +88,7 @@ public class OpenHABConfigurationRecord {
 
     /**
      * Constructor for top level domain. This constructor is intended for use with top level domains
-     * 
+     *
      * @param domain
      *            Domain in which this record sits. The domain allows the system
      *            to identify a record in a multitierd array. If the domain
@@ -105,7 +105,7 @@ public class OpenHABConfigurationRecord {
     /**
      * Adds an action to the record. An action will be displayed in the GUI with
      * a button that the user can press.
-     * 
+     *
      * @param key
      * @param value
      */
@@ -119,7 +119,7 @@ public class OpenHABConfigurationRecord {
 
     /**
      * Adds the value to the record
-     * 
+     *
      * @param key
      * @param value
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/OpenHABConfigurationService.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/OpenHABConfigurationService.java
@@ -15,7 +15,7 @@ import java.util.List;
  * This is designed to interface between the REST services, and bindings.
  * The interface uses a domain string to identify different levels of configuration
  * data.
- * 
+ *
  * @author Chris Jackson
  * @since 1.4.0
  *
@@ -23,35 +23,35 @@ import java.util.List;
 public interface OpenHABConfigurationService {
     /**
      * Returns the name of this bundle
-     * 
+     *
      * @return String with the name of the bundle.
      */
     public String getBundleName();
 
     /**
      * Returns the name of this bundle
-     * 
+     *
      * @return String with the name of the bundle.
      */
     public String getCommonName();
 
     /**
      * Returns the name of this bundle
-     * 
+     *
      * @return String with the name of the bundle.
      */
     public String getDescription();
 
     /**
      * Returns the version of this bundle
-     * 
+     *
      * @return String with the name of the bundle.
      */
     public String getVersion();
 
     /**
      * Gets the configuration items for a domain.
-     * 
+     *
      * @param domain
      * @returns
      */
@@ -59,7 +59,7 @@ public interface OpenHABConfigurationService {
 
     /**
      * Sets the configuration items for a domain.
-     * 
+     *
      * @param domain
      * @param records
      */
@@ -67,7 +67,7 @@ public interface OpenHABConfigurationService {
 
     /**
      * Requests an action be performed on a domain.
-     * 
+     *
      * @param domain
      * @param action
      */
@@ -75,7 +75,7 @@ public interface OpenHABConfigurationService {
 
     /**
      * Requests an action be performed on a domain.
-     * 
+     *
      * @param domain
      * @param name
      * @param action

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbAssociationGroup.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbAssociationGroup.java
@@ -14,7 +14,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
 /**
  * This implements the configuration group for the XML product database.
- * 
+ *
  * @author Chris Jackson
  * @since 1.4.0
  *

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbCommandClass.java
@@ -15,7 +15,7 @@ import com.thoughtworks.xstream.annotations.XStreamConverter;
 
 /**
  * Implements a commandclass for the XML product database
- * 
+ *
  * @author Chris Jackson
  * @since 1.4.0
  *

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbConfigurationListItem.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbConfigurationListItem.java
@@ -14,7 +14,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
 /**
  * Implements the configuration list of the XML product database
- * 
+ *
  * @author Chris Jackson
  * @since 1.4.0
  *

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbConfigurationParameter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbConfigurationParameter.java
@@ -14,7 +14,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
 /**
  * Implements the configuration parameters for the XML product database
- * 
+ *
  * @author Chris Jackson
  * @since 1.4.0
  *

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbLabel.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbLabel.java
@@ -14,7 +14,7 @@ import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
 
 /**
  * Implements a label class for the XML product database
- * 
+ *
  * @author Chris Jackson
  * @since 1.4.0
  *

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbManufacturer.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbManufacturer.java
@@ -17,7 +17,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
 /**
  * Implements the manufacturer class for the XML product database
- * 
+ *
  * @author Chris Jackson
  * @since 1.4.0
  *

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbProduct.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbProduct.java
@@ -18,7 +18,7 @@ import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
 
 /**
  * Implements the product class for the XML product database
- * 
+ *
  * @author Chris Jackson
  * @since 1.4.0
  *

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbProductFile.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbProductFile.java
@@ -15,7 +15,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
 /**
  * Implements the top level class for the product file
- * 
+ *
  * @author Chris Jackson
  * @since 1.4.0
  *

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbProductReference.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveDbProductReference.java
@@ -14,7 +14,7 @@ import com.thoughtworks.xstream.annotations.XStreamConverter;
 
 /**
  * Implements the reference class for the XML product database
- * 
+ *
  * @author Chris Jackson
  * @since 1.4.0
  *

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveProductDatabase.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/config/ZWaveProductDatabase.java
@@ -49,7 +49,7 @@ public class ZWaveProductDatabase {
 
     /**
      * Constructor for the product database
-     * 
+     *
      * @param Language
      *            defines the language in which all labels will be returned
      */
@@ -60,7 +60,7 @@ public class ZWaveProductDatabase {
 
     /**
      * Constructor for the product database
-     * 
+     *
      * @param Language
      *            defines the language in which all labels will be returned
      */
@@ -99,7 +99,7 @@ public class ZWaveProductDatabase {
 
     /**
      * Loads the product file relating to the requested version.
-     * 
+     *
      * @param version the required device version
      * @return filename of the product file
      */
@@ -163,7 +163,7 @@ public class ZWaveProductDatabase {
 
     /**
      * Finds the manufacturer in the database.
-     * 
+     *
      * @param manufacturerId
      * @return true if the manufacturer was found
      */
@@ -187,7 +187,7 @@ public class ZWaveProductDatabase {
 
     /**
      * Finds a product in the database
-     * 
+     *
      * @param manufacturerId
      *            The manufacturer ID
      * @param productType
@@ -207,7 +207,7 @@ public class ZWaveProductDatabase {
     /**
      * Finds a product in the database. FindManufacturer must be called before
      * this function.
-     * 
+     *
      * @param productType
      *            The product type
      * @param productId
@@ -234,7 +234,7 @@ public class ZWaveProductDatabase {
     /**
      * Returns the manufacturer name. FindManufacturer or FindProduct must be
      * called before this method.
-     * 
+     *
      * @return String with the manufacturer name, or null if not found.
      */
     public String getManufacturerName() {
@@ -248,7 +248,7 @@ public class ZWaveProductDatabase {
     /**
      * Returns the manufacturer ID. FindManufacturer or FindProduct must be
      * called before this method.
-     * 
+     *
      * @return Integer with the manufacturer ID, or null if not found.
      */
     public Integer getManufacturerId() {
@@ -261,7 +261,7 @@ public class ZWaveProductDatabase {
 
     /**
      * Returns the product name. FindProduct must be called before this method.
-     * 
+     *
      * @return String with the product name, or null if not found.
      */
     public String getProductName() {
@@ -274,7 +274,7 @@ public class ZWaveProductDatabase {
 
     /**
      * Returns the product model. FindProduct must be called before this method.
-     * 
+     *
      * @return String with the product model, or null if not found.
      */
     public String getProductModel() {
@@ -288,7 +288,7 @@ public class ZWaveProductDatabase {
     /**
      * Returns the number of endpoints from the database. FindProduct must be
      * called before this method.
-     * 
+     *
      * @return number of endpoints
      */
     public Integer getProductEndpoints() {
@@ -302,7 +302,7 @@ public class ZWaveProductDatabase {
     /**
      * Checks if a specific command class is implemented by the device.
      * FindProduct must be called before this method.
-     * 
+     *
      * @param classNumber
      *            the class number to check
      * @return true if the class is supported
@@ -328,7 +328,7 @@ public class ZWaveProductDatabase {
     /**
      * Returns the command classes implemented by the device.
      * FindProduct must be called before this method.
-     * 
+     *
      * @return true if the class is supported
      */
     public List<ZWaveDbCommandClass> getProductCommandClasses() {
@@ -346,7 +346,7 @@ public class ZWaveProductDatabase {
     /**
      * Returns the configuration parameters list. FindProduct must be called
      * before this method.
-     * 
+     *
      * @return List of configuration parameters
      */
     public List<ZWaveDbConfigurationParameter> getProductConfigParameters() {
@@ -360,7 +360,7 @@ public class ZWaveProductDatabase {
     /**
      * Returns the associations list. FindProduct must be called before this
      * method.
-     * 
+     *
      * @return List of association groups
      */
     public List<ZWaveDbAssociationGroup> getProductAssociationGroups() {
@@ -380,7 +380,7 @@ public class ZWaveProductDatabase {
      * Helper function to find the label associated with the specified database
      * language If no language is defined, or if the label cant be found in the
      * specified language the english label will be returned.
-     * 
+     *
      * @param labelList
      *            A List defining the label
      * @return String of the respective language
@@ -405,7 +405,7 @@ public class ZWaveProductDatabase {
     /**
      * enum defining the languages used for the multilingual labels in the
      * product database
-     * 
+     *
      */
     public enum Languages {
         ENGLISH("en"),

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmConverter.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * ZWaveAlarmConverter class. Converter for communication with the
  * {@link ZWaveAlarmCommandClass}. Implements polling of the alarm
  * status and receiving of alarm events.
- * 
+ *
  * @author Chris Jackson
  * @since 1.6.0
  */
@@ -45,7 +45,7 @@ public class ZWaveAlarmConverter extends ZWaveCommandClassConverter<ZWaveAlarmCo
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveAlarmConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmSensorConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveAlarmSensorConverter.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * ZWaveAlarmSensorConverter class. Converter for communication with the
  * {@link ZWaveAlarmSensorCommandClass}. Implements polling of the alarm sensor
  * status and receiving of alarm sensor events.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */
@@ -45,7 +45,7 @@ public class ZWaveAlarmSensorConverter extends ZWaveCommandClassConverter<ZWaveA
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveAlarmSensorConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveBasicConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveBasicConverter.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * through the BASIC command class. Note that some devices report their
  * status as BASIC Report messages as well. We try to handle these devices
  * as best as possible.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */
@@ -49,7 +49,7 @@ public class ZWaveBasicConverter extends ZWaveCommandClassConverter<ZWaveBasicCo
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveBasicConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveBatteryConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveBatteryConverter.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * ZWaveBatteryConverter class. Converter for communication with the
  * {@link ZWaveBatteryCommandClass}. Implements polling of the battery
  * status and receiving of battery events.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */
@@ -41,7 +41,7 @@ public class ZWaveBatteryConverter extends ZWaveCommandClassConverter<ZWaveBatte
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveBatteryConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveBinarySensorConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveBinarySensorConverter.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * ZWaveBinarySensorConverter class. Converter for communication with the
  * {@link ZWaveBinarySensorConverter}. Implements polling of the binary sensor
  * status and receiving of binary sensor events.
- * 
+ *
  * @author Jan-Willem Spuij
  * @author Chris Jackson
  * @since 1.4.0
@@ -46,7 +46,7 @@ public class ZWaveBinarySensorConverter extends ZWaveCommandClassConverter<ZWave
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveBinarySensorConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveBinarySwitchConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveBinarySwitchConverter.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * ZWaveBinarySwitchConverter class. Converter for communication with the
  * {@link ZWaveBatteryCommandClass}. Implements polling of the battery
  * status and receiving of battery events.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */
@@ -46,7 +46,7 @@ public class ZWaveBinarySwitchConverter extends ZWaveCommandClassConverter<ZWave
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveBinarySwitchConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveCommandClassConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveCommandClassConverter.java
@@ -23,7 +23,7 @@ import org.openhab.core.types.Command;
  * ZWaveCommandClassConverter class. Base class for all converters
  * that convert between Z-Wave command classes and openHAB
  * items.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  * @param <COMMAND_CLASS_TYPE> the {@link ZWaveCommandClass} that this converter converts for.
@@ -34,7 +34,7 @@ public abstract class ZWaveCommandClassConverter<COMMAND_CLASS_TYPE extends ZWav
     /**
      * Constructor. Creates a new instance of the {@link ZWaveCommandClassConverter}
      * class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use to send messages.
      * @param eventPublisher the {@link EventPublisher} that can be used to send updates.
      */
@@ -45,7 +45,7 @@ public abstract class ZWaveCommandClassConverter<COMMAND_CLASS_TYPE extends ZWav
     /**
      * Execute refresh method. This method is called every time a binding item is
      * refreshed and the corresponding node should be sent a message.
-     * 
+     *
      * @param node the {@link ZWaveNode} that is bound to the item.
      * @param commandClass the {@link ZWaveCommandClass} that will be used to send a polling message.
      * @param endpointId the endpoint id to send the message.
@@ -57,7 +57,7 @@ public abstract class ZWaveCommandClassConverter<COMMAND_CLASS_TYPE extends ZWav
      * Handles an incoming {@link ZWaveCommandClassValueEvent}. Implement
      * this message in derived classes to convert the value and post an
      * update on the openHAB bus.
-     * 
+     *
      * @param event the received {@link ZWaveCommandClassValueEvent}.
      * @param item the {@link Item} that should receive the event.
      */
@@ -66,7 +66,7 @@ public abstract class ZWaveCommandClassConverter<COMMAND_CLASS_TYPE extends ZWav
     /**
      * Receives a command from openHAB and translates it to an operation
      * on the Z-Wave network.
-     * 
+     *
      * @param command the received command
      * @param node the {@link ZWaveNode} to send the command to
      * @param commandClass the {@link ZWaveCommandClass} to send the command to.

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConfigurationConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConfigurationConverter.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 /***
  * ZWaveConfigurationConverter class. Converter for communication with the
  * {@link ZWaveConfigurationCommandClass}.
- * 
+ *
  * @author Chris Jackson
  * @since 1.7.0
  */
@@ -48,7 +48,7 @@ public class ZWaveConfigurationConverter extends ZWaveCommandClassConverter<ZWav
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveConfigurationConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterBase.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterBase.java
@@ -28,7 +28,7 @@ import org.openhab.core.types.State;
  * ZWaveConverterBase class. Base class for all converters
  * that convert between the Z-Wave API and openHAB
  * items.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */
@@ -42,7 +42,7 @@ public abstract class ZWaveConverterBase {
     /**
      * Constructor. Creates a new instance of the {@link ZWaveConverterBase}
      * class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use to send messages.
      * @param eventPublisher the {@link EventPublisher} that can be used to send updates.
      */
@@ -54,7 +54,7 @@ public abstract class ZWaveConverterBase {
     /**
      * Returns the {@link EventPublisher} that can be used
      * inside the converter to publish event updates.
-     * 
+     *
      * @return the eventPublisher
      */
     protected EventPublisher getEventPublisher() {
@@ -63,7 +63,7 @@ public abstract class ZWaveConverterBase {
 
     /**
      * Returns the {@link ZWaveController} that is used to send messages.
-     * 
+     *
      * @return the controller to use to send messages.
      */
     protected ZWaveController getController() {
@@ -72,7 +72,7 @@ public abstract class ZWaveConverterBase {
 
     /**
      * Add a {@link ZWaveStateConverter} to the map of converters for fast lookup.
-     * 
+     *
      * @param converter the {@link ZWaveStateConverter} to add.
      */
     protected void addStateConverter(ZWaveStateConverter<?, ?> converter) {
@@ -81,7 +81,7 @@ public abstract class ZWaveConverterBase {
 
     /**
      * Add a {@link ZWaveStateConverter} to the map of converters for fast lookup.
-     * 
+     *
      * @param converter the {@link ZWaveStateConverter} to add.
      */
     protected void addCommandConverter(ZWaveCommandConverter<?, ?> converter) {
@@ -91,7 +91,7 @@ public abstract class ZWaveConverterBase {
     /**
      * Returns the default Refresh interval for the converter to use.
      * 0 (zero) indicates that the converter does not refresh by default or does not support it.
-     * 
+     *
      * @return the refresh interval for this converter.
      */
     abstract int getRefreshInterval();
@@ -99,7 +99,7 @@ public abstract class ZWaveConverterBase {
     /**
      * Gets a {@link ZWaveStateConverter} that is suitable for this {@link CommandClass} and the data types supported by
      * the {@link Item}
-     * 
+     *
      * @param commandClass the {@link CommandClass} that sent the value.
      * @param item the {@link Item} that has to receive the State;
      * @return a converter object that converts between the value and the state;
@@ -127,7 +127,7 @@ public abstract class ZWaveConverterBase {
 
     /**
      * Gets a {@link ZWaveCommandConverter} that is suitable for this {@link CommandClass}
-     * 
+     *
      * @param commandClass the {@link CommandClass} that sent the value.
      * @return a converter object that converts between the value and the state;
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterHandler.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveConverterHandler.java
@@ -53,7 +53,7 @@ public class ZWaveConverterHandler {
     /**
      * Constructor. Creates a new instance of the @ link ZWaveConverterHandler}
      * class.
-     * 
+     *
      * @param controller
      *            the {@link ZWaveController} to use to send messages.
      * @param eventPublisher
@@ -117,7 +117,7 @@ public class ZWaveConverterHandler {
 
     /**
      * Returns a converter to convert between the Z-Wave API and the binding.
-     * 
+     *
      * @param commandClass
      *            the {@link CommandClass} to create a converter for.
      * @return a {@link ZWaveCommandClassConverter} or null if a converter is
@@ -130,7 +130,7 @@ public class ZWaveConverterHandler {
     /**
      * Returns the command class that provides the best suitable converter to
      * convert between the Z-Wave API and the binding.
-     * 
+     *
      * @param item
      *            the {@link item} to resolve a converter for.
      * @param node
@@ -166,7 +166,7 @@ public class ZWaveConverterHandler {
     /**
      * Execute refresh method. This method is called every time a binding item
      * is refreshed and the corresponding node should be sent a message.
-     * 
+     *
      * @param provider
      *            the {@link ZWaveBindingProvider} that provides the item
      * @param itemName
@@ -268,7 +268,7 @@ public class ZWaveConverterHandler {
 
     /**
      * Get the refresh interval for an item binding
-     * 
+     *
      * @param provider
      *            the {@link ZWaveBindingProvider} that provides the item
      * @param itemName
@@ -338,7 +338,7 @@ public class ZWaveConverterHandler {
      * Handles an incoming {@link ZWaveCommandClassValueEvent}. Implement this
      * message in derived classes to convert the value and post an update on the
      * openHAB bus.
-     * 
+     *
      * @param provider
      *            the {@link ZWaveBindingProvider} that provides the item
      * @param itemName
@@ -381,7 +381,7 @@ public class ZWaveConverterHandler {
     /**
      * Receives a command from openHAB and translates it to an operation on the
      * Z-Wave network.
-     * 
+     *
      * @param provider
      *            the {@link ZWaveBindingProvider} that provides the item
      * @param itemName

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveIndicatorConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveIndicatorConverter.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 /***
  * ZWaveIndicatorConverter class. Converter for communication with the
  * {@link ZWaveIndicatorCommandClass}.
- * 
+ *
  * @author Pedro Paixao
  * @since 1.8.0
  */
@@ -57,7 +57,7 @@ public class ZWaveIndicatorConverter extends ZWaveCommandClassConverter<ZWaveInd
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveIndicatorConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */
@@ -89,7 +89,7 @@ public class ZWaveIndicatorConverter extends ZWaveCommandClassConverter<ZWaveInd
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * Process Z-Wave Indicator Report events. Apply any pending changes (see receiveCommand) and if
      * indicator is changed in any way issue an INDICATOR_SET message to update the node's indicator value
      */
@@ -206,15 +206,15 @@ public class ZWaveIndicatorConverter extends ZWaveCommandClassConverter<ZWaveInd
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * The node's indicator status can change at any time, and without the knowledge of the Z-Wave binding so
      * before any changes are made to the indicator we need to get it's actual value from the device.
      * Hence the receiveCommand method adds the desired command to a "pending" list, and issues an INDICATOR_GET
      * it does not change the actual device Indicator value.
-     * 
+     *
      * When the node responds with the INDICATOR_REPORT pending commands are applied to the indicator value
      * and the result is then sent to the node. This is performed in the handleEvent() method.
-     * 
+     *
      * Pending changes are stored in a hash of hashes with the following keys "ItemName" and "bit" value is 1
      * for turn bit ON, -1 to turn the bound bit OFF, 0 no change.
      *

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveInfoConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveInfoConverter.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 /**
  * ZWaveInfoConverter class. Converters between binding items
  * and the Z-Wave API to gather statistic information.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */
@@ -42,7 +42,7 @@ public class ZWaveInfoConverter extends ZWaveConverterBase {
     /**
      * Constructor. Creates a new instance of the {@link ZWaveConverterBase}
      * class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use to send messages.
      * @param eventPublisher the {@link EventPublisher} that can be used to send updates.
      */
@@ -61,7 +61,7 @@ public class ZWaveInfoConverter extends ZWaveConverterBase {
     /**
      * Execute refresh method. This method is called every time a binding item is
      * refreshed and information for the corresponding node should be looked up.
-     * 
+     *
      * @param item the item to refresh.
      * @param node the {@link ZWaveNode} that is bound to the item.
      * @param endpointId the endpoint id to send the message.
@@ -168,7 +168,7 @@ public class ZWaveInfoConverter extends ZWaveConverterBase {
     /**
      * Z-Wave information item enumeration. It Defines the information that can be
      * requested by the binding on the item.
-     * 
+     *
      * @author Jan-Willem Spuij
      * @author Brian Crosby
      * @since 1.3.0
@@ -306,7 +306,7 @@ public class ZWaveInfoConverter extends ZWaveConverterBase {
 
         /**
          * Returns the label of the ZWaveInformationItem enumeration
-         * 
+         *
          * @return the label
          */
         public String getLabel() {
@@ -316,7 +316,7 @@ public class ZWaveInfoConverter extends ZWaveConverterBase {
         /**
          * Lookup function based on the binding information label.
          * Returns null if the binding information item is not found.
-         * 
+         *
          * @param label the label to lookup
          * @return enumeration value of the binding information item.
          */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMeterConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMeterConverter.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * ZWaveMultiLevelSensorConverter class. Converter for communication with the
  * {@link ZWaveMultiLevelSensorCommandClass}. Implements polling of the sensor
  * status and receiving of sensor events.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */
@@ -46,7 +46,7 @@ public class ZWaveMeterConverter extends ZWaveCommandClassConverter<ZWaveMeterCo
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveMeterConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMultiLevelSensorConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMultiLevelSensorConverter.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * ZWaveMultiLevelSensorConverter class. Converter for communication with the
  * {@link ZWaveMultiLevelSensorCommandClass}. Implements polling of the sensor
  * status and receiving of sensor events.
- * 
+ *
  * @author Jan-Willem Spuij
  * @author Chris Jackson
  * @since 1.4.0
@@ -50,7 +50,7 @@ public class ZWaveMultiLevelSensorConverter extends ZWaveCommandClassConverter<Z
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveMultiLevelSensorConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMultiLevelSwitchConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveMultiLevelSwitchConverter.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
  * ZWaveBinarySwitchConverter class. Converter for communication with the
  * {@link ZWaveBatteryCommandClass}. Implements polling of the battery
  * status and receiving of battery events.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */
@@ -65,7 +65,7 @@ public class ZWaveMultiLevelSwitchConverter extends ZWaveCommandClassConverter<Z
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveMultiLevelSwitchConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSceneConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSceneConverter.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 /**
  * ZWaveSceneConverter class. Converters between binding items
  * and the Z-Wave API for scene controllers.
- * 
+ *
  * @author Chris Jackson
  * @since 1.4.0
  */
@@ -40,7 +40,7 @@ public class ZWaveSceneConverter extends ZWaveCommandClassConverter<ZWaveSceneAc
     /**
      * Constructor. Creates a new instance of the {@link ZWaveConverterBase}
      * class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use to send messages.
      * @param eventPublisher the {@link EventPublisher} that can be used to send updates.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSwitchAllConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveSwitchAllConverter.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 /***
  * ZWaveSwitchAllConverter class. Converter for communication with the
  * {@link ZWaveSwitchAllCommandClass}. Implements All On/All Off.
- * 
+ *
  * @author Pedro Paixao
  * @since 1.8.0
  */
@@ -42,7 +42,7 @@ public class ZWaveSwitchAllConverter extends ZWaveCommandClassConverter<ZWaveSwi
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveSwitchAllConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveThermostatFanModeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveThermostatFanModeConverter.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * ZWaveThermostatFanModeConverter class. Converter for communication with the
  * {@link ZWaveThermostatFanModeCommandClass}. Implements polling of the fan
  * mode state and receiving of fan mode events.
- * 
+ *
  * @author Dan Cunningham
  * @since 1.6.0
  */
@@ -41,7 +41,7 @@ public class ZWaveThermostatFanModeConverter extends ZWaveCommandClassConverter<
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveThermostatFanModeConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveThermostatFanStateConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveThermostatFanStateConverter.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  * ZWaveThermostatFanStateConverter class. Converter for communication with the
  * {@link ZWaveThermostatFanStateCommandClass}. Implements polling of the fan
  * state and receiving of fan state events.
- * 
+ *
  * @author Dan Cunningham
  * @since 1.6.0
  */
@@ -39,7 +39,7 @@ public class ZWaveThermostatFanStateConverter extends ZWaveCommandClassConverter
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveThermostatFanStateConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveThermostatModeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveThermostatModeConverter.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * ZWaveThermostatModeConverter class. Converter for communication with the
  * {@link ZWaveThermostatModeCommandClass}. Implements polling of the mode
  * state and receiving of mode state events.
- * 
+ *
  * @author Dan Cunningham
  * @since 1.6.0
  */
@@ -41,7 +41,7 @@ public class ZWaveThermostatModeConverter extends ZWaveCommandClassConverter<ZWa
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveThermostatModeConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveThermostatOperatingStateConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveThermostatOperatingStateConverter.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  * ZWaveThermostatOperatingStateConverter class. Converter for communication with the
  * {@link ZWaveThermostatOperatingStateCommandClass}. Implements polling of the operating
  * state and receiving of operating state events.
- * 
+ *
  * @author Dan Cunningham
  * @since 1.6.0
  */
@@ -40,7 +40,7 @@ public class ZWaveThermostatOperatingStateConverter
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveThermostatOperatingStateConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveThermostatSetpointConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/ZWaveThermostatSetpointConverter.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * ZWaveThermostatSetpointConverter class. Converter for communication with the
  * {@link ZWaveThermostatSetpointCommandClass}. Implements polling of the setpoint
  * status and receiving of setpoint events.
- * 
+ *
  * @author Matthew Bowman
  * @author Dave Hock
  * @author Chris Jackson
@@ -46,7 +46,7 @@ public class ZWaveThermostatSetpointConverter extends ZWaveCommandClassConverter
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveThermostatSetpointConverter} class.
-     * 
+     *
      * @param controller the {@link ZWaveController} to use for sending messages.
      * @param eventPublisher the {@link EventPublisher} to use to publish events.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/BigDecimalCommandConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/BigDecimalCommandConverter.java
@@ -15,7 +15,7 @@ import org.openhab.core.library.types.DecimalType;
 
 /**
  * Converts from {@link DecimalType} command to a Z-Wave value.
- * 
+ *
  * @author Matthew Bowman
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/BinaryOnOffCommandConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/BinaryOnOffCommandConverter.java
@@ -13,7 +13,7 @@ import org.openhab.core.library.types.OnOffType;
 
 /**
  * Converts from {@link OnOffType} command to a Z-Wave value.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/BinaryPercentCommandConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/BinaryPercentCommandConverter.java
@@ -13,7 +13,7 @@ import org.openhab.core.library.types.PercentType;
 
 /**
  * Converts from {@link PercentType} command to a Z-Wave value.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/IntegerCommandConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/IntegerCommandConverter.java
@@ -13,7 +13,7 @@ import org.openhab.core.library.types.DecimalType;
 
 /**
  * Converts from {@link DecimalType} command to a Z-Wave value.
- * 
+ *
  * @author Chris Jackson
  * @since 1.7.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/MultiLevelIncreaseDecreaseCommandConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/MultiLevelIncreaseDecreaseCommandConverter.java
@@ -14,7 +14,7 @@ import org.openhab.core.library.types.PercentType;
 
 /**
  * Converts from {@link IncreaseDecreaseType} command to a Z-Wave value.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/MultiLevelOnOffCommandConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/MultiLevelOnOffCommandConverter.java
@@ -13,7 +13,7 @@ import org.openhab.core.library.types.OnOffType;
 
 /**
  * Converts from {@link OnOffType} command to a Z-Wave value.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/MultiLevelPercentCommandConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/MultiLevelPercentCommandConverter.java
@@ -13,7 +13,7 @@ import org.openhab.core.library.types.PercentType;
 
 /**
  * Converts from {@link PercentType} command to a Z-Wave value.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/MultiLevelUpDownCommandConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/MultiLevelUpDownCommandConverter.java
@@ -13,7 +13,7 @@ import org.openhab.core.library.types.UpDownType;
 
 /**
  * Converts from {@link UpDownType} command to a Z-Wave value.
- * 
+ *
  * @author Ben Jones
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/RestoreValueMultiLevelOnOffCommandConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/RestoreValueMultiLevelOnOffCommandConverter.java
@@ -14,7 +14,7 @@ import org.openhab.core.library.types.OnOffType;
 /**
  * Converts from {@link OnOffType} command to a Z-Wave value.
  * Restores the dimmer to the last value it had.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/ZWaveCommandConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/command/ZWaveCommandConverter.java
@@ -16,7 +16,7 @@ import org.openhab.core.types.Command;
 /**
  * Abstract base class for converting item commands to
  * Z-Wave command class commands.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  * @param <OPENHAB_TYPE> the command to convert
@@ -26,7 +26,7 @@ public abstract class ZWaveCommandConverter<OPENHAB_TYPE extends Command, ZWAVE_
 
     /**
      * Returns the type of the openHAB {@link Command} that this {@link ZWaveCommandConverter} converts to.
-     * 
+     *
      * @return the supported {@link Command}
      */
     @SuppressWarnings("unchecked")
@@ -37,7 +37,7 @@ public abstract class ZWaveCommandConverter<OPENHAB_TYPE extends Command, ZWAVE_
 
     /**
      * Converts a an OpenHab command to a Z-Wave value.
-     * 
+     *
      * @param command the {@link Command} to convert.
      * @param item the item to convert the command for.
      * @return the Z-Wave value to convert to.
@@ -46,7 +46,7 @@ public abstract class ZWaveCommandConverter<OPENHAB_TYPE extends Command, ZWAVE_
 
     /**
      * Converts a an OpenHab command to a Z-Wave value.
-     * 
+     *
      * @param command the {@link Command} to convert.
      * @param item the item to convert the command for.
      * @return the Z-Wave value to convert to.

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BatteryDecimalTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BatteryDecimalTypeConverter.java
@@ -13,7 +13,7 @@ import org.openhab.core.library.types.DecimalType;
 /**
  * Converts from a {@link Integer} to a {@link DecimalType}
  * Only processes for the BATTERY command class.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BatteryPercentTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BatteryPercentTypeConverter.java
@@ -13,7 +13,7 @@ import org.openhab.core.library.types.PercentType;
 /**
  * Converts from a {@link Integer} to a {@link PercentType}
  * Only processes for the BATTERY command class.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BigDecimalDecimalTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BigDecimalDecimalTypeConverter.java
@@ -14,7 +14,7 @@ import org.openhab.core.library.types.DecimalType;
 
 /**
  * Converts from an {@link BigDecimal} to a {@link DecimalType}
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BigDecimalOnOffTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BigDecimalOnOffTypeConverter.java
@@ -14,7 +14,7 @@ import org.openhab.core.library.types.OnOffType;
 
 /**
  * Converts from big decimal Z-Wave value to a {@link OnOffType}
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BigDecimalOpenClosedTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BigDecimalOpenClosedTypeConverter.java
@@ -14,7 +14,7 @@ import org.openhab.core.library.types.OpenClosedType;
 
 /**
  * Converts from a Z-Wave big decimal value to a {@link OpenClosedType}
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BinaryDecimalTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BinaryDecimalTypeConverter.java
@@ -12,7 +12,7 @@ import org.openhab.core.library.types.DecimalType;
 
 /**
  * Converts from a binary Z-Wave value to a {@link DecimalType}
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BinaryPercentTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BinaryPercentTypeConverter.java
@@ -12,7 +12,7 @@ import org.openhab.core.library.types.PercentType;
 
 /**
  * Converts from a binary Z-Wave value to a {@link PercentType}
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BooleanOnOffTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BooleanOnOffTypeConverter.java
@@ -12,7 +12,7 @@ import org.openhab.core.library.types.OnOffType;
 
 /**
  * Converts from Z-Wave boolean value to a {@link OnOffType}
- * 
+ *
  * @author Ben Jones
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BooleanOpenClosedTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/BooleanOpenClosedTypeConverter.java
@@ -12,7 +12,7 @@ import org.openhab.core.library.types.OpenClosedType;
 
 /**
  * Converts from a Z-Wave boolean value to a {@link OpenClosedType}
- * 
+ *
  * @author Ben Jones
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/DateDateTimeTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/DateDateTimeTypeConverter.java
@@ -15,7 +15,7 @@ import org.openhab.core.library.types.DateTimeType;
 
 /**
  * Converts from a {@link Date} to a {@link DateTimeType}
- * 
+ *
  * @author Ben Jones
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/IntegerDecimalTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/IntegerDecimalTypeConverter.java
@@ -12,7 +12,7 @@ import org.openhab.core.library.types.DecimalType;
 
 /**
  * Converts from an {@link Integer} to a {@link DecimalType}
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/IntegerOnOffTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/IntegerOnOffTypeConverter.java
@@ -12,7 +12,7 @@ import org.openhab.core.library.types.OnOffType;
 
 /**
  * Converts from integer Z-Wave value to a {@link OnOffType}
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/IntegerOpenClosedTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/IntegerOpenClosedTypeConverter.java
@@ -12,7 +12,7 @@ import org.openhab.core.library.types.OpenClosedType;
 
 /**
  * Converts from a Z-Wave integer value to a {@link OpenClosedType}
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/IntegerPercentTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/IntegerPercentTypeConverter.java
@@ -12,7 +12,7 @@ import org.openhab.core.library.types.PercentType;
 
 /**
  * Converts from a {@link Integer} to a {@link PercentType}
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/IntegerUpDownTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/IntegerUpDownTypeConverter.java
@@ -12,7 +12,7 @@ import org.openhab.core.library.types.UpDownType;
 
 /**
  * Converts from a {@link Integer} to a {@link UpDownType}
- * 
+ *
  * @author Ben Jones
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/StateComparator.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/StateComparator.java
@@ -16,7 +16,7 @@ import org.openhab.core.types.State;
 /**
  * State Comparator class. Compares two States to determine which one is more
  * specific.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/StringStringTypeConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/StringStringTypeConverter.java
@@ -12,7 +12,7 @@ import org.openhab.core.library.types.StringType;
 
 /**
  * Converts from a {@link String} to a {@link StringType}
- * 
+ *
  * @author Ben Jones
  * @since 1.4.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/ZWaveStateConverter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/converter/state/ZWaveStateConverter.java
@@ -14,7 +14,7 @@ import org.openhab.core.types.State;
 
 /**
  * Converts raw Z-Wave values to openHAB states.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  * @param <ZWAVE_TYPE> the type of the raw Z-Wave value.
@@ -24,7 +24,7 @@ public abstract class ZWaveStateConverter<ZWAVE_TYPE, OPENHAB_TYPE extends State
 
     /**
      * Returns the type of the openHAB {@link State} that this {@link ZWaveStateConverter} converts to.
-     * 
+     *
      * @return the supported {@link State}
      */
     @SuppressWarnings("unchecked")
@@ -35,7 +35,7 @@ public abstract class ZWaveStateConverter<ZWAVE_TYPE, OPENHAB_TYPE extends State
 
     /**
      * Returns the type the state converter converts from.
-     * 
+     *
      * @return the supported Z-Wave type
      */
     public Class<?> getType() {
@@ -44,7 +44,7 @@ public abstract class ZWaveStateConverter<ZWAVE_TYPE, OPENHAB_TYPE extends State
 
     /**
      * Converts a Z-Wave value to an OpenHab state.
-     * 
+     *
      * @param value the Z-Wave value to convert.
      * @return the openHAB state to convert to.
      */
@@ -52,7 +52,7 @@ public abstract class ZWaveStateConverter<ZWAVE_TYPE, OPENHAB_TYPE extends State
 
     /**
      * Converts a Z-Wave value to an OpenHab state.
-     * 
+     *
      * @param value the Z-Wave value to convert.
      * @return the openHAB state to convert to.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ConfigurationParameter.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ConfigurationParameter.java
@@ -13,7 +13,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 /**
  * This class provides a storage class for zwave configuration parameters
  * within the configuration command class. This is then serialized to XML.
- * 
+ *
  * @author Chris Jackson
  * @since 1.4.0
  *
@@ -29,7 +29,7 @@ public class ConfigurationParameter {
 
     /***
      * Constructor. Creates a new instance of the {@link ConfigurationParameter} class.
-     * 
+     *
      * @param index. The parameter index.
      * @param value. The parameter value;
      * @throws IllegalArgumentException thrown when the index or size arguments are out of range.
@@ -51,7 +51,7 @@ public class ConfigurationParameter {
 
     /**
      * Gets the configuration parameter value
-     * 
+     *
      * @return the value
      */
     public Integer getValue() {
@@ -60,7 +60,7 @@ public class ConfigurationParameter {
 
     /**
      * Sets the configuration parameter value.
-     * 
+     *
      * @param value the value to set
      */
     public void setValue(Integer value) throws IllegalArgumentException {
@@ -69,7 +69,7 @@ public class ConfigurationParameter {
 
     /**
      * Returns the parameter index.
-     * 
+     *
      * @return the index
      */
     public Integer getIndex() {
@@ -78,7 +78,7 @@ public class ConfigurationParameter {
 
     /**
      * Returns the parameter size.
-     * 
+     *
      * @return the size
      */
     public Integer getSize() {
@@ -87,7 +87,7 @@ public class ConfigurationParameter {
 
     /**
      * Sets the parameter as a WriteOnly parameter
-     * 
+     *
      * @param write true if the parameter should not be read
      */
     public void setWriteOnly(boolean write) {
@@ -96,7 +96,7 @@ public class ConfigurationParameter {
 
     /**
      * Returns true if this parameter is write only
-     * 
+     *
      * @return true if the parameter should not be read back
      */
     public boolean getWriteOnly() {
@@ -105,7 +105,7 @@ public class ConfigurationParameter {
 
     /**
      * Sets the parameter as a ReadOnly parameter
-     * 
+     *
      * @param read true if the parameters is readonly
      */
     public void setReadOnly(boolean read) {
@@ -114,7 +114,7 @@ public class ConfigurationParameter {
 
     /**
      * Returns true if this parameter is read only
-     * 
+     *
      * @return true if the parameter should not be written to
      */
     public boolean getReadOnly() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialInterfaceException.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialInterfaceException.java
@@ -10,7 +10,7 @@ package org.openhab.binding.zwave.internal.protocol;
 
 /**
  * Exceptions thrown from the serial interface.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.3.0
  */
@@ -26,7 +26,7 @@ public class SerialInterfaceException extends Exception {
 
     /**
      * Constructor. Creates a new instance of SerialInterfaceException.
-     * 
+     *
      * @param message the detail message.
      */
     public SerialInterfaceException(String message) {
@@ -35,7 +35,7 @@ public class SerialInterfaceException extends Exception {
 
     /**
      * Constructor. Creates a new instance of SerialInterfaceException.
-     * 
+     *
      * @param cause the cause. (A null value is permitted, and indicates that the cause is nonexistent or unknown.)
      */
     public SerialInterfaceException(Throwable cause) {
@@ -44,7 +44,7 @@ public class SerialInterfaceException extends Exception {
 
     /**
      * Constructor. Creates a new instance of SerialInterfaceException.
-     * 
+     *
      * @param message the detail message.
      * @param cause the cause. (A null value is permitted, and indicates that the cause is nonexistent or unknown.)
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/SerialMessage.java
@@ -84,7 +84,7 @@ public class SerialMessage {
      * to indicate that a transaction is complete. The priority indicates the
      * priority to send the message with. Higher priority messages are taken from
      * the send queue earlier than lower priority messages.
-     * 
+     *
      * @param messageClass the message class to use
      * @param messageType the message type to use
      * @param expectedReply the expected Reply for this messaage
@@ -101,7 +101,7 @@ public class SerialMessage {
      * to indicate that a transaction is complete. The priority indicates the
      * priority to send the message with. Higher priority messages are taken from
      * the send queue earlier than lower priority messages.
-     * 
+     *
      * @param nodeId the node the message is destined for
      * @param messageClass the message class to use
      * @param messageType the message type to use
@@ -124,7 +124,7 @@ public class SerialMessage {
     /**
      * Constructor. Creates a new instance of the SerialMessage class from a
      * specified buffer.
-     * 
+     *
      * @param buffer the buffer to create the SerialMessage from.
      */
     public SerialMessage(byte[] buffer) {
@@ -134,7 +134,7 @@ public class SerialMessage {
     /**
      * Constructor. Creates a new instance of the SerialMessage class from a
      * specified buffer, and subsequently sets the node ID.
-     * 
+     *
      * @param nodeId the node the message is destined for
      * @param buffer the buffer to create the SerialMessage from.
      */
@@ -162,7 +162,7 @@ public class SerialMessage {
 
     /**
      * Converts a byte array to a hexadecimal string representation
-     * 
+     *
      * @param bb the byte array to convert
      * @return string the string representation
      */
@@ -176,7 +176,7 @@ public class SerialMessage {
 
     /**
      * Calculates a checksum for the specified buffer.
-     * 
+     *
      * @param buffer the buffer to calculate.
      * @return the checksum value.
      */
@@ -203,7 +203,7 @@ public class SerialMessage {
 
     /**
      * Gets the SerialMessage as a byte array.
-     * 
+     *
      * @return the message
      */
     public byte[] getMessageBuffer() {
@@ -252,7 +252,7 @@ public class SerialMessage {
      * - the message type is equal
      * - the expected reply is equal
      * - the payload is equal
-     * 
+     *
      * @param obj the object to compare this message with.
      */
     @Override
@@ -284,7 +284,7 @@ public class SerialMessage {
 
     /**
      * Gets the message type (Request / Response).
-     * 
+     *
      * @return the message type
      */
     public SerialMessageType getMessageType() {
@@ -293,7 +293,7 @@ public class SerialMessage {
 
     /**
      * Gets the message class. This is the function it represents.
-     * 
+     *
      * @return
      */
     public SerialMessageClass getMessageClass() {
@@ -302,7 +302,7 @@ public class SerialMessage {
 
     /**
      * Returns the Node Id for / from this message.
-     * 
+     *
      * @return the messageNode
      */
     public int getMessageNode() {
@@ -311,7 +311,7 @@ public class SerialMessage {
 
     /**
      * Gets the message payload.
-     * 
+     *
      * @return the message payload
      */
     public byte[] getMessagePayload() {
@@ -321,7 +321,7 @@ public class SerialMessage {
     /**
      * Gets a byte of the message payload at the specified index.
      * The byte is returned as an integer between 0x00 (0) and 0xFF (255).
-     * 
+     *
      * @param index the index of the byte to return.
      * @return an integer between 0x00 (0) and 0xFF (255).
      */
@@ -331,7 +331,7 @@ public class SerialMessage {
 
     /**
      * Sets the message payload.
-     * 
+     *
      * @param messagePayload
      */
     public void setMessagePayload(byte[] messagePayload) {
@@ -340,7 +340,7 @@ public class SerialMessage {
 
     /**
      * Gets the transmit options for this SendData Request.
-     * 
+     *
      * @return the transmitOptions
      */
     public int getTransmitOptions() {
@@ -349,7 +349,7 @@ public class SerialMessage {
 
     /**
      * Sets the transmit options for this SendData Request.
-     * 
+     *
      * @param transmitOptions the transmitOptions to set
      */
     public void setTransmitOptions(int transmitOptions) {
@@ -358,7 +358,7 @@ public class SerialMessage {
 
     /**
      * Gets the callback ID for this SendData Request.
-     * 
+     *
      * @return the callbackId
      */
     public int getCallbackId() {
@@ -367,7 +367,7 @@ public class SerialMessage {
 
     /**
      * Sets the callback ID for this SendData Request
-     * 
+     *
      * @param callbackId the callbackId to set
      */
     public void setCallbackId(int callbackId) {
@@ -376,7 +376,7 @@ public class SerialMessage {
 
     /**
      * Gets the expected reply for this message.
-     * 
+     *
      * @return the expectedReply
      */
     public SerialMessageClass getExpectedReply() {
@@ -385,7 +385,7 @@ public class SerialMessage {
 
     /**
      * Returns the priority of this Serial message.
-     * 
+     *
      * @return the priority
      */
     public SerialMessagePriority getPriority() {
@@ -394,7 +394,7 @@ public class SerialMessage {
 
     /**
      * Sets the priority of this Serial message.
-     * 
+     *
      * @param p the new priority
      */
     public void setPriority(SerialMessagePriority p) {
@@ -410,7 +410,7 @@ public class SerialMessage {
 
     /**
      * Indicates that the transaction for the incoming message is canceled by a command class
-     * 
+     *
      * @return the transactionCanceled
      */
     public boolean isTransactionCanceled() {
@@ -434,7 +434,7 @@ public class SerialMessage {
 
     /**
      * Returns true is there is an ack pending from the controller
-     * 
+     *
      * @return true if still waiting on the ack
      */
     public boolean isAckPending() {
@@ -457,7 +457,7 @@ public class SerialMessage {
     /**
      * Serial message type enumeration. Indicates whether the message
      * is a request or a response.
-     * 
+     *
      * @author Jan-Willem Spuij
      * @since 1.3.0
      */
@@ -487,7 +487,7 @@ public class SerialMessage {
      * Normally these are GET commands, but the system overrides the
      * priority to the lowest so they don't cause any impact on the
      * system.
-     * 
+     *
      * @author Jan-Willem Spuij
      * @author Chris Jackson
      * @since 1.3.0
@@ -504,7 +504,7 @@ public class SerialMessage {
     /**
      * Serial message class enumeration. Enumerates the different messages
      * that can be exchanged with the controller.
-     * 
+     *
      * @author Jan-Willem Spuij
      * @since 1.3.0
      */
@@ -607,7 +607,7 @@ public class SerialMessage {
 
         /**
          * Lookup function based on the generic device class code.
-         * 
+         *
          * @param i the code to lookup
          * @return enumeration value of the generic device class.
          */
@@ -620,7 +620,7 @@ public class SerialMessage {
 
         /**
          * Returns the enumeration key.
-         * 
+         *
          * @return the key
          */
         public int getKey() {
@@ -629,7 +629,7 @@ public class SerialMessage {
 
         /**
          * Returns the enumeration label.
-         * 
+         *
          * @return the label
          */
         public String getLabel() {
@@ -640,7 +640,7 @@ public class SerialMessage {
     /**
      * Comparator Class. Compares two serial messages with each other based on
      * node status (awake / sleep), priority and sequence number.
-     * 
+     *
      * @author Jan-Willem Spuij
      * @since 1.3.0
      */
@@ -650,7 +650,7 @@ public class SerialMessage {
 
         /**
          * Constructor. Creates a new instance of the SerialMessageComparator class.
-         * 
+         *
          * @param controller the {@link ZWaveController to use}
          */
         public SerialMessageComparator(ZWaveController controller) {
@@ -660,7 +660,7 @@ public class SerialMessage {
         /**
          * Compares a serial message to another serial message.
          * Used by the priority queue to order messages.
-         * 
+         *
          * @param arg0 the first serial message to compare the other to.
          * @param arg1 the other serial message to compare the first one to.
          */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveEndpoint.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveEndpoint.java
@@ -36,7 +36,7 @@ public class ZWaveEndpoint {
 
     /**
      * Constructor. Creates a new instance of the ZWaveEndpoint class.
-     * 
+     *
      * @param node the parent node of this endpoint.
      * @param endpointId the endpoint ID.
      */
@@ -50,7 +50,7 @@ public class ZWaveEndpoint {
 
     /**
      * Gets the endpoint ID
-     * 
+     *
      * @return endpointId the endpointId
      */
     public int getEndpointId() {
@@ -59,7 +59,7 @@ public class ZWaveEndpoint {
 
     /**
      * Gets the Command classes this endpoint implements.
-     * 
+     *
      * @return the command classes.
      */
     public Collection<ZWaveCommandClass> getCommandClasses() {
@@ -69,7 +69,7 @@ public class ZWaveEndpoint {
     /**
      * Gets a commandClass object this endpoint implements. Returns null if
      * this endpoint does not support this command class.
-     * 
+     *
      * @param commandClass
      *            The command class to get.
      * @return the command class.
@@ -81,7 +81,7 @@ public class ZWaveEndpoint {
     /**
      * Adds a command class to the list of supported command classes by this
      * endpoint. Does nothing if command class is already added.
-     * 
+     *
      * @param commandClass the command class instance to add.
      */
     public void addCommandClass(ZWaveCommandClass commandClass) {
@@ -94,7 +94,7 @@ public class ZWaveEndpoint {
 
     /**
      * Returns the device class for this endpoint.
-     * 
+     *
      * @return the deviceClass
      */
     public ZWaveDeviceClass getDeviceClass() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveEventListener.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveEventListener.java
@@ -13,7 +13,7 @@ import org.openhab.binding.zwave.internal.protocol.event.ZWaveEvent;
 /**
  * ZWave Event Listener interface. Classes that implement this interface
  * need to be able to handle incoming ZWaveEvent events.
- * 
+ *
  * @author Brian Crosby
  * @since 1.3.0
  */
@@ -21,7 +21,7 @@ public interface ZWaveEventListener {
 
     /**
      * Event handler method for incoming Z-Wave events.
-     * 
+     *
      * @param event the incoming Z-Wave event.
      */
     void ZWaveIncomingEvent(ZWaveEvent event);

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNode.java
@@ -40,7 +40,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 /**
  * Z-Wave node class. Represents a node in the Z-Wave network.
- * 
+ *
  * @author Brian Crosby
  * @author Chris Jackson
  * @since 1.3.0
@@ -113,7 +113,7 @@ public class ZWaveNode {
 
     /**
      * Constructor. Creates a new instance of the ZWaveNode class.
-     * 
+     *
      * @param homeId the home ID to use.
      * @param nodeId the node ID to use.
      * @param controller the wave controller instance
@@ -132,7 +132,7 @@ public class ZWaveNode {
      * NOTE: XStream doesn't run any default constructor. So, any initialisation
      * made in a constructor, or statically, won't be performed!!!
      * Set defaults here if it's important!!!
-     * 
+     *
      * @param controller the wave controller instance
      */
     public void setRestoredFromConfigfile(ZWaveController controller) {
@@ -148,7 +148,7 @@ public class ZWaveNode {
 
     /**
      * Gets the node ID.
-     * 
+     *
      * @return the node id
      */
     public int getNodeId() {
@@ -157,7 +157,7 @@ public class ZWaveNode {
 
     /**
      * Gets whether the node is listening.
-     * 
+     *
      * @return boolean indicating whether the node is listening or not.
      */
     public boolean isListening() {
@@ -166,7 +166,7 @@ public class ZWaveNode {
 
     /**
      * Sets whether the node is listening.
-     * 
+     *
      * @param listening
      */
     public void setListening(boolean listening) {
@@ -178,7 +178,7 @@ public class ZWaveNode {
      * Frequently listening is responding to a beam signal. Apart from
      * increased latency, nothing else is noticeable from the serial api
      * side.
-     * 
+     *
      * @return boolean indicating whether the node is frequently
      *         listening or not.
      */
@@ -191,7 +191,7 @@ public class ZWaveNode {
      * Frequently listening is responding to a beam signal. Apart from
      * increased latency, nothing else is noticeable from the serial api
      * side.
-     * 
+     *
      * @param frequentlyListening indicating whether the node is frequently
      *            listening or not.
      */
@@ -201,7 +201,7 @@ public class ZWaveNode {
 
     /**
      * Gets the Heal State of the node.
-     * 
+     *
      * @return String indicating the node Heal State.
      */
     public String getHealState() {
@@ -210,7 +210,7 @@ public class ZWaveNode {
 
     /**
      * Sets the Heal State of the node.
-     * 
+     *
      * @param healState
      */
     public void setHealState(String healState) {
@@ -219,7 +219,7 @@ public class ZWaveNode {
 
     /**
      * Gets whether the node is dead.
-     * 
+     *
      * @return
      */
     public boolean isDead() {
@@ -274,7 +274,7 @@ public class ZWaveNode {
 
     /**
      * Gets the home ID
-     * 
+     *
      * @return the homeId
      */
     public Integer getHomeId() {
@@ -285,7 +285,7 @@ public class ZWaveNode {
      * Gets the node name.
      * If Node Naming Command Class is supported get name from device,
      * else return the name stored in binding
-     * 
+     *
      * @return the name
      */
     public String getName() {
@@ -303,7 +303,7 @@ public class ZWaveNode {
      * Sets the node name.
      * If Node Naming Command Class is supported set name in the device,
      * else set it in locally in the binding
-     * 
+     *
      * @param name the name to set
      */
     public void setName(String name) {
@@ -323,7 +323,7 @@ public class ZWaveNode {
      * Gets the node location.
      * If Node Naming Command Class is supported get location from device,
      * else return the location stored in binding
-     * 
+     *
      * @return the location
      */
     public String getLocation() {
@@ -341,7 +341,7 @@ public class ZWaveNode {
      * Sets the node location.
      * If Node Naming Command Class is supported set location in the device,
      * else set it in locally in the binding
-     * 
+     *
      * @param location the location to set
      */
     public void setLocation(String location) {
@@ -359,7 +359,7 @@ public class ZWaveNode {
 
     /**
      * Gets the manufacturer of the node.
-     * 
+     *
      * @return the manufacturer
      */
     public int getManufacturer() {
@@ -368,7 +368,7 @@ public class ZWaveNode {
 
     /**
      * Sets the manufacturer of the node.
-     * 
+     *
      * @param tempMan the manufacturer to set
      */
     public void setManufacturer(int tempMan) {
@@ -377,7 +377,7 @@ public class ZWaveNode {
 
     /**
      * Gets the device id of the node.
-     * 
+     *
      * @return the deviceId
      */
     public int getDeviceId() {
@@ -386,7 +386,7 @@ public class ZWaveNode {
 
     /**
      * Sets the device id of the node.
-     * 
+     *
      * @param tempDeviceId the device to set
      */
     public void setDeviceId(int tempDeviceId) {
@@ -395,7 +395,7 @@ public class ZWaveNode {
 
     /**
      * Gets the device type of the node.
-     * 
+     *
      * @return the deviceType
      */
     public int getDeviceType() {
@@ -404,7 +404,7 @@ public class ZWaveNode {
 
     /**
      * Sets the device type of the node.
-     * 
+     *
      * @param tempDeviceType the deviceType to set
      */
     public void setDeviceType(int tempDeviceType) {
@@ -413,7 +413,7 @@ public class ZWaveNode {
 
     /**
      * Get the date/time the node was last updated (ie a frame was received from it).
-     * 
+     *
      * @return the lastUpdated time
      */
     public Date getLastReceived() {
@@ -422,7 +422,7 @@ public class ZWaveNode {
 
     /**
      * Get the date/time we last sent a frame to the node.
-     * 
+     *
      * @return the lastSent
      */
     public Date getLastSent() {
@@ -431,7 +431,7 @@ public class ZWaveNode {
 
     /**
      * Gets the node state.
-     * 
+     *
      * @return the nodeState
      */
     public ZWaveNodeState getNodeState() {
@@ -440,7 +440,7 @@ public class ZWaveNode {
 
     /**
      * Gets the node stage.
-     * 
+     *
      * @return the nodeStage
      */
     public ZWaveNodeInitStage getNodeInitializationStage() {
@@ -449,7 +449,7 @@ public class ZWaveNode {
 
     /**
      * Gets the initialization state
-     * 
+     *
      * @return true if initialization has been completed
      */
     public boolean isInitializationComplete() {
@@ -458,7 +458,7 @@ public class ZWaveNode {
 
     /**
      * Sets the node stage.
-     * 
+     *
      * @param nodeStage the nodeStage to set
      */
     public void setNodeStage(ZWaveNodeInitStage nodeStage) {
@@ -467,7 +467,7 @@ public class ZWaveNode {
 
     /**
      * Gets the node version
-     * 
+     *
      * @return the version
      */
     public int getVersion() {
@@ -476,7 +476,7 @@ public class ZWaveNode {
 
     /**
      * Sets the node version.
-     * 
+     *
      * @param version the version to set
      */
     public void setVersion(int version) {
@@ -485,7 +485,7 @@ public class ZWaveNode {
 
     /**
      * Gets the node application firmware version
-     * 
+     *
      * @return the version
      */
     public String getApplicationVersion() {
@@ -506,7 +506,7 @@ public class ZWaveNode {
 
     /**
      * Gets whether the node is routing messages.
-     * 
+     *
      * @return the routing
      */
     public boolean isRouting() {
@@ -515,7 +515,7 @@ public class ZWaveNode {
 
     /**
      * Sets whether the node is routing messages.
-     * 
+     *
      * @param routing the routing to set
      */
     public void setRouting(boolean routing) {
@@ -524,7 +524,7 @@ public class ZWaveNode {
 
     /**
      * Gets the time stamp the node was last queried.
-     * 
+     *
      * @return the queryStageTimeStamp
      */
     public Date getQueryStageTimeStamp() {
@@ -559,7 +559,7 @@ public class ZWaveNode {
 
     /**
      * Returns the device class of the node.
-     * 
+     *
      * @return the deviceClass
      */
     public ZWaveDeviceClass getDeviceClass() {
@@ -568,7 +568,7 @@ public class ZWaveNode {
 
     /**
      * Returns the Command classes this node implements.
-     * 
+     *
      * @return the command classes.
      */
     public Collection<ZWaveCommandClass> getCommandClasses() {
@@ -578,7 +578,7 @@ public class ZWaveNode {
     /**
      * Returns a commandClass object this node implements.
      * Returns null if command class is not supported by this node.
-     * 
+     *
      * @param commandClass The command class to get.
      * @return the command class.
      */
@@ -588,7 +588,7 @@ public class ZWaveNode {
 
     /**
      * Returns whether a node supports this command class.
-     * 
+     *
      * @param commandClass the command class to check
      * @return true if the command class is supported, false otherwise.
      */
@@ -599,7 +599,7 @@ public class ZWaveNode {
     /**
      * Adds a command class to the list of supported command classes by this node.
      * Does nothing if command class is already added.
-     * 
+     *
      * @param commandClass the command class instance to add.
      */
     public void addCommandClass(ZWaveCommandClass commandClass) {
@@ -620,7 +620,7 @@ public class ZWaveNode {
      * Removes a command class from the node.
      * This is used to remove classes that a node may report it supports
      * but it doesn't respond to.
-     * 
+     *
      * @param commandClass The command class key
      */
     public void removeCommandClass(CommandClass commandClass) {
@@ -635,7 +635,7 @@ public class ZWaveNode {
      * first try command classes of endpoints. If not found the return a
      * supported command class on the node itself.
      * Returns null if a command class is not found.
-     * 
+     *
      * @param commandClass The command class to resolve.
      * @param endpointId the endpoint / instance to resolve this command class for.
      * @return the command class.
@@ -686,7 +686,7 @@ public class ZWaveNode {
      * Encapsulates a serial message for sending to a
      * multi-instance instance/ multi-channel endpoint on
      * a node.
-     * 
+     *
      * @param serialMessage the serial message to encapsulate
      * @param commandClass the command class used to generate the message.
      * @param endpointId the instance / endpoint to encapsulate the message for
@@ -735,7 +735,7 @@ public class ZWaveNode {
 
     /**
      * Return a list with the nodes neighbors
-     * 
+     *
      * @return list of node IDs
      */
     public List<Integer> getNeighbors() {
@@ -752,7 +752,7 @@ public class ZWaveNode {
     /**
      * Updates a nodes routing information
      * Generation of routes uses associations
-     * 
+     *
      * @param nodeId
      */
     public ArrayList<Integer> getRoutingList() {
@@ -803,7 +803,7 @@ public class ZWaveNode {
 
     /**
      * Add a node ID to the neighbor list
-     * 
+     *
      * @param nodeId the node to add
      */
     public void addNeighbor(Integer nodeId) {
@@ -812,7 +812,7 @@ public class ZWaveNode {
 
     /**
      * Gets the number of times the node has been determined as DEAD
-     * 
+     *
      * @return dead count
      */
     public int getDeadCount() {
@@ -821,7 +821,7 @@ public class ZWaveNode {
 
     /**
      * Gets the number of times the node has been determined as DEAD
-     * 
+     *
      * @return dead count
      */
     public Date getDeadTime() {
@@ -830,7 +830,7 @@ public class ZWaveNode {
 
     /**
      * Gets the number of packets that have been resent to the node
-     * 
+     *
      * @return retry count
      */
     public int getRetryCount() {
@@ -859,7 +859,7 @@ public class ZWaveNode {
 
     /**
      * Gets the number of packets sent to the node
-     * 
+     *
      * @return send count
      */
     public int getSendCount() {
@@ -869,7 +869,7 @@ public class ZWaveNode {
     /**
      * Gets the applicationUpdateReceived flag.
      * This is set to indicate that we have received the required information from the device
-     * 
+     *
      * @return true if information received
      */
     public boolean getApplicationUpdateReceived() {
@@ -879,7 +879,7 @@ public class ZWaveNode {
     /**
      * Sets the applicationUpdateReceived flag.
      * This is set to indicate that we have received the required information from the device
-     * 
+     *
      * @param received true if received
      */
     public void setApplicationUpdateReceived(boolean received) {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNodeState.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/ZWaveNodeState.java
@@ -10,7 +10,7 @@ package org.openhab.binding.zwave.internal.protocol;
 
 /**
  * Represents the state that the node is in.
- * 
+ *
  * @author Chris Jackson
  * @since 1.7.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmCommandClass.java
@@ -31,7 +31,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 /**
  * Handles the Alarm command class.
  * The event is reported as occurs (0xFF) or does not occur (0x00).
- * 
+ *
  * @author Chris Jackson
  * @since 1.6.0
  */
@@ -56,7 +56,7 @@ public class ZWaveAlarmCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveAlarmCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -128,7 +128,7 @@ public class ZWaveAlarmCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the ALARM_GET command
-     * 
+     *
      * @return the serial message
      */
     @Override
@@ -145,7 +145,7 @@ public class ZWaveAlarmCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the ALARM_GET command
-     * 
+     *
      * @return the serial message
      */
     public SerialMessage getMessage(AlarmType alarmType) {
@@ -207,7 +207,7 @@ public class ZWaveAlarmCommandClass extends ZWaveCommandClass
         /**
          * Lookup function based on the alarm type code.
          * Returns null if the code does not exist.
-         * 
+         *
          * @param i the code to lookup
          * @return enumeration value of the alarm type.
          */
@@ -236,7 +236,7 @@ public class ZWaveAlarmCommandClass extends ZWaveCommandClass
 
     /**
      * Class to hold alarm state
-     * 
+     *
      * @author Chris Jackson
      */
     @XStreamAlias("alarmState")
@@ -271,7 +271,7 @@ public class ZWaveAlarmCommandClass extends ZWaveCommandClass
 
         /**
          * Constructor. Creates a instance of the ZWaveAlarmValueEvent class.
-         * 
+         *
          * @param nodeId the nodeId of the event
          * @param endpoint the endpoint of the event.
          * @param alarmType the alarm type that triggered the event;

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmSensorCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmSensorCommandClass.java
@@ -34,7 +34,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  * The event is reported as occurs (0xFF) or does not occur (0x00).
  * The commands include the possibility to get a given
  * value and report a value.
- * 
+ *
  * @author Jan-Willem Spuij
  * @author Chris Jackson
  * @since 1.3.0
@@ -60,7 +60,7 @@ public class ZWaveAlarmSensorCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveAlarmSensorCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -182,7 +182,7 @@ public class ZWaveAlarmSensorCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the SENSOR_ALARM_GET command
-     * 
+     *
      * @return the serial message
      */
     @Override
@@ -198,7 +198,7 @@ public class ZWaveAlarmSensorCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the SENSOR_ALARM_GET command
-     * 
+     *
      * @return the serial message
      */
     public SerialMessage getMessage(AlarmType alarmType) {
@@ -228,7 +228,7 @@ public class ZWaveAlarmSensorCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the SENSOR_ALARM_SUPPORTED_GET command
-     * 
+     *
      * @return the serial message, or null if the supported command is not supported.
      */
     public SerialMessage getSupportedMessage() {
@@ -306,7 +306,7 @@ public class ZWaveAlarmSensorCommandClass extends ZWaveCommandClass
     /**
      * Z-Wave AlarmType enumeration. The alarm type indicates the type
      * of alarm that is reported.
-     * 
+     *
      * @author Jan-Willem Spuij
      * @author Chris Jackson
      * @since 1.3.0
@@ -350,7 +350,7 @@ public class ZWaveAlarmSensorCommandClass extends ZWaveCommandClass
         /**
          * Lookup function based on the alarm type code.
          * Returns null if the code does not exist.
-         * 
+         *
          * @param i the code to lookup
          * @return enumeration value of the alarm type.
          */
@@ -379,7 +379,7 @@ public class ZWaveAlarmSensorCommandClass extends ZWaveCommandClass
 
     /**
      * Class to hold alarm state
-     * 
+     *
      * @author Chris Jackson
      */
     @XStreamAlias("alarmSensor")
@@ -412,7 +412,7 @@ public class ZWaveAlarmSensorCommandClass extends ZWaveCommandClass
     /**
      * Z-Wave Alarm Sensor Event class. Indicates that an alarm value
      * changed.
-     * 
+     *
      * @author Jan-Willem Spuij
      * @since 1.4.0
      */
@@ -422,7 +422,7 @@ public class ZWaveAlarmSensorCommandClass extends ZWaveCommandClass
 
         /**
          * Constructor. Creates a instance of the ZWaveAlarmSensorValueEvent class.
-         * 
+         *
          * @param nodeId the nodeId of the event
          * @param endpoint the endpoint of the event.
          * @param alarmType the alarm type that triggered the event;

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveApplicationStatusClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveApplicationStatusClass.java
@@ -25,7 +25,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 /**
  * Handles the Application Status command class.
- * 
+ *
  * @author Dan Cunningham
  * @since 1.6.0
  */
@@ -49,7 +49,7 @@ public class ZWaveApplicationStatusClass extends ZWaveCommandClass {
 
     /**
      * Creates a new instance of the ZWaveApplicationStatusClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAssociationCommandClass.java
@@ -67,7 +67,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
 
     /**
      * Creates a new instance of the ZWaveAssociationCommandClass class.
-     * 
+     *
      * @param node
      *            the node this command class belongs to
      * @param controller
@@ -125,7 +125,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
 
     /**
      * Processes a CONFIGURATIONCMD_REPORT / CONFIGURATIONCMD_SET message.
-     * 
+     *
      * @param serialMessage
      *            the incoming message to process.
      * @param offset
@@ -219,7 +219,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
 
     /**
      * Processes a ASSOCIATIONCMD_GROUPINGSREPORT message.
-     * 
+     *
      * @param serialMessage
      *            the incoming message to process.
      * @param offset
@@ -243,7 +243,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
 
     /**
      * Gets a SerialMessage with the ASSOCIATIONCMD_SET command
-     * 
+     *
      * @param group
      *            the association group
      * @param node
@@ -265,7 +265,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
 
     /**
      * Gets a SerialMessage with the ASSOCIATIONCMD_REMOVE command
-     * 
+     *
      * @param group
      *            the association group
      * @param node
@@ -287,7 +287,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
 
     /**
      * Gets a SerialMessage with the ASSOCIATIONCMD_GET command
-     * 
+     *
      * @param group
      *            the association group to read
      * @return the serial message
@@ -305,7 +305,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
 
     /**
      * Gets a SerialMessage with the ASSOCIATIONCMD_GROUPINGSGET command
-     * 
+     *
      * @return the serial message
      */
     public SerialMessage getGroupingsMessage() {
@@ -340,9 +340,9 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
      * Returns a list of nodes that are currently members of the association
      * group. This method only returns the list that is currently in the
      * class - it does not interact with the device.
-     * 
+     *
      * To update the list stored in the class, call getAssociationMessage
-     * 
+     *
      * @param group
      *            number of the association group
      * @return List of nodes in the group
@@ -356,7 +356,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
 
     /**
      * Returns the number of association groups
-     * 
+     *
      * @return Number of association groups
      */
     public int getGroupCount() {
@@ -365,7 +365,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
 
     /**
      * Returns the maximum number of association groups
-     * 
+     *
      * @return Number of association groups
      */
     public int getMaxGroups() {
@@ -376,7 +376,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
      * ZWave association group received event.
      * Send from the association members to the binding
      * Note that multiple events can be required to build up the full list.
-     * 
+     *
      * @author Chris Jackson
      * @since 1.4.0
      */
@@ -388,7 +388,7 @@ public class ZWaveAssociationCommandClass extends ZWaveCommandClass implements Z
         /**
          * Constructor. Creates a new instance of the ZWaveAssociationEvent
          * class.
-         * 
+         *
          * @param nodeId the nodeId of the event. Must be set to the controller node.
          */
         public ZWaveAssociationEvent(int nodeId, int group) {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBasicCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBasicCommandClass.java
@@ -29,7 +29,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  * commands that can be used to control the basic functionality of a device.
  * The commands include the possibility to set a given level, get a given
  * level and report a level.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.3.0
  */
@@ -48,7 +48,7 @@ public class ZWaveBasicCommandClass extends ZWaveCommandClass implements ZWaveBa
 
     /**
      * Creates a new instance of the ZWaveBasicCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -96,7 +96,7 @@ public class ZWaveBasicCommandClass extends ZWaveCommandClass implements ZWaveBa
 
     /**
      * Processes a BASIC_REPORT / BASIC_SET message.
-     * 
+     *
      * @param serialMessage the incoming message to process.
      * @param offset the offset position from which to start message processing.
      * @param endpoint the endpoint or instance number this message is meant for.
@@ -111,7 +111,7 @@ public class ZWaveBasicCommandClass extends ZWaveCommandClass implements ZWaveBa
 
     /**
      * Gets a SerialMessage with the BASIC GET command
-     * 
+     *
      * @return the serial message
      */
     @Override
@@ -141,7 +141,7 @@ public class ZWaveBasicCommandClass extends ZWaveCommandClass implements ZWaveBa
 
     /**
      * Gets a SerialMessage with the BASIC SET command
-     * 
+     *
      * @param the level to set.
      * @return the serial message
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBasicCommands.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBasicCommands.java
@@ -11,7 +11,7 @@ package org.openhab.binding.zwave.internal.protocol.commandclass;
 /**
  * Interface to implement for all command classes that implement the basic
  * commands like GET/SET value.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.3.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBatteryCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBatteryCommandClass.java
@@ -32,7 +32,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  * warnings.
  * The commands include the possibility to get a given
  * battery level and report a battery level.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.3.0
  */
@@ -56,7 +56,7 @@ public class ZWaveBatteryCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveBatteryCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -124,7 +124,7 @@ public class ZWaveBatteryCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the BATTERY_GET command
-     * 
+     *
      * @return the serial message
      */
     @Override
@@ -172,7 +172,7 @@ public class ZWaveBatteryCommandClass extends ZWaveCommandClass
 
     /**
      * Returns the current battery level. If the battery level is unknown, returns null
-     * 
+     *
      * @return battery level
      */
     public Integer getBatteryLevel() {
@@ -181,7 +181,7 @@ public class ZWaveBatteryCommandClass extends ZWaveCommandClass
 
     /**
      * Returns the current battery warning state.
-     * 
+     *
      * @return true if device is saying battery is low
      */
     public Boolean getBatteryLow() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBinarySensorCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBinarySensorCommandClass.java
@@ -33,7 +33,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  * status or event as on (0xFF) or off (0x00).
  * The commands include the possibility to get a given
  * value and report a value.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.3.0
  */
@@ -56,7 +56,7 @@ public class ZWaveBinarySensorCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveBinarySensorCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -118,7 +118,7 @@ public class ZWaveBinarySensorCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the SENSOR_BINARY_GET command
-     * 
+     *
      * @return the serial message
      */
     @Override
@@ -176,7 +176,7 @@ public class ZWaveBinarySensorCommandClass extends ZWaveCommandClass
     /**
      * Z-Wave SensorType enumeration. The sensor type indicates the type
      * of sensor that is reported.
-     * 
+     *
      * @author Chris Jackson
      * @since 1.5.0
      */
@@ -221,7 +221,7 @@ public class ZWaveBinarySensorCommandClass extends ZWaveCommandClass
         /**
          * Lookup function based on the sensor type code.
          * Returns null if the code does not exist.
-         * 
+         *
          * @param i the code to lookup
          * @return enumeration value of the sensor type.
          */
@@ -250,7 +250,7 @@ public class ZWaveBinarySensorCommandClass extends ZWaveCommandClass
 
     /**
      * Z-Wave Binary Sensor Event class. Indicates that an sensor value changed.
-     * 
+     *
      * @author Chris Jackson
      * @since 1.5.0
      */
@@ -260,7 +260,7 @@ public class ZWaveBinarySensorCommandClass extends ZWaveCommandClass
 
         /**
          * Constructor. Creates a instance of the ZWaveBinarySensorValueEvent class.
-         * 
+         *
          * @param nodeId the nodeId of the event
          * @param endpoint the endpoint of the event.
          * @param sensorType the sensor type that triggered the event;

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBinarySwitchCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveBinarySwitchCommandClass.java
@@ -31,7 +31,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  * on or off and report their status as on (0xFF) or off (0x00).
  * The commands include the possibility to set a given level, get a given
  * level and report a level.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.3.0
  */
@@ -53,7 +53,7 @@ public class ZWaveBinarySwitchCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveBinarySwitchCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -104,7 +104,7 @@ public class ZWaveBinarySwitchCommandClass extends ZWaveCommandClass
 
     /**
      * Processes a SWITCH_BINARY_REPORT / SWITCH_BINARY_SET message.
-     * 
+     *
      * @param serialMessage the incoming message to process.
      * @param offset the offset position from which to start message processing.
      * @param endpoint the endpoint or instance number this message is meant for.
@@ -119,7 +119,7 @@ public class ZWaveBinarySwitchCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the SWITCH_BINARY_GET command
-     * 
+     *
      * @return the serial message
      */
     @Override
@@ -136,7 +136,7 @@ public class ZWaveBinarySwitchCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the SWITCH_BINARY_SET command
-     * 
+     *
      * @param the level to set. 0 is mapped to off, > 0 is mapped to on.
      * @return the serial message
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCRC16EncapsulationCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCRC16EncapsulationCommandClass.java
@@ -35,7 +35,7 @@ public class ZWaveCRC16EncapsulationCommandClass extends ZWaveCommandClass {
 
     /**
      * Creates a new instance of the ZWaveMultiCommandCommandClass class.
-     * 
+     *
      * @param node
      *            the node this command class belongs to
      * @param controller
@@ -72,7 +72,7 @@ public class ZWaveCRC16EncapsulationCommandClass extends ZWaveCommandClass {
     /**
      * Handle the crc16 encapsulated message. This processes the received frame,
      * checks the crc and forwards to the real command class.
-     * 
+     *
      * @param serialMessage
      *            The received message
      * @param offset

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClass.java
@@ -31,7 +31,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  * Z-Wave Command Class. Z-Wave device functions are controlled
  * by command classes. A command class can be have one or multiple
  * commands allowing the use of a certain function of the device.
- * 
+ *
  * @author Brian Crosby
  * @since 1.3.0
  */
@@ -60,7 +60,7 @@ public abstract class ZWaveCommandClass {
 
     /**
      * Protected constructor. Initiates a new instance of a Command Class.
-     * 
+     *
      * @param node the node this instance commands.
      * @param controller the controller to send messages to.
      * @param endpoint the endpoint this Command class belongs to.
@@ -74,7 +74,7 @@ public abstract class ZWaveCommandClass {
 
     /**
      * Returns the node this command class belongs to.
-     * 
+     *
      * @return node
      */
     protected ZWaveNode getNode() {
@@ -83,7 +83,7 @@ public abstract class ZWaveCommandClass {
 
     /**
      * Sets the node this command class belongs to.
-     * 
+     *
      * @param node the node to set
      */
     public void setNode(ZWaveNode node) {
@@ -92,7 +92,7 @@ public abstract class ZWaveCommandClass {
 
     /**
      * Returns the controller to send messages to.
-     * 
+     *
      * @return controller
      */
     protected ZWaveController getController() {
@@ -101,7 +101,7 @@ public abstract class ZWaveCommandClass {
 
     /**
      * Sets the controller to send messages to.
-     * 
+     *
      * @param controller the controller to set
      */
     public void setController(ZWaveController controller) {
@@ -110,7 +110,7 @@ public abstract class ZWaveCommandClass {
 
     /**
      * Returns the endpoint this command class belongs to.
-     * 
+     *
      * @return the endpoint this command class belongs to.
      */
     public ZWaveEndpoint getEndpoint() {
@@ -119,7 +119,7 @@ public abstract class ZWaveCommandClass {
 
     /**
      * Sets the endpoint this command class belongs to.
-     * 
+     *
      * @param endpoint the endpoint to set
      */
     public void setEndpoint(ZWaveEndpoint endpoint) {
@@ -128,7 +128,7 @@ public abstract class ZWaveCommandClass {
 
     /**
      * Returns the version of the command class.
-     * 
+     *
      * @return node
      */
     public int getVersion() {
@@ -137,7 +137,7 @@ public abstract class ZWaveCommandClass {
 
     /**
      * Sets the version number for this command class.
-     * 
+     *
      * @param version. The version number to set.
      */
     public void setVersion(int version) {
@@ -154,7 +154,7 @@ public abstract class ZWaveCommandClass {
     /**
      * Set options for this command class.
      * Options are provided from the device configuration database
-     * 
+     *
      * @param options class
      * @return true if options set ok
      */
@@ -165,7 +165,7 @@ public abstract class ZWaveCommandClass {
     /**
      * Returns the number of instances of this command class
      * in case the node supports the MULTI_INSTANCE command class (Version 1).
-     * 
+     *
      * @return the number of instances
      */
     public int getInstances() {
@@ -175,7 +175,7 @@ public abstract class ZWaveCommandClass {
     /**
      * Returns the number of instances of this command class
      * in case the node supports the MULTI_INSTANCE command class (Version 1).
-     * 
+     *
      * @param instances. The number of instances.
      */
     public void setInstances(int instances) {
@@ -184,14 +184,14 @@ public abstract class ZWaveCommandClass {
 
     /**
      * Returns the command class.
-     * 
+     *
      * @return command class
      */
     public abstract CommandClass getCommandClass();
 
     /**
      * Handles an incoming application command request.
-     * 
+     *
      * @param serialMessage the incoming message to process.
      * @param offset the offset position from which to start message processing.
      * @param endpoint the endpoint or instance number this message is meant for.
@@ -201,7 +201,7 @@ public abstract class ZWaveCommandClass {
     /**
      * Gets an instance of the right command class.
      * Returns null if the command class is not found.
-     * 
+     *
      * @param i the code to instantiate
      * @param node the node this instance commands.
      * @param controller the controller to send messages to.
@@ -214,7 +214,7 @@ public abstract class ZWaveCommandClass {
     /**
      * Gets an instance of the right command class.
      * Returns null if the command class is not found.
-     * 
+     *
      * @param classId the code to instantiate
      * @param node the node this instance commands.
      * @param controller the controller to send messages to.
@@ -258,7 +258,7 @@ public abstract class ZWaveCommandClass {
 
     /**
      * Extract a decimal value from a byte array.
-     * 
+     *
      * @param buffer the buffer to be parsed.
      * @param offset the offset at which to start reading
      * @return the extracted decimal value
@@ -299,7 +299,7 @@ public abstract class ZWaveCommandClass {
 
     /**
      * Extract a decimal value from a byte array.
-     * 
+     *
      * @param buffer the buffer to be parsed.
      * @param offset the offset at which to start reading
      * @return the extracted decimal value
@@ -326,7 +326,7 @@ public abstract class ZWaveCommandClass {
 
     /**
      * Encodes a decimal value as a byte array.
-     * 
+     *
      * @param value the decimal value to encode
      * @param index the value index
      * @return the value buffer
@@ -378,7 +378,7 @@ public abstract class ZWaveCommandClass {
      * Command class enumeration. Lists all command classes available.
      * Unsupported command classes by the binding return null for the command class Class.
      * Taken from: http://wiki.micasaverde.com/index.php/ZWave_Command_Classes
-     * 
+     *
      * @author Jan-Willem Spuij
      * @since 1.3.0
      */
@@ -532,7 +532,7 @@ public abstract class ZWaveCommandClass {
         /**
          * Lookup function based on the command class code.
          * Returns null if there is no command class with code i
-         * 
+         *
          * @param i the code to lookup
          * @return enumeration value of the command class.
          */
@@ -558,7 +558,7 @@ public abstract class ZWaveCommandClass {
         /**
          * Lookup function based on the command class label.
          * Returns null if there is no command class with that label.
-         * 
+         *
          * @param label the label to lookup
          * @return enumeration value of the command class.
          */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClassDynamicState.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClassDynamicState.java
@@ -16,7 +16,7 @@ import org.openhab.binding.zwave.internal.protocol.SerialMessage;
  * Interface that command classes can implement to implement retrieval of
  * dynamic state information..
  * For instance to support getting dynamic values from a node.
- * 
+ *
  * @author Jan-Willem Spuij
  * @author Chris Jackson
  * @since 1.3.0
@@ -27,7 +27,7 @@ public interface ZWaveCommandClassDynamicState {
      * state information. These queries need to be completed to be able to proceed to the next
      * node phase. The queries are returned so that the node can handle processing
      * to proceed to the next node phase.
-     * 
+     *
      * @param refresh if true will request all dynamic states even if they are already initialised
      * @return the messages with the queries for dynamic values.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClassInitialization.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveCommandClassInitialization.java
@@ -16,7 +16,7 @@ import org.openhab.binding.zwave.internal.protocol.SerialMessage;
  * Interface that command classes can implement to implement initialization.
  * For instance to support getting static values from a node, or handle dependencies
  * on other command classes.
- * 
+ *
  * @author Jan-Willem Spuij
  * @author Chris Jackson
  * @since 1.3.0
@@ -27,7 +27,7 @@ public interface ZWaveCommandClassInitialization {
      * to be performed. These queries need to be completed to be able to proceed to the next
      * node phase. The queries are returned so that the node can handle processing and counting
      * to proceed to the next node phase.
-     * 
+     *
      * @param refresh if true will request all initialised even if the class is already initialised
      * @return the messages with the queries for initialization.
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveGetCommands.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveGetCommands.java
@@ -12,14 +12,14 @@ import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 
 /**
  * Interface to implement for all command classes that implement the Get command.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.3.0
  */
 public interface ZWaveGetCommands {
     /**
      * Gets a SerialMessage with the GET command
-     * 
+     *
      * @return the serial message
      */
     public SerialMessage getValueMessage();

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveHailCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveHailCommandClass.java
@@ -22,7 +22,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 /**
  * Handles the Hail command class. Some devices handle state changes by
  * 'hailing' the controller and asking it to request the device values
- * 
+ *
  * @author Ben Jones
  * @since 1.4.0
  */
@@ -36,7 +36,7 @@ public class ZWaveHailCommandClass extends ZWaveCommandClass {
 
     /**
      * Creates a new instance of the ZWaveHailCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveIndicatorCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveIndicatorCommandClass.java
@@ -57,7 +57,7 @@ public class ZWaveIndicatorCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveIndicatorCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -105,7 +105,7 @@ public class ZWaveIndicatorCommandClass extends ZWaveCommandClass
 
     /**
      * Processes a INDICATOR_REPORT / INDICATOR_SET message.
-     * 
+     *
      * @param serialMessage the incoming message to process.
      * @param offset the offset position from which to start message processing.
      * @param endpoint the endpoint or instance number this message is meant for.
@@ -125,7 +125,7 @@ public class ZWaveIndicatorCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the INDICATOR GET command
-     * 
+     *
      * @return the serial message
      */
     @Override
@@ -155,7 +155,7 @@ public class ZWaveIndicatorCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the INDICATOR SET command
-     * 
+     *
      * @param the level to set.
      * @return the serial message
      */
@@ -172,7 +172,7 @@ public class ZWaveIndicatorCommandClass extends ZWaveCommandClass
 
     /**
      * Get current indicator value
-     * 
+     *
      * @return indicator
      */
     public int getValue() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveManufacturerSpecificCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveManufacturerSpecificCommandClass.java
@@ -24,7 +24,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 /**
  * Handles the manufacturer specific command class. Class to request and report
  * manufacturer specific information.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.3.0
  */
@@ -39,7 +39,7 @@ public class ZWaveManufacturerSpecificCommandClass extends ZWaveCommandClass {
 
     /**
      * Creates a new instance of the ZwaveManufacturerSpecificCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -98,7 +98,7 @@ public class ZWaveManufacturerSpecificCommandClass extends ZWaveCommandClass {
 
     /**
      * Gets a SerialMessage with the ManufacturerSpecific GET command
-     * 
+     *
      * @return the serial message
      */
     public SerialMessage getManufacturerSpecificMessage() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMeterCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMeterCommandClass.java
@@ -73,7 +73,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveMeterCommandClass class.
-     * 
+     *
      * @param node
      *            the node this command class belongs to
      * @param controller
@@ -218,7 +218,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the METER_GET command
-     * 
+     *
      * @return the serial message
      */
     @Override
@@ -276,7 +276,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the METER_GET command
-     * 
+     *
      * @return the serial message
      */
     public SerialMessage getMessage(MeterScale meterScale) {
@@ -291,7 +291,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the METER_SUPPORTED_GET command
-     * 
+     *
      * @return the serial message, or null if the supported command is not
      *         supported.
      */
@@ -308,7 +308,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the METER_RESET command
-     * 
+     *
      * @return the serial message
      */
     public SerialMessage getResetMessage() {
@@ -368,7 +368,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
     /**
      * Z-Wave MeterType enumeration. The meter type indicates the type of meter
      * that is reported.
-     * 
+     *
      * @author Ben Jones
      * @since 1.4.0
      */
@@ -402,7 +402,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
         /**
          * Lookup function based on the meter type code. Returns null if the
          * code does not exist.
-         * 
+         *
          * @param i
          *            the code to lookup
          * @return enumeration value of the meter type.
@@ -433,7 +433,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
     /**
      * Z-Wave MeterScale enumeration. The meter scale indicates the meter scale
      * that is reported.
-     * 
+     *
      * @author Jan-Willem Spuij
      * @since 1.4.0
      */
@@ -473,7 +473,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
 
         /**
          * Constructor. Creates a new enumeration value.
-         * 
+         *
          * @param scale the scale number
          * @param meterType the meter type
          * @param unit the unit
@@ -501,7 +501,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
         /**
          * Lookup function based on the meter type and code. Returns null if the
          * code does not exist.
-         * 
+         *
          * @param meterType the meter type to use to lookup the scale
          * @param i the code to lookup
          * @return enumeration value of the meter scale.
@@ -520,7 +520,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
         /**
          * Lookup function based on the name. Returns null if the
          * name does not exist.
-         * 
+         *
          * @param name the name to lookup
          * @return enumeration value of the meter scale.
          */
@@ -534,7 +534,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
 
         /**
          * Returns the scale code.
-         * 
+         *
          * @return the scale code.
          */
         protected int getScale() {
@@ -543,7 +543,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
 
         /**
          * Returns the meter type.
-         * 
+         *
          * @return the meterType
          */
         protected MeterType getMeterType() {
@@ -552,7 +552,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
 
         /**
          * Returns the unit as string.
-         * 
+         *
          * @return the unit
          */
         protected String getUnit() {
@@ -561,7 +561,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
 
         /**
          * Returns the label (category).
-         * 
+         *
          * @return the label
          */
         protected String getLabel() {
@@ -572,7 +572,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
 
     /**
      * Z-Wave Meter value Event class. Indicates that a meter value changed.
-     * 
+     *
      * @author Jan-Willem Spuij
      * @since 1.4.0
      */
@@ -583,7 +583,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
 
         /**
          * Constructor. Creates a instance of the ZWaveMeterValueEvent class.
-         * 
+         *
          * @param nodeId
          *            the nodeId of the event
          * @param endpoint
@@ -604,7 +604,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
 
         /**
          * Gets the meter type for this meter value event.
-         * 
+         *
          * @return the meter type for this meter value event.
          */
         public MeterType getMeterType() {
@@ -613,7 +613,7 @@ public class ZWaveMeterCommandClass extends ZWaveCommandClass
 
         /**
          * Gets the meter scale for this meter value event.
-         * 
+         *
          * @return the meter scale for this meter value event.
          */
         public MeterScale getMeterScale() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiCommandCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiCommandCommandClass.java
@@ -20,7 +20,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 /**
  * Handles the Multi Command command class.
- * 
+ *
  * @author Chris Jackson
  * @since 1.6.0
  */
@@ -34,7 +34,7 @@ public class ZWaveMultiCommandCommandClass extends ZWaveCommandClass {
 
     /**
      * Creates a new instance of the ZWaveMultiCommandCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -68,7 +68,7 @@ public class ZWaveMultiCommandCommandClass extends ZWaveCommandClass {
     /**
      * Handle the multi command message. This processes the received frame, processing each
      * command class in turn.
-     * 
+     *
      * @param serialMessage The received message
      * @param offset The starting offset into the payload
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiInstanceCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiInstanceCommandClass.java
@@ -83,7 +83,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
 
     /**
      * Creates a new instance of the ZWaveMultiInstanceCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -111,7 +111,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
     /**
      * Gets the endpoint object using it's endpoint ID as key.
      * Returns null if the endpoint is not found.
-     * 
+     *
      * @param endpointId the endpoint ID of the endpoint to get.
      * @return Endpoint object
      * @throws IllegalArgumentException thrown when the endpoint is not found.
@@ -123,7 +123,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
 
     /**
      * Gets the collection of endpoints attached to this node.
-     * 
+     *
      * @return the collection of endpoints.
      */
     public Collection<ZWaveEndpoint> getEndpoints() {
@@ -171,7 +171,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
      * Handles Multi Instance Report message. Handles Report on
      * the number of instances for the command class.
      * This is for Version 1 of the command class.
-     * 
+     *
      * @param serialMessage the serial message to process.
      * @param offset the offset at which to start processing.
      */
@@ -210,7 +210,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
      * Handles Multi Instance Encapsulation message. Decapsulates
      * an Application Command message and handles it using the right
      * instance.
-     * 
+     *
      * @param serialMessage the serial message to process.
      * @param offset the offset at which to start procesing.
      */
@@ -264,7 +264,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
      * the number of endpoints and whether they are dynamic and/or have the
      * same command classes.
      * This is for Version 2 of the command class.
-     * 
+     *
      * @param serialMessage the serial message to process.
      * @param offset the offset at which to start processing.
      */
@@ -299,7 +299,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
      * Handles Multi Channel Capability Report message. Handles Report on
      * an endpoint and adds command classes to the endpoint.
      * This is for Version 2 of the command class.
-     * 
+     *
      * @param serialMessage the serial message to process.
      * @param offset the offset at which to start processing.
      */
@@ -358,7 +358,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
 
     /**
      * Determines the device class properties of the endpoint.
-     * 
+     *
      * @param endpoint The endpoint to update.
      * @param genericDeviceClass The generic device class of the parent device of the endpoint
      * @param specificDeviceClass The specific device class of the parent device of the endpoint
@@ -402,7 +402,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
 
     /**
      * Adds command classes to the endpoint based on the message from the device.
-     * 
+     *
      * @param serialMessage The message to get command classes from.
      * @param offset The offset in the message.
      * @param endpoint The endpoint
@@ -443,7 +443,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
      * Handles Multi Channel Encapsulation message. Decapsulates
      * an Application Command message and handles it using the right
      * endpoint.
-     * 
+     *
      * @param serialMessage the serial message to process.
      * @param offset the offset at which to start processing.
      */
@@ -501,7 +501,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
     /**
      * Gets a SerialMessage with the MULTI_INSTANCE_GET command.
      * Returns the number of instances for this command class.
-     * 
+     *
      * @param the command class to return the number of instances for.
      * @return the serial message.
      */
@@ -519,7 +519,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
     /**
      * Gets a SerialMessage with the MULTI_INSTANCE_ENCAP command.
      * Encapsulates a message for a specific instance.
-     * 
+     *
      * @param serialMessage the serial message to encapsulate
      * @param instance the number of the instance to encapsulate the message for.
      * @return the encapsulated serial message.
@@ -544,7 +544,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
     /**
      * Gets a SerialMessage with the MULTI CHANNEL ENDPOINT GET command.
      * Returns the endpoints for this node.
-     * 
+     *
      * @return the serial message.
      */
     public SerialMessage getMultiChannelEndpointGetMessage() {
@@ -561,7 +561,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
     /**
      * Gets a SerialMessage with the MULTI_CHANNEL_CAPABILITY_GET command.
      * Gets the capabilities for a specific endpoint.
-     * 
+     *
      * @param the number of the endpoint to get the
      * @return the serial message.
      */
@@ -579,7 +579,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
     /**
      * Gets a SerialMessage with the MULTI_INSTANCE_ENCAP command.
      * Encapsulates a message for a specific instance.
-     * 
+     *
      * @param serialMessage the serial message to encapsulate
      * @param endpoint the endpoint to encapsulate the message for.
      * @return the encapsulated serial message.
@@ -605,7 +605,7 @@ public class ZWaveMultiInstanceCommandClass extends ZWaveCommandClass {
     /**
      * Initializes the Multi instance / endpoint command class by setting the number of instances
      * or getting the endpoints.
-     * 
+     *
      * @return SerialMessage message to send
      */
     public ArrayList<SerialMessage> initEndpoints(boolean refresh) {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSensorCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSensorCommandClass.java
@@ -62,7 +62,7 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveMultiLevelSensorCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -184,7 +184,7 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the SENSOR_MULTI_LEVEL_GET command
-     * 
+     *
      * @return the serial message
      */
     @Override
@@ -212,7 +212,7 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the SENSOR_MULTI_LEVEL_SUPPORTED_GET command
-     * 
+     *
      * @return the serial message
      */
     public SerialMessage getSupportedValueMessage() {
@@ -228,7 +228,7 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the SENSOR_MULTI_LEVEL_GET command
-     * 
+     *
      * @param sensorType the {@link SensorType} to get the value for.
      * @return the serial message
      */
@@ -305,7 +305,7 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
     /**
      * Z-Wave SensorType enumeration. The sensor type indicates the type
      * of sensor that is reported.
-     * 
+     *
      * @author Jan-Willem Spuij
      * @since 1.3.0
      */
@@ -368,7 +368,7 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
         /**
          * Lookup function based on the sensor type code.
          * Returns null if the code does not exist.
-         * 
+         *
          * @param i the code to lookup
          * @return enumeration value of the sensor type.
          */
@@ -397,7 +397,7 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
 
     /**
      * Class to hold alarm state
-     * 
+     *
      * @author Chris Jackson
      */
     @XStreamAlias("multilevelSensor")
@@ -429,7 +429,7 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
     /**
      * Z-Wave Multilevel Sensor Event class. Indicates that an sensor value
      * changed.
-     * 
+     *
      * @author Jan-Willem Spuij
      * @since 1.4.0
      */
@@ -440,7 +440,7 @@ public class ZWaveMultiLevelSensorCommandClass extends ZWaveCommandClass
 
         /**
          * Constructor. Creates a instance of the ZWaveMultiLevelSensorValueEvent class.
-         * 
+         *
          * @param nodeId the nodeId of the event
          * @param endpoint the endpoint of the event.
          * @param sensorType the sensor type that triggered the event;

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSwitchCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveMultiLevelSwitchCommandClass.java
@@ -35,7 +35,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  * Z-Wave dimmers have a range from 0 (off) to 99 (on). 255 (0xFF) means restore
  * to previous level. We translate 99 to 100%, so it's impossible to set
  * the level to 99%.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.3.0
  */
@@ -62,7 +62,7 @@ public class ZWaveMultiLevelSwitchCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveMultiLevelSwitchCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -127,7 +127,7 @@ public class ZWaveMultiLevelSwitchCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the SWITCH_MULTILEVEL_GET command
-     * 
+     *
      * @return the serial message
      */
     @Override
@@ -157,7 +157,7 @@ public class ZWaveMultiLevelSwitchCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the SWITCH_MULTILEVEL_SET command
-     * 
+     *
      * @param the level to set. 0 is mapped to off, > 0 is mapped to on.
      * @return the serial message
      */
@@ -174,7 +174,7 @@ public class ZWaveMultiLevelSwitchCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the SWITCH_MULTILEVEL_STOP_LEVEL_CHANGE command
-     * 
+     *
      * @return the serial message
      */
     public SerialMessage stopLevelChangeMessage() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveNoOperationCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveNoOperationCommandClass.java
@@ -26,7 +26,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  * to check if a node is reachable by sending a serial message without a command
  * to the specified node. This can for instance be used to check that a node is
  * non-responding.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.3.0
  */
@@ -38,7 +38,7 @@ public class ZWaveNoOperationCommandClass extends ZWaveCommandClass {
 
     /**
      * Creates a new instance of the ZWaveNoOperationCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -65,7 +65,7 @@ public class ZWaveNoOperationCommandClass extends ZWaveCommandClass {
 
     /**
      * Gets a SerialMessage with the No Operation command
-     * 
+     *
      * @return the serial message
      */
     public SerialMessage getNoOperationMessage() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSceneActivationCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSceneActivationCommandClass.java
@@ -21,7 +21,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 /**
  * Handles scene activation messages
- * 
+ *
  * @author Chris Jackson
  * @since 1.4.0
  */
@@ -36,7 +36,7 @@ public class ZWaveSceneActivationCommandClass extends ZWaveCommandClass {
 
     /**
      * Creates a new instance of the ZWaveSceneActivationCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -74,7 +74,7 @@ public class ZWaveSceneActivationCommandClass extends ZWaveCommandClass {
 
     /**
      * Processes a SCENEACTIVATION_SET message.
-     * 
+     *
      * @param serialMessage the incoming message to process.
      * @param offset the offset position from which to start message processing.
      * @param endpoint the endpoint or instance number this message is meant for.

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSetCommands.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSetCommands.java
@@ -13,14 +13,14 @@ import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 /**
  * Interface to implement for all command classes that implement the SET
  * commands like SET value.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.3.0
  */
 public interface ZWaveSetCommands {
     /**
      * Gets a SerialMessage with the SET command
-     * 
+     *
      * @param value the value to set.
      * @return the serial message
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveSwitchAllCommandClass.java
@@ -93,7 +93,7 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
 
     /**
      * Creates a new instance of the ZWaveSwitchAllCommandClass class.
-     * 
+     *
      * @param node
      *            the node this command class belongs to
      * @param controller
@@ -179,7 +179,7 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
 
     /**
      * Create a new SwitchAll set message
-     * 
+     *
      * @param mode
      *            as (0x00 - Exclude, 0x01 Only All On, 0x02 Only All Off, 0xFF
      *            Both All on and All off)
@@ -207,7 +207,7 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
 
     /**
      * Create the All On message
-     * 
+     *
      * @return
      */
     public SerialMessage allOnMessage() {
@@ -223,7 +223,7 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
 
     /**
      * Create the All Off message
-     * 
+     *
      * @return
      */
     public SerialMessage allOffMessage() {
@@ -247,7 +247,7 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
 
     /**
      * get the Switch All mode
-     * 
+     *
      * @return the mode
      */
     public SwitchAllMode getMode() {
@@ -257,7 +257,7 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
     /**
      * ZWave Switch All mode received event. Sent from the Switch All Command
      * Class to the binding when the switch all mode is received.
-     * 
+     *
      * @author Pedro Paixao
      * @since 1.8.0
      */
@@ -266,7 +266,7 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
         /**
          * Constructor. Creates a new instance of the ZWaveSwitchAllModeEvent
          * class.
-         * 
+         *
          * @param nodeId
          *            the nodeId of the event
          */
@@ -276,7 +276,7 @@ public class ZWaveSwitchAllCommandClass extends ZWaveCommandClass implements ZWa
 
         /**
          * Returns the switch all mode that was received as event.
-         * 
+         *
          * @return the mode.
          */
         public Integer getParameter() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatFanModeCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatFanModeCommandClass.java
@@ -32,7 +32,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 /**
  * Handles the Thermostat FanMode command class.
- * 
+ *
  * @author Dan Cunningham
  * @since 1.6.0
  */
@@ -60,7 +60,7 @@ public class ZWaveThermostatFanModeCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveThermostatFanModeCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -142,7 +142,7 @@ public class ZWaveThermostatFanModeCommandClass extends ZWaveCommandClass
 
     /**
      * Processes a THERMOSTAT_FAN_MODE_REPORT message.
-     * 
+     *
      * @param serialMessage the incoming message to process.
      * @param offset the offset position from which to start message processing.
      * @param endpoint the endpoint or instance number this message is meant for.
@@ -229,7 +229,7 @@ public class ZWaveThermostatFanModeCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the THERMOSTAT_FAN_MODE_SUPPORTED_GET command
-     * 
+     *
      * @return the serial message, or null if the supported command is not supported.
      */
     public SerialMessage getSupportedMessage() {
@@ -276,7 +276,7 @@ public class ZWaveThermostatFanModeCommandClass extends ZWaveCommandClass
     /**
      * Z-Wave FanModeType enumeration. The fanMode type indicates the type
      * of fanMode that is reported.
-     * 
+     *
      * @author Dan Cunningham
      * @since 1.6.0
      */
@@ -314,7 +314,7 @@ public class ZWaveThermostatFanModeCommandClass extends ZWaveCommandClass
         /**
          * Lookup function based on the fan mode type code.
          * Returns null if the code does not exist.
-         * 
+         *
          * @param i the code to lookup
          * @return enumeration value of the fan mode type.
          */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatFanStateCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatFanStateCommandClass.java
@@ -32,7 +32,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 /**
  * Handles the Thermostat FanState command class.
- * 
+ *
  * @author Dan Cunningham
  * @since 1.6.0
  */
@@ -55,7 +55,7 @@ public class ZWaveThermostatFanStateCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveThermostatFanStateCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -100,7 +100,7 @@ public class ZWaveThermostatFanStateCommandClass extends ZWaveCommandClass
 
     /**
      * Processes a THERMOSTAT_FAN_STATE_REPORT message.
-     * 
+     *
      * @param serialMessage the incoming message to process.
      * @param offset the offset position from which to start message processing.
      * @param endpoint the endpoint or instance number this message is meant for.
@@ -177,7 +177,7 @@ public class ZWaveThermostatFanStateCommandClass extends ZWaveCommandClass
     /**
      * Z-Wave FanStateType enumeration. The fanState type indicates the type
      * of fanState that is reported.
-     * 
+     *
      * @author Dan Cunningham
      * @since 1.6.0
      */
@@ -225,7 +225,7 @@ public class ZWaveThermostatFanStateCommandClass extends ZWaveCommandClass
         /**
          * Lookup function based on the fanState type code.
          * Returns null if the code does not exist.
-         * 
+         *
          * @param i the code to lookup
          * @return enumeration value of the fanState type.
          */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatModeCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatModeCommandClass.java
@@ -32,7 +32,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 /**
  * Handles the Thermostat Mode command class.
- * 
+ *
  * @author Dan Cunningham
  * @since 1.6.0
  */
@@ -60,7 +60,7 @@ public class ZWaveThermostatModeCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveThermostatModeCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -141,7 +141,7 @@ public class ZWaveThermostatModeCommandClass extends ZWaveCommandClass
 
     /**
      * Processes a THERMOSTAT_MODE_REPORT message.
-     * 
+     *
      * @param serialMessage the incoming message to process.
      * @param offset the offset position from which to start message processing.
      * @param endpoint the endpoint or instance number this message is meant for.
@@ -227,7 +227,7 @@ public class ZWaveThermostatModeCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the THERMOSTAT_MODE_SUPPORTED_GET command
-     * 
+     *
      * @return the serial message, or null if the supported command is not supported.
      */
     public SerialMessage getSupportedMessage() {
@@ -277,7 +277,7 @@ public class ZWaveThermostatModeCommandClass extends ZWaveCommandClass
     /**
      * Z-Wave ModeType enumeration. The mode type indicates the type
      * of mode that is reported.
-     * 
+     *
      * @author Dan Cunningham
      * @since 1.6.0
      */
@@ -324,7 +324,7 @@ public class ZWaveThermostatModeCommandClass extends ZWaveCommandClass
         /**
          * Lookup function based on the mode type code.
          * Returns null if the code does not exist.
-         * 
+         *
          * @param i the code to lookup
          * @return enumeration value of the mode type.
          */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatOperatingStateCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatOperatingStateCommandClass.java
@@ -31,7 +31,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 /**
  * Handles the Thermostat OperatingState command class.
- * 
+ *
  * @author Dan Cunningham
  * @since 1.6.0
  */
@@ -52,7 +52,7 @@ public class ZWaveThermostatOperatingStateCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveThermostatOperatingStateCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -98,7 +98,7 @@ public class ZWaveThermostatOperatingStateCommandClass extends ZWaveCommandClass
 
     /**
      * Processes a THERMOSTAT_OPERATING_STATE_REPORT message.
-     * 
+     *
      * @param serialMessage the incoming message to process.
      * @param offset the offset position from which to start message processing.
      * @param endpoint the endpoint or instance number this message is meant for.
@@ -173,7 +173,7 @@ public class ZWaveThermostatOperatingStateCommandClass extends ZWaveCommandClass
     /**
      * Z-Wave OperatingStateType enumeration. The operating state type indicates the type
      * of operating state that is reported from the thermostat.
-     * 
+     *
      * @author Dan Cunningham
      * @since 1.6.0
      */
@@ -220,7 +220,7 @@ public class ZWaveThermostatOperatingStateCommandClass extends ZWaveCommandClass
         /**
          * Lookup function based on the operating state type code.
          * Returns null if the code does not exist.
-         * 
+         *
          * @param i the code to lookup
          * @return enumeration value of the operatingState type.
          */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatSetpointCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveThermostatSetpointCommandClass.java
@@ -32,7 +32,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 /**
  * Handles the Thermostat Setpoint command class.
- * 
+ *
  * @author Matthew Bowman
  * @author Jan-Willem Spuij
  * @author Dave Hock
@@ -66,7 +66,7 @@ public class ZWaveThermostatSetpointCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveThermostatSetpointCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -148,7 +148,7 @@ public class ZWaveThermostatSetpointCommandClass extends ZWaveCommandClass
 
     /**
      * Processes a THERMOSTAT_SETPOINT_REPORT message.
-     * 
+     *
      * @param serialMessage the incoming message to process.
      * @param offset the offset position from which to start message processing.
      * @param endpoint the endpoint or instance number this message is meant for.
@@ -251,7 +251,7 @@ public class ZWaveThermostatSetpointCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the THERMOSTAT_SETPOINT_GET command
-     * 
+     *
      * @param setpointType the setpoint type to get
      * @return the serial message
      */
@@ -272,7 +272,7 @@ public class ZWaveThermostatSetpointCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the THERMOSTAT_SETPOINT_SUPPORTED_GET command
-     * 
+     *
      * @return the serial message, or null if the supported command is not supported.
      */
     public SerialMessage getSupportedMessage() {
@@ -297,7 +297,7 @@ public class ZWaveThermostatSetpointCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the THERMOSTAT_SETPOINT_SET command
-     * 
+     *
      * @param setpoint the setpoint to set.
      * @return the serial message
      */
@@ -312,7 +312,7 @@ public class ZWaveThermostatSetpointCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the THERMOSTAT_SETPOINT_SET command
-     * 
+     *
      * @param scale the scale (DegC or DegF)
      * @param setpointType the setpoint type to set
      * @param setpoint the setpoint to set.
@@ -346,7 +346,7 @@ public class ZWaveThermostatSetpointCommandClass extends ZWaveCommandClass
     /**
      * Z-Wave SetpointType enumeration. The setpoint type indicates the type
      * of setpoint that is reported.
-     * 
+     *
      * @author Matthew Bowman
      * @since 1.4.0
      */
@@ -386,7 +386,7 @@ public class ZWaveThermostatSetpointCommandClass extends ZWaveCommandClass
         /**
          * Lookup function based on the setpoint type code.
          * Returns null if the code does not exist.
-         * 
+         *
          * @param i the code to lookup
          * @return enumeration value of the setpoint type.
          */
@@ -414,7 +414,7 @@ public class ZWaveThermostatSetpointCommandClass extends ZWaveCommandClass
 
     /**
      * Class to hold setpoint state
-     * 
+     *
      * @author Chris Jackson
      */
     private class Setpoint {
@@ -452,7 +452,7 @@ public class ZWaveThermostatSetpointCommandClass extends ZWaveCommandClass
     /**
      * Z-Wave Thermostat Setpoint Event class. Indicates that a setpoint value
      * changed.
-     * 
+     *
      * @author Jan-Willem Spuij
      * @since 1.4.0
      */
@@ -463,7 +463,7 @@ public class ZWaveThermostatSetpointCommandClass extends ZWaveCommandClass
 
         /**
          * Constructor. Creates a instance of the ZWaveThermostatSetpointValueEvent class.
-         * 
+         *
          * @param nodeId the nodeId of the event
          * @param endpoint the endpoint of the event.
          * @param setpointType the setpoint type that triggered the event;

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveVersionCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveVersionCommandClass.java
@@ -30,7 +30,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  * used by the node, the individual command class versions
  * used by the node and the vendor specific application
  * version from a device.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.3.0
  */
@@ -51,7 +51,7 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
 
     /**
      * Creates a new instance of the ZWaveVersionCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -151,7 +151,7 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
 
     /**
      * Gets a SerialMessage with the VERSION_GET command
-     * 
+     *
      * @return the serial message
      */
     public SerialMessage getVersionMessage() {
@@ -168,7 +168,7 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
      * Gets a SerialMessage with the VERSION COMMAND CLASS GET command.
      * This version is used to differentiate between multiple versions of a command
      * and to enable extra functionality.
-     * 
+     *
      * @param commandClass The command class to get the version for.
      * @return the serial message
      */
@@ -185,7 +185,7 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
 
     /**
      * Check the version of a command class by sending a VERSION_COMMAND_CLASS_GET message to the node.
-     * 
+     *
      * @param commandClass the command class to check the version for.
      * @return serial message to be sent
      */
@@ -214,7 +214,7 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
 
     /**
      * Returns the version of the protocol used by the device
-     * 
+     *
      * @return Protocol version as double (version . subversion)
      */
     public String getProtocolVersion() {
@@ -223,7 +223,7 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
 
     /**
      * Returns the version of the firmware used by the device
-     * 
+     *
      * @return Application version as double (version . subversion)
      */
     public String getApplicationVersion() {
@@ -265,7 +265,7 @@ public class ZWaveVersionCommandClass extends ZWaveCommandClass {
         /**
          * Lookup function based on the sensor type code.
          * Returns null if the code does not exist.
-         * 
+         *
          * @param i the code to lookup
          * @return enumeration value of the sensor type.
          */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveWakeUpCommandClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveWakeUpCommandClass.java
@@ -35,7 +35,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 /**
  * Wake Up Command Class. Enables a node to notify another device
  * that it woke up and is ready to receive commands.
- * 
+ *
  * @author Jan-Willem Spuij
  * @author Chris Jackson
  * @since 1.3.0
@@ -90,7 +90,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
 
     /**
      * Creates a new instance of the ZWaveWakeUpCommandClass class.
-     * 
+     *
      * @param node the node this command class belongs to
      * @param controller the controller to use
      * @param endpoint the endpoint this Command class belongs to
@@ -208,7 +208,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the WAKE_UP_NO_MORE_INFORMATION command.
-     * 
+     *
      * @return the serial message
      */
     public SerialMessage getNoMoreInformationMessage() {
@@ -230,7 +230,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
      * The message is only added if it's not the WAKE_UP_NO_MORE_INFORMATION message
      * since we don't want to send this at the next wakeup.
      * This combines the previous 'putInWakeUpQueue' with 'isAlive'.
-     * 
+     *
      * @param serialMessage the message to put in the wake-up queue.
      * @return true if the message can be sent immediately
      */
@@ -264,7 +264,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the WAKE UP INTERVAL GET command
-     * 
+     *
      * @return the serial message
      */
     public SerialMessage getIntervalMessage() {
@@ -280,7 +280,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
 
     /**
      * Gets a SerialMessage with the WAKE UP INTERVAL CAPABILITIES GET command
-     * 
+     *
      * @return the serial message
      */
     public SerialMessage getIntervalCapabilitiesMessage() {
@@ -296,7 +296,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
 
     /**
      * Returns the interval at which the device wakes up every time.
-     * 
+     *
      * @return the interval in seconds.
      */
     public int getInterval() {
@@ -305,7 +305,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
 
     /**
      * Returns the minimum wake up interval that can be set to the device.
-     * 
+     *
      * @return the minInterval in seconds.
      */
     public int getMinInterval() {
@@ -314,7 +314,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
 
     /**
      * Returns the maximum wake up interval that can be set to the device.
-     * 
+     *
      * @return the maxInterval in seconds.
      */
     public int getMaxInterval() {
@@ -323,7 +323,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
 
     /**
      * Returns the factory default wake up interval for the device.
-     * 
+     *
      * @return the defaultInterval in seconds.
      */
     public int getDefaultInterval() {
@@ -332,7 +332,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
 
     /**
      * Returns the minimum step that must be taken into account when setting the interval for the device.
-     * 
+     *
      * @return the intervalStep in seconds.
      */
     public int getIntervalStep() {
@@ -415,7 +415,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
 
     /**
      * Returns whether the node is awake.
-     * 
+     *
      * @return the isAwake
      */
     public boolean isAwake() {
@@ -426,7 +426,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
      * Sets whether the node is awake.
      * If the node is awake we send the first message in the wake-up queue.
      * The remaining messages are triggered within the notification handler
-     * 
+     *
      * @param isAwake the isAwake to set
      */
     public void setAwake(boolean isAwake) {
@@ -463,7 +463,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
     /**
      * Sends a command to the device to set the wakeup interval.
      * The wakeup node is set to the controller.
-     * 
+     *
      * @param interval the wakeup interval in seconds
      * @return the serial message
      * @author Chris Jackson
@@ -484,7 +484,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
 
     /**
      * Gets the size of the wake up queue
-     * 
+     *
      * @return number of messages currently queued
      */
     public int getWakeupQueueLength() {
@@ -493,7 +493,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
 
     /**
      * Gets the target node for the Wakeup command class
-     * 
+     *
      * @return wakeup target node id
      */
     public int getTargetNodeId() {
@@ -502,7 +502,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
 
     /**
      * Gets the time the node last woke up
-     * 
+     *
      * @return Date of the last wakeup
      */
     public Date getLastWakeup() {
@@ -555,7 +555,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
     /**
      * ZWave wake-up event.
      * Notifies users that a device has woken up or changed its wakeup parameters
-     * 
+     *
      * @author Chris Jackson
      * @since 1.5.0
      */
@@ -565,7 +565,7 @@ public class ZWaveWakeUpCommandClass extends ZWaveCommandClass
         /**
          * Constructor. Creates a new instance of the ZWaveWakeUpEvent
          * class.
-         * 
+         *
          * @param nodeId the nodeId of the event.
          */
         public ZWaveWakeUpEvent(int nodeId, int event) {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveCommandClassValueEvent.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveCommandClassValueEvent.java
@@ -14,7 +14,7 @@ import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClas
  * ZWave Command Class event. This event is fired when a command class
  * receives a value from the node. The event can be subclasses to add
  * additional information to the event.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */
@@ -25,7 +25,7 @@ public class ZWaveCommandClassValueEvent extends ZWaveEvent {
 
     /**
      * Constructor. Creates a new instance of the ZWaveCommandClassValueEvent class.
-     * 
+     *
      * @param nodeId the nodeId of the event
      * @param endpoint the endpoint of the event.
      * @param commandClass the command class that fired the ZWaveCommandClassValueEvent;
@@ -40,7 +40,7 @@ public class ZWaveCommandClassValueEvent extends ZWaveEvent {
 
     /**
      * Gets the command class that fired the ZWaveCommandClassValueEvent;
-     * 
+     *
      * @return the command class.
      */
     public CommandClass getCommandClass() {
@@ -49,7 +49,7 @@ public class ZWaveCommandClassValueEvent extends ZWaveEvent {
 
     /**
      * Gets the value for the event.
-     * 
+     *
      * @return the value.
      */
     public Object getValue() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveEvent.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveEvent.java
@@ -12,7 +12,7 @@ package org.openhab.binding.zwave.internal.protocol.event;
  * Z-Wave base event class. The Z-Wave controller notifies listeners using
  * Z-Wave events. Inherited classes should be created to indicate the type
  * of event and a possible event value.
- * 
+ *
  * @author Victor Belov
  * @author Brian Crosby
  * @ since 1.3.0
@@ -23,7 +23,7 @@ public abstract class ZWaveEvent {
 
     /**
      * Constructor. Creates a new instance of the Z-Wave event class.
-     * 
+     *
      * @param nodeId the nodeId of the event
      * @param endpoint the endpoint of the event.
      */
@@ -35,7 +35,7 @@ public abstract class ZWaveEvent {
     /**
      * Constructor. Creates a new instance of the Z-Wave event class
      * with default endpoint.
-     * 
+     *
      * @param nodeId the nodeId of the event
      */
     public ZWaveEvent(int nodeId) {
@@ -44,7 +44,7 @@ public abstract class ZWaveEvent {
 
     /**
      * Gets the node ID of this event.
-     * 
+     *
      * @return
      */
     public int getNodeId() {
@@ -53,7 +53,7 @@ public abstract class ZWaveEvent {
 
     /**
      * Gets the endpoint of this event.
-     * 
+     *
      * @return
      */
     public int getEndpoint() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveInclusionEvent.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveInclusionEvent.java
@@ -10,7 +10,7 @@ package org.openhab.binding.zwave.internal.protocol.event;
 
 /**
  * This event signals a node being included or excluded into the network.
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */
@@ -20,7 +20,7 @@ public class ZWaveInclusionEvent extends ZWaveEvent {
     /**
      * Constructor. Creates a new instance of the ZWaveInclusionEvent
      * class.
-     * 
+     *
      * @param nodeId the nodeId of the event.
      */
     public ZWaveInclusionEvent(Type type, int nodeId) {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveIndicatorCommandClassChangeEvent.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveIndicatorCommandClassChangeEvent.java
@@ -16,7 +16,7 @@ import org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveCommandClas
  * ZWave Command Class event. This event is fired when a command class
  * receives a value from the node. The event can be subclasses to add
  * additional information to the event.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */
@@ -25,7 +25,7 @@ public class ZWaveIndicatorCommandClassChangeEvent extends ZWaveCommandClassValu
 
     /**
      * Constructor. Creates a new instance of the ZWaveCommandClassValueEvent class.
-     * 
+     *
      * @param nodeId the nodeId of the event
      * @param endpoint the endpoint of the event.
      * @param commandClass the command class that fired the ZWaveCommandClassValueEvent;
@@ -40,7 +40,7 @@ public class ZWaveIndicatorCommandClassChangeEvent extends ZWaveCommandClassValu
 
     /**
      * Gets the value for the event.
-     * 
+     *
      * @return the value.
      */
     public int getOldValue() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveInitializationCompletedEvent.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveInitializationCompletedEvent.java
@@ -13,7 +13,7 @@ package org.openhab.binding.zwave.internal.protocol.event;
  * Indicates that the ZWaveController has completed
  * the initialization phase and is ready to start
  * accepting commands and receiving events.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */
@@ -22,7 +22,7 @@ public class ZWaveInitializationCompletedEvent extends ZWaveEvent {
     /**
      * Constructor. Creates a new instance of the ZWaveTransactionCompletedEvent
      * class.
-     * 
+     *
      * @param nodeId the nodeId of the event. Must be set to the controller node.
      */
     public ZWaveInitializationCompletedEvent(int nodeId) {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveNetworkEvent.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveNetworkEvent.java
@@ -12,7 +12,7 @@ package org.openhab.binding.zwave.internal.protocol.event;
  * Network event signals that a network function has completed.
  * This is used to notify higher layers of network functions so they
  * can be handled by (for example) a network heal process.
- * 
+ *
  * @author Chris Jackson
  * @since 1.4.0
  */
@@ -23,7 +23,7 @@ public class ZWaveNetworkEvent extends ZWaveEvent {
     /**
      * Constructor. Creates a new instance of the ZWaveNetworkEvent
      * class.
-     * 
+     *
      * @param nodeId the nodeId of the event.
      */
     public ZWaveNetworkEvent(Type type, int nodeId, State state) {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveNodeInfoEvent.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveNodeInfoEvent.java
@@ -10,7 +10,7 @@ package org.openhab.binding.zwave.internal.protocol.event;
 
 /**
  * This event signals a node information frame.
- * 
+ *
  * @author Chris Jackson
  * @since 1.8.0
  */
@@ -19,7 +19,7 @@ public class ZWaveNodeInfoEvent extends ZWaveEvent {
     /**
      * Constructor. Creates a new instance of the ZWaveInclusionEvent
      * class.
-     * 
+     *
      * @param nodeId the nodeId of the event.
      */
     public ZWaveNodeInfoEvent(int nodeId) {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveNodeStatusEvent.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveNodeStatusEvent.java
@@ -12,7 +12,7 @@ import org.openhab.binding.zwave.internal.protocol.ZWaveNodeState;
 
 /**
  * Node status event is used to signal if a node is alive or dead
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */
@@ -22,7 +22,7 @@ public class ZWaveNodeStatusEvent extends ZWaveEvent {
     /**
      * Constructor. Creates a new instance of the ZWaveNetworkEvent
      * class.
-     * 
+     *
      * @param nodeId the nodeId of the event.
      */
     public ZWaveNodeStatusEvent(int nodeId, ZWaveNodeState state) {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveTransactionCompletedEvent.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/event/ZWaveTransactionCompletedEvent.java
@@ -13,7 +13,7 @@ import org.openhab.binding.zwave.internal.protocol.SerialMessage;
 /**
  * ZWave Transaction Completed Event. Indicated that a transaction (a
  * sequence of messages with an expected reply) has completed.
- * 
+ *
  * @author Jan-Willem Spuij
  * @since 1.4.0
  */
@@ -27,7 +27,7 @@ public class ZWaveTransactionCompletedEvent extends ZWaveEvent {
      * class.
      * The 'state' flag is provided by the message handler when the message is processed
      * and its value is defined by the message class.
-     * 
+     *
      * @param completedMessage the original {@link SerialMessage} that has been completed.
      * @param state a flag indicating success / failure of the transaction processing
      */
@@ -40,7 +40,7 @@ public class ZWaveTransactionCompletedEvent extends ZWaveEvent {
 
     /**
      * Gets the original {@link SerialMessage} that has been completed.
-     * 
+     *
      * @return the original message.
      */
     public SerialMessage getCompletedMessage() {
@@ -49,7 +49,7 @@ public class ZWaveTransactionCompletedEvent extends ZWaveEvent {
 
     /**
      * Returns the processing state of this transaction
-     * 
+     *
      * @return
      */
     public boolean getState() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStage.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeInitStage.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 /**
  * Node Stage Enumeration for node initialisation.
- * 
+ *
  * @author Brian Crosby
  * @author Chris Jackson
  * @since 1.3.0
@@ -69,7 +69,7 @@ public enum ZWaveNodeInitStage {
 
     /**
      * Get the stage protocol number.
-     * 
+     *
      * @return number
      */
     public int getStage() {
@@ -78,7 +78,7 @@ public enum ZWaveNodeInitStage {
 
     /**
      * Get the stage label
-     * 
+     *
      * @return label
      */
     public String getLabel() {
@@ -88,7 +88,7 @@ public enum ZWaveNodeInitStage {
     /**
      * Lookup function based on the command class code.
      * Returns null if there is no command class with code i
-     * 
+     *
      * @param i the code to lookup
      * @return enumeration value of the command class.
      */
@@ -102,7 +102,7 @@ public enum ZWaveNodeInitStage {
 
     /**
      * Return the next stage after the current stage
-     * 
+     *
      * @return the next stage
      */
     public ZWaveNodeInitStage getNextStage() {
@@ -117,7 +117,7 @@ public enum ZWaveNodeInitStage {
 
     /**
      * Check if the current stage has completed the static stages.
-     * 
+     *
      * @return true if static stages complete
      */
     public boolean isStaticComplete() {
@@ -129,7 +129,7 @@ public enum ZWaveNodeInitStage {
 
     /**
      * Check if the current stage has completed the static stages.
-     * 
+     *
      * @return true if static stages complete
      */
     public boolean isStageMandatory() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeSerializer.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeSerializer.java
@@ -87,7 +87,7 @@ public class ZWaveNodeSerializer {
 
     /**
      * Serializes an XML tree of a {@link ZWaveNode}
-     * 
+     *
      * @param node
      *            the node to serialize
      */
@@ -125,7 +125,7 @@ public class ZWaveNodeSerializer {
 
     /**
      * Deserializes an XML tree of a {@link ZWaveNode}
-     * 
+     *
      * @param nodeId
      *            the number of the node to deserialize
      * @return returns the Node or null in case Serialization failed.
@@ -161,7 +161,7 @@ public class ZWaveNodeSerializer {
 
     /**
      * Deletes the persistence store for the specified node.
-     * 
+     *
      * @param nodeId The node ID to remove
      * @return true if the file was deleted
      */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeStageAdvancer.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeStageAdvancer.java
@@ -150,7 +150,7 @@ public class ZWaveNodeStageAdvancer implements ZWaveEventListener {
 
     /**
      * Constructor. Creates a new instance of the ZWaveNodeStageAdvancer class.
-     * 
+     *
      * @param node
      *            the node this advancer belongs to.
      * @param controller
@@ -217,7 +217,7 @@ public class ZWaveNodeStageAdvancer implements ZWaveEventListener {
 
     /**
      * Sends a message if there is one queued
-     * 
+     *
      * @return true if a message was sent. false otherwise.
      */
     private boolean sendMessage() {
@@ -894,7 +894,7 @@ public class ZWaveNodeStageAdvancer implements ZWaveEventListener {
 
     /**
      * Move the messages to the queue
-     * 
+     *
      * @param msgs
      *            the message collection
      */
@@ -909,7 +909,7 @@ public class ZWaveNodeStageAdvancer implements ZWaveEventListener {
 
     /**
      * Move all the messages in a collection to the queue
-     * 
+     *
      * @param msgs
      *            the message collection
      */
@@ -924,7 +924,7 @@ public class ZWaveNodeStageAdvancer implements ZWaveEventListener {
 
     /**
      * Move all the messages in a collection to the queue and encapsulates them
-     * 
+     *
      * @param msgs
      *            the message collection
      * @param the
@@ -943,7 +943,7 @@ public class ZWaveNodeStageAdvancer implements ZWaveEventListener {
 
     /**
      * Gets the current node stage
-     * 
+     *
      * @return current node stage
      */
     public ZWaveNodeInitStage getCurrentStage() {
@@ -963,7 +963,7 @@ public class ZWaveNodeStageAdvancer implements ZWaveEventListener {
 
     /**
      * Sets the time stamp the node was last queried.
-     * 
+     *
      * @param queryStageTimeStamp
      *            the queryStageTimeStamp to set
      */
@@ -973,7 +973,7 @@ public class ZWaveNodeStageAdvancer implements ZWaveEventListener {
 
     /**
      * Returns whether the initialization process has completed.
-     * 
+     *
      * @return true if initialization has completed. False otherwise.
      */
     public boolean isInitializationComplete() {
@@ -982,7 +982,7 @@ public class ZWaveNodeStageAdvancer implements ZWaveEventListener {
 
     /**
      * Returns whether the node was restored from a config file.
-     * 
+     *
      * @return the restoredFromConfigfile
      */
     public boolean isRestoredFromConfigfile() {

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AddNodeMessageClass.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ApplicationCommandMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ApplicationCommandMessageClass.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ApplicationUpdateMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ApplicationUpdateMessageClass.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a Node Information Frame (NIF) message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */
@@ -93,9 +93,12 @@ public class ApplicationUpdateMessageClass extends ZWaveCommandProcessor {
                         // See if the command class already exists on the node
                         CommandClass commandClass = CommandClass.getCommandClass(data);
                         if (node.getCommandClass(commandClass) == null) { // add it
-                            ZWaveCommandClass zwaveCommandClass = ZWaveCommandClass.getInstance(data, node, zController);
+                            ZWaveCommandClass zwaveCommandClass = ZWaveCommandClass.getInstance(data, node,
+                                    zController);
                             if (zwaveCommandClass != null) {
-                                logger.trace(String.format("NODE %d: Application update request. Adding Command class %s.", nodeId,commandClass));
+                                logger.trace(
+                                        String.format("NODE %d: Application update request. Adding Command class %s.",
+                                                nodeId, commandClass));
                                 node.addCommandClass(zwaveCommandClass);
                             }
                         }
@@ -151,7 +154,7 @@ public class ApplicationUpdateMessageClass extends ZWaveCommandProcessor {
 
     /**
      * Update state enumeration. Indicates the type of application update state that was sent.
-     * 
+     *
      * @author Jan-Willem Spuij
      * @ since 1.3.0
      */
@@ -188,7 +191,7 @@ public class ApplicationUpdateMessageClass extends ZWaveCommandProcessor {
         /**
          * Lookup function based on the update state code.
          * Returns null when there is no update state with code i.
-         * 
+         *
          * @param i the code to lookup
          * @return enumeration value of the update state.
          */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AssignReturnRouteMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AssignReturnRouteMessageClass.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AssignSucReturnRouteMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/AssignSucReturnRouteMessageClass.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ControllerSetDefaultMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ControllerSetDefaultMessageClass.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.7.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/DeleteReturnRouteMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/DeleteReturnRouteMessageClass.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/EnableSucMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/EnableSucMessageClass.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This class processes a serial message to enable or disable the controller
  * SUC/SIS functionality
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/GetControllerCapabilitiesMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/GetControllerCapabilitiesMessageClass.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/GetRoutingInfoMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/GetRoutingInfoMessageClass.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/GetSucNodeIdMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/GetSucNodeIdMessageClass.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message to get the SUC node ID
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/GetVersionMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/GetVersionMessageClass.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/IdentifyNodeMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/IdentifyNodeMessageClass.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/IsFailedNodeMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/IsFailedNodeMessageClass.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This class processes a serial message from the zwave controller.
  * It queries the controller to see if the node is on its 'failed nodes' list.
- * 
+ *
  * @author Wez Hunter
  * @since 1.6.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/MemoryGetIdMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/MemoryGetIdMessageClass.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RemoveFailedNodeMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RemoveFailedNodeMessageClass.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RemoveNodeMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RemoveNodeMessageClass.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RequestNodeInfoMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RequestNodeInfoMessageClass.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RequestNodeNeighborUpdateMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/RequestNodeNeighborUpdateMessageClass.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SendDataMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SendDataMessageClass.java
@@ -163,7 +163,7 @@ public class SendDataMessageClass extends ZWaveCommandProcessor {
     /**
      * Transmission state enumeration. Indicates the
      * transmission state of the message to the node.
-     * 
+     *
      * @author Jan-Willem Spuij
      * @ since 1.3.0
      */
@@ -198,7 +198,7 @@ public class SendDataMessageClass extends ZWaveCommandProcessor {
         /**
          * Lookup function based on the transmission state code.
          * Returns null when there is no transmission state with code i.
-         * 
+         *
          * @param i the code to lookup
          * @return enumeration value of the transmission state.
          */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SerialApiGetCapabilitiesMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SerialApiGetCapabilitiesMessageClass.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SerialApiGetInitDataMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SerialApiGetInitDataMessageClass.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SerialApiSetTimeoutsMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SerialApiSetTimeoutsMessageClass.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.7.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SerialApiSoftResetMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SerialApiSoftResetMessageClass.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetSucNodeMessageClass.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/SetSucNodeMessageClass.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class processes a serial message from the zwave controller
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */

--- a/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ZWaveCommandProcessor.java
+++ b/bundles/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/serialmessage/ZWaveCommandProcessor.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  * When the controller has further data, it responds with a REQUEST.
  * These calls map to the handleResponse and handleRequest methods
  * which must be overridden by the individual classes.
- * 
+ *
  * @author Chris Jackson
  * @since 1.5.0
  */
@@ -40,7 +40,7 @@ public abstract class ZWaveCommandProcessor {
 
     /**
      * Checks if the processor marked the transaction as complete
-     * 
+     *
      * @return true is the transaction was completed.
      */
     public boolean isTransactionComplete() {
@@ -50,7 +50,7 @@ public abstract class ZWaveCommandProcessor {
     /**
      * Perform a check to see if this is the expected reply
      * and we can complete the transaction
-     * 
+     *
      * @param lastSentMessage The original message we sent to the controller
      * @param incomingMessage The response from the controller
      */
@@ -77,7 +77,7 @@ public abstract class ZWaveCommandProcessor {
 
     /**
      * Method for handling the response from the controller
-     * 
+     *
      * @param zController the ZWave controller
      * @param lastSentMessage The original message we sent to the controller
      * @param incomingMessage The response from the controller
@@ -91,7 +91,7 @@ public abstract class ZWaveCommandProcessor {
 
     /**
      * Method for handling the request from the controller
-     * 
+     *
      * @param zController the ZWave controller
      * @param lastSentMessage The original message we sent to the controller
      * @param incomingMessage The response from the controller
@@ -105,7 +105,7 @@ public abstract class ZWaveCommandProcessor {
 
     /**
      * Returns the message processor for the specified message class
-     * 
+     *
      * @param serialMessage The message class required to be processed
      * @return The message processor
      */


### PR DESCRIPTION
These changes are made automatically by the "save as" function of the new IDE if a file is edited.  
Would like to commit all of these white space changes independently of any functional changes to avoid mixing white space and functional changes in the same diff.