### PR TITLE
MiOS Binding - Add default configuration entry for openHAB 1.x

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1190,6 +1190,38 @@ hue:secret=openHABRuntime
 # Port of the bridge to control (optional, defaults to 50000)
 #milight:<MilightId2>.port=
 
+################################## MiOS Binding #######################################
+#
+# MiOS Binding Configuration settings allow for multiple MiOS Units,
+# and take the form:
+#
+#   <unit>.<parameter>=<value>
+#
+# Where:
+# * <unit> = a friendly, alpha-numeric, MiOS Unit name used in Item Definitions.
+# * <parameter> is a named parameter, outlined below.
+#
+# The only required parameter is <host>, all others default.  The <unit> name in the
+# example below defaults to "house", but can be any value.
+#
+# IP Address/DNS Name of the MiOS Unit (required, no default)
+#house.host=
+
+# TCP Port (optional, defaults to 3480)
+#house.port=3480
+
+# Timeout time (ms) used to compute MiOS Unit timeouts (optional, defaults to 60000)
+#house.timeout=60000
+
+# Wait time (ms) for MiOS Unit to bundle changes together (optional, defaults to 0)
+#house.minimumDelay=0
+
+# Number of incremental cycles before a full cycle occurs. (optional, defaults to 0)
+#house.refreshCount=0
+
+# Number of communication errors to force a full cycle load (optional, defaults to 1)
+#house.errorCount=1
+
 ############################### Systeminfo Binding ####################################
 #
 # Interval in milliseconds when to find new refresh candidates


### PR DESCRIPTION
Added a section to the default openHAB 1.x configuration file, matching the description in the MiOS Binding Wiki page.

This is an openHAB 1.8.x Cherry-Pick candidate (for ease-of-use)


Ref: https://community.openhab.org/t/mios-where-in-openhab-cfg/7695

Signed-off-by: Mark Clark <mr.guessed@gmail.com> (github: mrguessed)