### PR TITLE
Updated Tellstick performance Closes #4089

### DIFF
--- a/bundles/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickBinding.java
+++ b/bundles/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickBinding.java
@@ -10,9 +10,12 @@ package org.openhab.binding.tellstick.internal;
 
 import java.math.BigDecimal;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import org.openhab.binding.tellstick.TellstickBindingConfig;
 import org.openhab.binding.tellstick.TellstickBindingProvider;
@@ -43,6 +46,7 @@ import com.sun.jna.Platform;
  * device. It uses a JNA bridge to talk to the C api of the tellstick.
  *
  * @author jarlebh
+ * @author Elias Gabrielsson
  * @since 1.5.0
  */
 public class TellstickBinding extends AbstractActiveBinding<TellstickBindingProvider>implements ManagedService {
@@ -64,9 +68,14 @@ public class TellstickBinding extends AbstractActiveBinding<TellstickBindingProv
      */
     private long refreshInterval = 60000;
 
-    private TellstickController controller = new TellstickController();
+    private TellstickController controller;
+    private Thread controllerThread;
+    private SortedMap<TellstickDevice, TellstickSendEvent> messageQue;
 
     public TellstickBinding() {
+        messageQue = Collections.synchronizedSortedMap(new TreeMap<TellstickDevice, TellstickSendEvent>());
+        controller = new TellstickController(messageQue);
+        controllerThread = new Thread(controller);
     }
 
     @Override
@@ -79,6 +88,7 @@ public class TellstickBinding extends AbstractActiveBinding<TellstickBindingProv
         logger.info("Deactivate " + this);
         try {
             deRegisterListeners();
+            controllerThread.interrupt();
         } catch (Exception e) {
             logger.error("Failed to deactivate", e);
         }
@@ -114,11 +124,14 @@ public class TellstickBinding extends AbstractActiveBinding<TellstickBindingProv
         logger.debug("internalReceiveCommand() is called! for " + itemName + " with " + command);
         TellstickBindingConfig config = findTellstickBindingConfig(itemName);
         if (config != null) {
-            try {
-                TellstickDevice dev = findDevice(config);
-                controller.handleSendEvent(config, dev, command);
-            } catch (Exception e) {
-                logger.error("Failed to send msg to " + config, e);
+            if(!controllerThread.isAlive()){
+                controllerThread.start();
+            }
+            TellstickDevice dev = findDevice(config);
+            Long eventTime = System.currentTimeMillis();
+            synchronized (messageQue) {
+                messageQue.put(dev, new TellstickSendEvent(config, dev, command, eventTime));
+                messageQue.notify();
             }
         }
     }

--- a/bundles/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickController.java
+++ b/bundles/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickController.java
@@ -61,7 +61,7 @@ public class TellstickController implements Runnable {
                 try {
                     handleSendEvent(sendEvent.getConfig(), sendEvent.getDev(), sendEvent.getCommand());
                 } catch (TellstickException e) {
-                    logger.error("Failed to send msg to " + sendEvent.getConfig(), e);
+                    logger.error("Failed to send msg to {}, error: {}", sendEvent.getConfig(), e);
                 }
 
             } catch (InterruptedException ie) {
@@ -77,7 +77,7 @@ public class TellstickController implements Runnable {
         long resendInterval = config.getResendInterval();
         for (int i = 0; i < resend; i++) {
             checkLastAndWait(resendInterval);
-            logger.info("Send " + command + " to " + dev + " time=" + i + " conf " + config);
+            logger.info("Send {} to {} time={} conf: {}", command, dev, i, config);
             switch (config.getValueSelector()) {
 
                 case COMMAND:
@@ -159,7 +159,7 @@ public class TellstickController implements Runnable {
 
     private void checkLastAndWait(long resendInterval) {
         while ((System.currentTimeMillis() - lastSend) < resendInterval) {
-            logger.info("Wait for " + resendInterval + " millisec");
+            logger.info("Wait for {} millisec", resendInterval);
             try {
                 Thread.sleep(resendInterval);
             } catch (InterruptedException e) {

--- a/bundles/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickSendEvent.java
+++ b/bundles/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/internal/TellstickSendEvent.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.tellstick.internal;
+
+import org.openhab.binding.tellstick.TellstickBindingConfig;
+import org.openhab.binding.tellstick.internal.device.TellstickDevice;
+import org.openhab.core.types.Command;
+
+/**
+ * This is a wrapper class for handle the send queue to the Tellstick device.
+ *
+ * @author Elias Gabrielsson
+ * @since 1.9.0
+ */
+
+public class TellstickSendEvent implements Comparable<TellstickSendEvent> {
+    private TellstickBindingConfig config;
+    private TellstickDevice dev;
+    private Command command;
+    private Long eventTime;
+
+    public TellstickSendEvent(TellstickBindingConfig config, TellstickDevice dev, Command command, Long eventTime) {
+        this.config = config;
+        this.dev = dev;
+        this.command = command;
+        this.eventTime = eventTime;
+    }
+
+    public Command getCommand() {
+        return command;
+    }
+
+    public TellstickBindingConfig getConfig() {
+        return config;
+    }
+
+    public TellstickDevice getDev() {
+        return dev;
+    }
+
+    public Long getEventTime() {
+        return eventTime;
+    }
+
+    public void setCommand(Command command) {
+        this.command = command;
+    }
+
+    public void setConfig(TellstickBindingConfig config) {
+        this.config = config;
+    }
+
+    public void setDev(TellstickDevice dev) {
+        this.dev = dev;
+    }
+
+    public void setEventTime(Long eventTime) {
+        this.eventTime = eventTime;
+    }
+
+    @Override
+    public int compareTo(TellstickSendEvent o) {
+        return eventTime.compareTo(o.getEventTime());
+    }
+}


### PR DESCRIPTION
This will improve send performance for sliding dimmer devices with over 50% in certain cases.
If issue #1683 still exist I guess its fixed by this patch.
#### Internal design:

An internal send que between tellstick binding and controller have been implemented.
The que removes outdated send events which not have been broadcasted by the tellstick device yet.

Signed-off-by: Elias Gabrielsson elias@rehash.se (github: EliasGabrielsson)
