### PR TITLE
[garadget] avoid NPE if comm failure

### DIFF
--- a/bundles/binding/org.openhab.binding.garadget/src/main/java/org/openhab/binding/garadget/internal/GaradgetBinding.java
+++ b/bundles/binding/org.openhab.binding.garadget/src/main/java/org/openhab/binding/garadget/internal/GaradgetBinding.java
@@ -237,6 +237,10 @@ public class GaradgetBinding extends AbstractActiveBinding<GaradgetBindingProvid
 
         for (final String deviceId : pollMap.keySet()) {
             final GaradgetDevice device = devices.get(deviceId);
+            if (device == null) {
+                logger.warn("Unable to poll variables for deviceId {}; skipping.", deviceId);
+                continue;
+            }
             final TreeSet<String> varNames = pollMap.get(deviceId);
             for (final String varName : varNames) {
                 connection.sendCommand(device, varName, null, new HttpResponseHandler() {


### PR DESCRIPTION
Comm failures may return empty map of devices.  Skip variable poll in those cases to avoid NPE.