### PR TITLE
Zwave product database entries for two Devolo devices

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -30,6 +30,17 @@
 			<Label lang="en">Scene Switch</Label>
 			<ConfigFile>devolo/mt2652.xml</ConfigFile>
 		</Product>
+		<Product>
+			<Reference>
+				<Type>2004</Type>
+				<Id>04a4</Id>
+			</Reference>
+			<Model>ZS6101</Model>
+			<Label lang="en">Smoke Detector</Label>
+			<Label lang="de">Rauchmelder</Label>
+			<!--Use the Configuration for the Vision ZS6101 -->
+			<ConfigFile>vision/zs6101.xml</ConfigFile>
+		</Product>
 	</Manufacturer>
 	<Manufacturer>
 		<Id>0000</Id>
@@ -2107,6 +2118,16 @@
 			<Model>LCZ251</Model>
 			<Label lang="en">Living Connect Z Thermostat 2.51</Label>
 			<Label lang="de">Living Connect Z Thermostat 2.51</Label>
+			<ConfigFile>danfoss/lcz_251.xml</ConfigFile>
+		</Product>
+		<Product>
+			<Reference> <!-- This Type and Id are know to be used by the Devolo badged device --> 
+				<Type>0005</Type>
+				<Id>0175</Id>
+			</Reference>
+			<Model>LCZ</Model>
+			<Label lang="en">Living Connect Z Thermostat (Devolo)</Label>
+			<Label lang="de">Living Connect Z Thermostat (Devolo)</Label>
 			<ConfigFile>danfoss/lcz_251.xml</ConfigFile>
 		</Product>
 		<Product>


### PR DESCRIPTION
Devolo resells a number of Z-Wave devices. In this case a Danfoss theromstat and a Vision smoke detector.
The Danfoss theromstat has kept it manufacture id but has a no device reference.
The Vison smoke detector has been given the Devolo manufacture id.

In both cases the products.xml has a new entry for the device which simply reference the OEM ConfigFile.
