### PR TITLE
eBUS - Fix NullPointException if telegram value is invalid/out of range

### DIFF
--- a/bundles/binding/org.openhab.binding.ebus/src/main/java/org/openhab/binding/ebus/internal/parser/EBusTelegramParser.java
+++ b/bundles/binding/org.openhab.binding.ebus/src/main/java/org/openhab/binding/ebus/internal/parser/EBusTelegramParser.java
@@ -333,6 +333,12 @@ public class EBusTelegramParser {
                 // Extract the value from byte buffer
                 Object value = getValue(byteBuffer, entry.getValue());
 
+                if(value == null) {
+                    // its okay if the value is null, maybe out of range min/max or replace value found
+                    logger.trace("Returned value is null, skip ...");
+                    continue;
+                }
+
                 // If compiled script available for this key, execute it now
                 if (settings.getCsript() != null) {
                     try {


### PR DESCRIPTION
If the value is out of min/max range the returned value can be null. This is okay, but need to be catched.