### PR TITLE
ClassicUI: full image and chart refresh

### DIFF
--- a/bundles/ui/org.openhab.ui.webapp/snippets/chart.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/chart.html
@@ -1,1 +1,1 @@
-%setrefresh%<p><center><img style="padding:10px;width:90%" src="%url%" %refresh% /></center></p>
+<p><center><img style="padding:10px;width:90%" src="%url%" %refresh% /></center></p>

--- a/bundles/ui/org.openhab.ui.webapp/snippets/image.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/image.html
@@ -1,1 +1,1 @@
-%setrefresh%<p><center><img style="padding:10px;width:90%" src="%url%" %refresh% /></center></p>
+<p><center><img style="padding:10px;width:90%" src="%url%" %refresh% /></center></p>

--- a/bundles/ui/org.openhab.ui.webapp/snippets/image_link.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/image_link.html
@@ -1,1 +1,1 @@
-%setrefresh%<p><center><a href="#_%id%" onclick="OH.asyncLoad('%id%')"><img style="padding:10px;width:90%" src="%url%" %refresh% /></a></center></p>
+<p><center><a href="#_%id%" onclick="OH.asyncLoad('%id%')"><img style="padding:10px;width:90%" src="%url%" %refresh% /></a></center></p>

--- a/bundles/ui/org.openhab.ui.webapp/snippets/main.html
+++ b/bundles/ui/org.openhab.ui.webapp/snippets/main.html
@@ -50,8 +50,6 @@
         search = search + "sitemap=%sitemap%&w=" + hash.substring(2) + "&poll=true";
         url = path + search;
         WA.Request(url, null, -1, true, null); 
-        OH.imageRefresh = OH.imagesToRefreshOnPage;
-        OH.imagesToRefreshOnPage = 0;
       });
 
       WA.AddEventListener("load", function () {
@@ -105,13 +103,29 @@
         WA.Request(request, null, null, true);
       };
 
-      // Functions for image refresh
-      OH.imageRefresh = 0;
-      OH.imagesToRefreshOnPage = 0;
+      // Functions for image and chart support
+
+      OH.imageTimers = {};
+
+      OH.startReloadImage = function startReloadImage(url, id) {
+        var img = document.getElementById(id);
+        if (img && OH.imageTimers[id] === undefined) {
+          OH.imageTimers[id] = setTimeout('OH.reloadImage(\''+url+'\', \''+id+'\')', img.dataset.timeout);
+        }
+      }
 
       OH.reloadImage = function reloadImage(url, id) {
-        if (OH.imageRefresh) {
-          document.getElementById(id).src = url + new Date().getMilliseconds();
+        OH.imageTimers[id] = undefined;
+        var img = document.getElementById(id);
+        if (img) {
+          // if image is currently visible
+          if (img.offsetWidth > 0 && img.offsetHeight > 0) { 
+            // load the specified URL with cache busting
+            img.src = url.replace( /&t=\d+/g , '&t=' + new Date().getTime());
+          } else {
+            // load a blank image (a data URI does not work in Safari)
+            img.src = "images/none.png";
+          }
         }
       };
 

--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/ChartRenderer.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/ChartRenderer.java
@@ -8,6 +8,8 @@
  */
 package org.openhab.ui.webapp.internal.render;
 
+import java.util.Date;
+
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.emf.common.util.EList;
 import org.openhab.core.items.GroupItem;
@@ -54,23 +56,20 @@ public class ChartRenderer extends AbstractWidgetRenderer {
 				itemParam = "items=" + chart.getItem();
 			}
 			
-			String url = "/chart?" + itemParam + "&period=" + chart.getPeriod() + "&random=1";
+			String url = "/chart?" + itemParam + "&period=" + chart.getPeriod() + "&t=" + (new Date()).getTime();
 			if(chart.getService() != null)
 				url += "&service=" + chart.getService();
 			
 			String snippet = getSnippet("image");			
 
 			if(chart.getRefresh()>0) {
-				snippet = StringUtils.replace(snippet, "%setrefresh%", "<script type=\"text/javascript\">OH.imagesToRefreshOnPage=1</script>");
-				snippet = StringUtils.replace(snippet, "%refresh%", "id=\"%id%\" onload=\"setTimeout('OH.reloadImage(\\'%url%\\', \\'%id%\\')', " + chart.getRefresh() + ")\"");
+				snippet = StringUtils.replace(snippet, "%refresh%", "id=\"%id%\" data-timeout=\"" + chart.getRefresh() + "\" onload=\"OH.startReloadImage('%url%', '%id%')\"");
 			} else {
-				snippet = StringUtils.replace(snippet, "%setrefresh%", "");
 				snippet = StringUtils.replace(snippet, "%refresh%", "");
 			}
 
 			snippet = StringUtils.replace(snippet, "%id%", itemUIRegistry.getWidgetId(w));
 			snippet = StringUtils.replace(snippet, "%url%", url);
-			snippet = StringUtils.replace(snippet, "%refresh%", Integer.toString(chart.getRefresh()));
 			
 			sb.append(snippet);
 		} catch (ItemNotFoundException e) {

--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/ImageRenderer.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/ImageRenderer.java
@@ -43,10 +43,8 @@ public class ImageRenderer extends AbstractWidgetRenderer {
 				getSnippet("image_link") : getSnippet("image");			
 
 		if(image.getRefresh()>0) {
-			snippet = StringUtils.replace(snippet, "%setrefresh%", "<script type=\"text/javascript\">OH.imagesToRefreshOnPage=1</script>");
-			snippet = StringUtils.replace(snippet, "%refresh%", "id=\"%id%\" onload=\"setTimeout('OH.reloadImage(\\'%url%\\', \\'%id%\\')', " + image.getRefresh() + ")\"");
+			snippet = StringUtils.replace(snippet, "%refresh%", "id=\"%id%\" data-timeout=\"" + image.getRefresh() + "\" onload=\"OH.startReloadImage('%url%', '%id%')\"");
 		} else {
-			snippet = StringUtils.replace(snippet, "%setrefresh%", "");
 			snippet = StringUtils.replace(snippet, "%refresh%", "");
 		}
 		


### PR DESCRIPTION
Support the `refresh=` parameter to Image and Chart widgets in all cases in the classic web UI.  Testing feedback should go in [this topic](https://community.openhab.org/t/please-help-test-fix-for-image-and-chart-refresh-in-classic-web-ui/8106).

Same change as in https://github.com/eclipse/smarthome/pull/1106.
