### PR TITLE
OneWireBinding: New feature pushbutton

### DIFF
--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OneWireBinding.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OneWireBinding.java
@@ -18,7 +18,8 @@ import org.openhab.binding.onewire.internal.connection.OneWireConnection;
 import org.openhab.binding.onewire.internal.control.AbstractOneWireControlBindingConfig;
 import org.openhab.binding.onewire.internal.deviceproperties.AbstractOneWireDevicePropertyBindingConfig;
 import org.openhab.binding.onewire.internal.deviceproperties.AbstractOneWireDevicePropertyWritableBindingConfig;
-import org.openhab.binding.onewire.internal.listener.InterfaceOneWireDevicePropertyWantsUpdateListener;
+import org.openhab.binding.onewire.internal.deviceproperties.OneWireDevicePropertyExecutableBindingConfig;
+import org.openhab.binding.onewire.internal.listener.OneWireDevicePropertyWantsUpdateListener;
 import org.openhab.binding.onewire.internal.listener.OneWireDevicePropertyWantsUpdateEvent;
 import org.openhab.binding.onewire.internal.scheduler.OneWireUpdateScheduler;
 import org.openhab.core.binding.AbstractBinding;
@@ -42,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * @since 0.6.0
  */
 public class OneWireBinding extends AbstractBinding<OneWireBindingProvider>
-        implements ManagedService, InterfaceOneWireDevicePropertyWantsUpdateListener {
+        implements ManagedService, OneWireDevicePropertyWantsUpdateListener {
 
     private static final Logger logger = LoggerFactory.getLogger(OneWireBinding.class);
 
@@ -116,13 +117,23 @@ public class OneWireBinding extends AbstractBinding<OneWireBindingProvider>
 
         OneWireBindingConfig lvBindigConfig = getBindingConfig(pvItemName);
 
-        if (lvBindigConfig instanceof AbstractOneWireDevicePropertyWritableBindingConfig) {
+        if (lvBindigConfig instanceof OneWireDevicePropertyExecutableBindingConfig) {
+            // This Binding implements a special behavior
+            logger.debug("call execute for item " + pvItemName);
+
+            ((OneWireDevicePropertyExecutableBindingConfig) lvBindigConfig).execute(pvCommand);
+        } else if (lvBindigConfig instanceof AbstractOneWireDevicePropertyWritableBindingConfig) {
+            logger.debug("write to item " + pvItemName);
+
             AbstractOneWireDevicePropertyWritableBindingConfig lvWritableBindingConfig = (AbstractOneWireDevicePropertyWritableBindingConfig) lvBindigConfig;
 
+            // Standard Write Operation
             String lvStringValue = lvWritableBindingConfig.convertTypeToString(pvCommand);
 
             OneWireConnection.writeToOneWire(lvWritableBindingConfig.getDevicePropertyPath(), lvStringValue);
         } else if (lvBindigConfig instanceof AbstractOneWireControlBindingConfig) {
+            logger.debug("call executeControl for item " + pvItemName);
+
             AbstractOneWireControlBindingConfig lvControlBindingConfig = (AbstractOneWireControlBindingConfig) lvBindigConfig;
             lvControlBindingConfig.executeControl(this, pvCommand);
         } else {

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OneWireBindingConfigFactory.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OneWireBindingConfigFactory.java
@@ -11,6 +11,7 @@ package org.openhab.binding.onewire.internal;
 import org.openhab.binding.onewire.internal.control.OneWireClearCacheControlBindingConfig;
 import org.openhab.binding.onewire.internal.deviceproperties.OneWireDevicePropertyContactBindingConfig;
 import org.openhab.binding.onewire.internal.deviceproperties.OneWireDevicePropertyNumberBindingConfig;
+import org.openhab.binding.onewire.internal.deviceproperties.OneWireDevicePropertyPushButtonBindingConfig;
 import org.openhab.binding.onewire.internal.deviceproperties.OneWireDevicePropertyStringBindingConfig;
 import org.openhab.binding.onewire.internal.deviceproperties.OneWireDevicePropertySwitchBindingConfig;
 import org.openhab.binding.onewire.internal.deviceproperties.OneWireDevicePropertySwitchMinMaxNumberWarningBindingConfig;
@@ -37,7 +38,8 @@ public class OneWireBindingConfigFactory {
     /**
      * @param pvItem
      * @param pvBindingConfig
-     * @return a new BindingConfig, corresponding to the given <code><pvItem/code> and <code><pvBindingConfig/code>
+     * @return a new BindingConfig, corresponding to the given
+     *         <code><pvItem/code> and <code><pvBindingConfig/code>
      * @throws BindingConfigParseException
      */
     public static OneWireBindingConfig createOneWireDeviceProperty(Item pvItem, String pvBindingConfig)
@@ -47,6 +49,8 @@ public class OneWireBindingConfigFactory {
         OneWireBindingConfig lvNewBindingConfig = null;
         if (OneWireClearCacheControlBindingConfig.isBindingConfigToCreate(pvItem, pvBindingConfig)) {
             lvNewBindingConfig = new OneWireClearCacheControlBindingConfig(pvBindingConfig);
+        } else if (OneWireDevicePropertyPushButtonBindingConfig.isBindingConfigToCreate(pvItem, pvBindingConfig)) {
+            lvNewBindingConfig = new OneWireDevicePropertyPushButtonBindingConfig(pvBindingConfig);
         } else if (OneWireDevicePropertySwitchMinMaxNumberWarningBindingConfig.isBindingConfigToCreate(pvItem,
                 pvBindingConfig)) {
             lvNewBindingConfig = new OneWireDevicePropertySwitchMinMaxNumberWarningBindingConfig(pvBindingConfig);
@@ -69,10 +73,11 @@ public class OneWireBindingConfigFactory {
     }
 
     /**
-     * 
+     *
      * @param pvItem
      * @param pvBindingConfig
-     * @return is the given Item a valid one, which can be used for a OneWireBinding?
+     * @return is the given Item a valid one, which can be used for a
+     *         OneWireBinding?
      * @throws BindingConfigParseException
      */
     public static boolean isValidItemType(Item pvItem, String pvBindingConfig) throws BindingConfigParseException {

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/AbstractOneWireDevicePropertyBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/AbstractOneWireDevicePropertyBindingConfig.java
@@ -11,7 +11,7 @@ package org.openhab.binding.onewire.internal.deviceproperties;
 import java.util.ArrayList;
 
 import org.openhab.binding.onewire.internal.OneWireBindingConfig;
-import org.openhab.binding.onewire.internal.deviceproperties.modifier.InterfaceOneWireTypeModifier;
+import org.openhab.binding.onewire.internal.deviceproperties.modifier.OneWireTypeModifier;
 import org.openhab.core.types.Type;
 import org.openhab.model.item.binding.BindingConfigParseException;
 import org.slf4j.Logger;
@@ -70,7 +70,7 @@ public abstract class AbstractOneWireDevicePropertyBindingConfig implements OneW
     private int ivAutoRefreshInSecs = 60; // Default 60 Sekunden
 
     /** maintains state of filters for eliminating outliers */
-    private ArrayList<InterfaceOneWireTypeModifier> ivTypeModifieryList = new ArrayList<InterfaceOneWireTypeModifier>();
+    private ArrayList<OneWireTypeModifier> ivTypeModifieryList = new ArrayList<OneWireTypeModifier>();
 
     public AbstractOneWireDevicePropertyBindingConfig(String pvBindingConfig) throws BindingConfigParseException {
         super();
@@ -196,7 +196,7 @@ public abstract class AbstractOneWireDevicePropertyBindingConfig implements OneW
      * @return a list of configured modifiers for this 1-Wire property device
      *         binding
      */
-    public ArrayList<InterfaceOneWireTypeModifier> getTypeModifieryList() {
+    public ArrayList<OneWireTypeModifier> getTypeModifieryList() {
         return ivTypeModifieryList;
     }
 
@@ -209,7 +209,7 @@ public abstract class AbstractOneWireDevicePropertyBindingConfig implements OneW
     public Type convertReadValueToType(String pvReadValue) {
         Type lvType = convertReadValueToUnmodifiedType(pvReadValue);
 
-        for (InterfaceOneWireTypeModifier lvTypeModifier : getTypeModifieryList()) {
+        for (OneWireTypeModifier lvTypeModifier : getTypeModifieryList()) {
             logger.debug("type of " + getDevicePropertyPath() + " before modifier:" + lvTypeModifier.getModifierName()
                     + "type=" + lvType.toString());
             lvType = lvTypeModifier.modify4Read(lvType);

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/AbstractOneWireDevicePropertyWritableBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/AbstractOneWireDevicePropertyWritableBindingConfig.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.binding.onewire.internal.deviceproperties;
 
-import org.openhab.binding.onewire.internal.deviceproperties.modifier.InterfaceOneWireTypeModifier;
+import org.openhab.binding.onewire.internal.deviceproperties.modifier.OneWireTypeModifier;
 import org.openhab.core.types.Type;
 import org.openhab.model.item.binding.BindingConfigParseException;
 import org.slf4j.Logger;
@@ -37,7 +37,7 @@ public abstract class AbstractOneWireDevicePropertyWritableBindingConfig
      *         property
      */
     public String convertTypeToString(Type pvType) {
-        for (InterfaceOneWireTypeModifier lvTypeModifier : getTypeModifieryList()) {
+        for (OneWireTypeModifier lvTypeModifier : getTypeModifieryList()) {
             logger.debug("type of " + getDevicePropertyPath() + " before modifier:" + lvTypeModifier.getModifierName()
                     + "type=" + pvType.toString());
             pvType = lvTypeModifier.modify4Write(pvType);

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/OneWireDevicePropertyExecutableBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/OneWireDevicePropertyExecutableBindingConfig.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.onewire.internal.deviceproperties;
+
+import org.openhab.core.types.Command;
+
+
+
+/**
+ * Interface to implement a special behavior for Items (like a Switch Tab)
+ * 
+ * @author Dennis Riegelbauer
+ * @since 1.7.0
+ * 
+ */
+public interface OneWireDevicePropertyExecutableBindingConfig {
+
+	public void execute(Command pvCommand); 
+
+}

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/OneWireDevicePropertyPushButtonBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/OneWireDevicePropertyPushButtonBindingConfig.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.onewire.internal.deviceproperties;
+
+import org.openhab.binding.onewire.internal.connection.OneWireConnection;
+import org.openhab.core.items.Item;
+import org.openhab.core.library.items.SwitchItem;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.types.Command;
+import org.openhab.model.item.binding.BindingConfigParseException;
+
+/**
+ * This Class is a specialized writable BindingConfig with a special execute command. 
+ * It connects openHab Switch-Items to 1-Wire device properties and simulates a PushButton (ON-wait-OFF or OFF-wait-ON)
+ * 
+ * For Basic Configuration of the binding, see
+ * OneWireDevicePropertySwitchBindingConfig.java
+ * 
+ * Example:
+ * <ul>
+ * <li>
+ * <code>onewire="deviceId=29.66C30E000000;propertyName=sensed.0;refreshinterval=10";pushbutton=500;invert",autoupdate="false"</code>
+ * </li>
+ * </ul>
+ * 
+ * @author Dennis Riegelbauer
+ * @since 1.7.0
+ * 
+ */
+public class OneWireDevicePropertyPushButtonBindingConfig extends
+		OneWireDevicePropertySwitchBindingConfig implements
+		OneWireDevicePropertyExecutableBindingConfig {
+
+	private int waitTime;
+	
+	public OneWireDevicePropertyPushButtonBindingConfig(String pvBindingConfig)
+			throws BindingConfigParseException {
+		super(pvBindingConfig);
+		super.parseBindingConfig(pvBindingConfig);
+		this.parsePushButtonConfig(pvBindingConfig);
+	}
+	
+	protected void parseBindingConfig(String pvBindingConfig) throws BindingConfigParseException {
+		String[] lvConfigParts = pvBindingConfig.trim().split(";");
+
+		for (String lvConfigPart : lvConfigParts) {
+			parsePushButtonConfig(lvConfigPart);
+		}
+	}
+	
+	private void parsePushButtonConfig(String pvConfigPart) {
+		String lvConfigProperty = null;
+
+		lvConfigProperty = "pushbutton=";
+		if (pvConfigPart.startsWith(lvConfigProperty)) {
+			String lvConfigValue = pvConfigPart.substring(lvConfigProperty.length());
+			this.waitTime = Integer.parseInt(lvConfigValue);
+		}
+	}
+	
+	/**
+	 * Checks, if this special binding-type matches to the given pvBindingConfig
+	 * 
+	 * @param pvItem
+	 * @param pvBindingConfig
+	 * @return boolean
+	 */
+	public static boolean isBindingConfigToCreate(Item pvItem, String pvBindingConfig) {
+		return ((pvItem instanceof SwitchItem) && (pvBindingConfig.contains("pushbutton")));
+	}
+
+	@Override
+	public void execute(Command pvCommand) {
+		if (pvCommand.equals(OnOffType.ON)) {
+			write(OnOffType.ON);
+			sleep();
+			write(OnOffType.OFF);
+		} else if (pvCommand.equals(OnOffType.OFF)) {
+			write(OnOffType.OFF);
+			sleep();
+			write(OnOffType.ON);
+		} else {
+			throw new IllegalStateException("Unknown command for this binding:"
+					+ pvCommand.toString());
+		}		
+	}
+	
+	private void sleep() {
+		try {
+			Thread.sleep(this.waitTime);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
+	private void write(Command pvCommand) {
+		OneWireConnection.writeToOneWire(this.getDevicePropertyPath(),
+				this.convertTypeToString(pvCommand));
+	}
+
+	@Override
+	public String toString() {
+		final int maxLen = 20;
+		return "OneWireDevicePropertyPushButtonBindingConfig [getDeviceId()="
+				+ getDeviceId()
+				+ ", getPropertyName()="
+				+ getPropertyName()
+				+ ", getAutoRefreshInSecs()="
+				+ getAutoRefreshInSecs()
+				+ ", getDevicePropertyPath()="
+				+ getDevicePropertyPath()
+				+ ", getTypeModifieryList()="
+				+ (getTypeModifieryList() != null ? getTypeModifieryList()
+						.subList(0,
+								Math.min(getTypeModifieryList().size(), maxLen))
+						: null) + "]";
+	}
+}

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/OneWireDevicePropertySwitchBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/OneWireDevicePropertySwitchBindingConfig.java
@@ -40,7 +40,7 @@ public class OneWireDevicePropertySwitchBindingConfig extends AbstractOneWireDev
         parseBindingConfig(pvBindingConfig);
     }
 
-    private void parseBindingConfig(String pvBindingConfig) throws BindingConfigParseException {
+    protected void parseBindingConfig(String pvBindingConfig) throws BindingConfigParseException {
         String[] lvConfigParts = pvBindingConfig.trim().split(";");
 
         for (String lvConfigPart : lvConfigParts) {

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/modifier/AbstractOneWireDecimalTypeModifier.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/modifier/AbstractOneWireDecimalTypeModifier.java
@@ -18,7 +18,7 @@ import org.openhab.core.types.Type;
  * @since 1.7.0
  *
  */
-abstract public class AbstractOneWireDecimalTypeModifier implements InterfaceOneWireTypeModifier {
+abstract public class AbstractOneWireDecimalTypeModifier implements OneWireTypeModifier {
 
     /*
      * (non-Javadoc)

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/modifier/AbstractOneWireOnOffTypeModifier.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/modifier/AbstractOneWireOnOffTypeModifier.java
@@ -18,7 +18,7 @@ import org.openhab.core.types.Type;
  * @since 1.7.0
  *
  */
-abstract public class AbstractOneWireOnOffTypeModifier implements InterfaceOneWireTypeModifier {
+abstract public class AbstractOneWireOnOffTypeModifier implements OneWireTypeModifier {
 
     /*
      * (non-Javadoc)

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/modifier/AbstractOneWireOpenClosedTypeModifier.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/modifier/AbstractOneWireOpenClosedTypeModifier.java
@@ -18,7 +18,7 @@ import org.openhab.core.types.Type;
  * @since 1.7.0
  *
  */
-abstract public class AbstractOneWireOpenClosedTypeModifier implements InterfaceOneWireTypeModifier {
+abstract public class AbstractOneWireOpenClosedTypeModifier implements OneWireTypeModifier {
 
     /*
      * (non-Javadoc)

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/modifier/OneWireTypeModifier.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/deviceproperties/modifier/OneWireTypeModifier.java
@@ -17,7 +17,7 @@ import org.openhab.core.types.Type;
  * @since 1.7.0
  *
  */
-public interface InterfaceOneWireTypeModifier {
+public interface OneWireTypeModifier {
 
     /**
      * @return name of the modifier

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/listener/OneWireDevicePropertyWantsUpdateListener.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/listener/OneWireDevicePropertyWantsUpdateListener.java
@@ -17,7 +17,7 @@ import java.util.EventListener;
  * @since 1.7.0
  *
  */
-public interface InterfaceOneWireDevicePropertyWantsUpdateListener extends EventListener {
+public interface OneWireDevicePropertyWantsUpdateListener extends EventListener {
 
     /**
      * This method must be implemenented by the classes, which implements the Listener

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/scheduler/OneWireUpdateScheduler.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/scheduler/OneWireUpdateScheduler.java
@@ -19,7 +19,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.openhab.binding.onewire.internal.listener.InterfaceOneWireDevicePropertyWantsUpdateListener;
+import org.openhab.binding.onewire.internal.listener.OneWireDevicePropertyWantsUpdateListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +71,7 @@ public class OneWireUpdateScheduler {
     /**
      * @param pvWantsUpdateListener
      */
-    public OneWireUpdateScheduler(InterfaceOneWireDevicePropertyWantsUpdateListener pvWantsUpdateListener) {
+    public OneWireUpdateScheduler(OneWireDevicePropertyWantsUpdateListener pvWantsUpdateListener) {
         super();
         ivOneWireUpdateTask = new OneWireUpdateTask(ivUpdateQueue, pvWantsUpdateListener);
     }

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/scheduler/OneWireUpdateTask.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/scheduler/OneWireUpdateTask.java
@@ -13,7 +13,7 @@ package org.openhab.binding.onewire.internal.scheduler;
 
 import java.util.concurrent.BlockingQueue;
 
-import org.openhab.binding.onewire.internal.listener.InterfaceOneWireDevicePropertyWantsUpdateListener;
+import org.openhab.binding.onewire.internal.listener.OneWireDevicePropertyWantsUpdateListener;
 import org.openhab.binding.onewire.internal.listener.OneWireDevicePropertyWantsUpdateEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,10 +31,10 @@ public class OneWireUpdateTask extends Thread {
 
     private final BlockingQueue<String> ivUpdateQueue;
 
-    private InterfaceOneWireDevicePropertyWantsUpdateListener ivWantsUpdateListener;
+    private OneWireDevicePropertyWantsUpdateListener ivWantsUpdateListener;
 
     public OneWireUpdateTask(BlockingQueue<String> pvQueue,
-            InterfaceOneWireDevicePropertyWantsUpdateListener pvWantsUpdateListener) {
+            OneWireDevicePropertyWantsUpdateListener pvWantsUpdateListener) {
         super("OneWireBinding/ReaderTask");
         setDaemon(true);
         this.ivUpdateQueue = pvQueue;
@@ -70,7 +70,7 @@ public class OneWireUpdateTask extends Thread {
     /**
      * @return
      */
-    public InterfaceOneWireDevicePropertyWantsUpdateListener getIvWantsUpdateListener() {
+    public OneWireDevicePropertyWantsUpdateListener getIvWantsUpdateListener() {
         return ivWantsUpdateListener;
     }
 }


### PR DESCRIPTION
The new option makes it possible to use a relay like a pushbutton. It
is possible to do that with a rule and timer, but then you have no
control of the real time a button is pushed on slow systems.

Example:
onewire="deviceId=29.66C30E000000;propertyName=sensed.0;refreshinterval=10";pushbutton=500;invert",autoupdate="false"

New PullRequest for closed: #4063
