### PR TITLE
[zwave] Added a new id for Domitech lightbulb

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -3280,8 +3280,12 @@
 		<Product>
 			<Reference>
 				<Type>4c42</Type>
-				<Id>3135</Id>
+				<Id>3134</Id>
 			</Reference>
+            <Reference>
+                <Type>4c42</Type>
+                <Id>3135</Id>
+            </Reference>
 			<Model>ZB22UK</Model>
 			<Label lang="en">Smart LED Light Bulb</Label>
 			<ConfigFile>domitech/domezbulb.xml</ConfigFile>


### PR DESCRIPTION
This is one I just bought:

2016-03-10 13:14:51.362 [DEBUG] [.z.i.config.ZWaveConfiguration:276 ]- NODE 31: No database entry: Domitech [ID:3134,Type:4c42]
