### PR TITLE
fritzboxtr064 binding: fix compilation error

### DIFF
--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Helper.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Helper.java
@@ -8,9 +8,8 @@
  */
 package org.openhab.binding.fritzboxtr064.internal;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.StringWriter;
+import java.io.Writer;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -19,10 +18,12 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.xml.serialize.OutputFormat;
-import org.apache.xml.serialize.XMLSerializer;
+import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSOutput;
+import org.w3c.dom.ls.LSSerializer;
 
 /***
  * Static Helper methods
@@ -34,20 +35,26 @@ public class Helper {
 
     /***
      * Helper method which converts XML Document into pretty formatted string
-     * 
+     *
      * @param doc to convert
      * @return converted XML as String
      */
     public static String documentToString(Document doc) {
+
         String strMsg = "";
-        OutputFormat format = new OutputFormat(doc);
-        format.setIndenting(true);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        XMLSerializer serializer = new XMLSerializer(baos, format);
         try {
-            serializer.serialize(doc);
-            strMsg = baos.toString("UTF-8");
-        } catch (IOException e) {
+            DOMImplementation domImpl = doc.getImplementation();
+            DOMImplementationLS domImplLS = (DOMImplementationLS) domImpl.getFeature("LS", "3.0");
+            LSSerializer lsSerializer = domImplLS.createLSSerializer();
+            lsSerializer.getDomConfig().setParameter("format-pretty-print", true);
+
+            Writer stringWriter = new StringWriter();
+            LSOutput lsOutput = domImplLS.createLSOutput();
+            lsOutput.setEncoding("UTF-8");
+            lsOutput.setCharacterStream(stringWriter);
+            lsSerializer.write(doc, lsOutput);
+            strMsg = stringWriter.toString();
+        } catch (Exception e) {
             e.printStackTrace();
         }
         return strMsg;
@@ -55,7 +62,7 @@ public class Helper {
 
     /***
      * Converts a xml Node into String
-     * 
+     *
      * @param node to convert
      * @return converted string
      */

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Helper.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/Helper.java
@@ -18,6 +18,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -32,6 +34,7 @@ import org.w3c.dom.ls.LSSerializer;
  * @since 1.8.0
  */
 public class Helper {
+    private static final Logger logger = LoggerFactory.getLogger(FritzboxTr064Binding.class);
 
     /***
      * Helper method which converts XML Document into pretty formatted string
@@ -55,7 +58,7 @@ public class Helper {
             lsSerializer.write(doc, lsOutput);
             strMsg = stringWriter.toString();
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.warn("Error occured when converting document to string", e);
         }
         return strMsg;
     }
@@ -73,7 +76,7 @@ public class Helper {
             t.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
             t.transform(new DOMSource(node), new StreamResult(sw));
         } catch (TransformerException te) {
-            System.out.println("nodeToString Transformer Exception");
+            logger.warn("nodeToString Transformer Exception", te);
         }
         return sw.toString();
     }


### PR DESCRIPTION
Use org.w3c.dom.ls.LSSerializer instead of org.apache.xml.serialize.XMLSerializer, which is deprecated.

Since this binding did not compile for me on the command line, I replaced some deprecated symbols.