### PR TITLE
Maven warnings on build start

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,11 @@
                         </supportedProjectTypes>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.vafer</groupId>
+                    <artifactId>jdeb</artifactId>
+                    <version>1.5</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Because of missing version of plugin org.vafer:jdeb maven generates many warnings on each build start.