### PR TITLE
Z-wave: New device Everspring AN181 Mini-plug with meter

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/everspring/an181.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/everspring/an181.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+	<Model>AN181</Model>
+	<Label lang="en">Miniplug On/Off with meter function</Label>
+	<CommandClasses>
+		<Class><id>0x20</id></Class>	<!-- COMMAND_CLASS_BASIC_V1 -->
+		<Class><id>0x22</id></Class>	<!-- COMMAND_CLASS_APPLICATION_STATUS_V1 -->
+		<Class><id>0x25</id></Class>	<!-- COMMAND_CLASS_SWITCH_BINARY_V1 -->
+		<Class><id>0x27</id></Class>	<!-- COMMAND_CLASS_SWITCH_ALL_V1 -->
+		<Class><id>0x32</id></Class>	<!-- COMMAND_CLASS_METER_V3 -->
+		<Class><id>0x59</id></Class>	<!-- COMMAND_CLASS_ASSOCIATION_GRP_INFO_V1 -->
+		<Class><id>0x5a</id></Class>	<!-- COMMAND_CLASS_DEVICE_RESET_LOCALLY_V1 -->
+		<Class><id>0x5e</id></Class>	<!-- COMMAND_CLASS_ZWAVEPLUS_INFO_V2 -->
+		<Class><id>0x70</id></Class>	<!-- COMMAND_CLASS_CONFIGURATION_V1 -->
+		<Class><id>0x71</id></Class>	<!-- COMMAND_CLASS_NOTIFICATION_V4 -->
+		<Class><id>0x72</id></Class>	<!-- COMMAND_CLASS_MANUFACTURER_SPECIFIC_V2 -->
+		<Class><id>0x73</id></Class>	<!-- COMMAND_CLASS_POWERLEVEL_V1 -->
+		<Class><id>0x7a</id></Class>	<!-- COMMAND_CLASS_FIRMWARE_UPDATE_MD_V2 -->
+		<Class><id>0x85</id></Class>	<!-- COMMAND_CLASS_ASSOCIATION_V2-->
+		<Class><id>0x86</id></Class>	<!-- COMMAND_CLASS_VERSION_V2 -->
+	</CommandClasses>
+	<Configuration>
+		<Parameter>
+			<Index>1</Index>
+			<Type>short</Type>
+			<Default>255</Default>
+			<Minimum>0</Minimum>
+			<Maximum>255</Maximum>
+			<Size>2</Size>
+			<Label lang="en">Basic Set Command</Label>
+			<Help lang="en"><![CDATA[Set Basic Set Command value to be sent to group 2 when switch is turned on.<br/>
+						When the physical button on the mini-plug is used to turn OFF the switch the value "0" will always be sent to group 2, however this is not the case when the switch is turned off remotely.]]></Help>
+		</Parameter>
+		<Parameter>
+			<Index>2</Index>
+			<Type>byte</Type>
+			<Default>3</Default>
+			<Minimum>3</Minimum>
+			<Maximum>25</Maximum>
+			<Size>1</Size>
+			<Label lang="en">Delay</Label>
+			<Help lang="en"><![CDATA[The delaying time to report to Group 1]]></Help>
+		</Parameter>
+		<Parameter>
+			<Index>3</Index>
+			<Type>list</Type>
+			<Default>1</Default>
+			<Minimum>0</Minimum>
+			<Maximum>1</Maximum>
+			<Size>1</Size>
+			<Label lang="en">Remember Last State</Label>
+			<Help lang="en"><![CDATA[Remember last status on plug]]></Help>	
+			<Item>
+				<Value>0</Value>
+				<Label lang="en">Do not remember</Label>
+			</Item>
+			<Item>
+				<Value>1</Value>
+				<Label lang="en">Remember</Label>
+			</Item>
+		</Parameter>
+		<Parameter>
+			<Index>4</Index>
+			<Type>short</Type>
+			<Default>1</Default>
+			<Minimum>0</Minimum>
+			<Maximum>32767</Maximum>
+			<Size>2</Size>
+			<Label lang="en">Wattage Auto Report</Label>
+			<Help lang="en"><![CDATA[Set the interval for wattage auto report]]></Help>		
+		</Parameter>
+		<Parameter>
+			<Index>5</Index>
+			<Type>short</Type>
+			<Default>60</Default>
+			<Minimum>0</Minimum>
+			<Maximum>32767</Maximum>
+			<Size>2</Size>
+			<Label lang="en">Energy Auto report</Label>
+			<Help lang="en"><![CDATA[Set the interval for kWh auto report (0 = disabled)]]></Help>		
+		</Parameter>
+		<Parameter>
+			<Index>6</Index>
+			<Type>short</Type>
+			<Default>0</Default>
+			<Minimum>0</Minimum>
+			<Maximum>2500</Maximum>
+			<Size>2</Size>
+			<Label lang="en">Value of Wattage surpassed</Label>
+			<Help lang="en"><![CDATA[Auto report is sent when load surpasses the set value of wattage (0 = disabled)]]></Help>		
+		</Parameter>
+		<Parameter>
+			<Index>7</Index>
+			<Type>short</Type>
+			<Default>0</Default>
+			<Minimum>0</Minimum>
+			<Maximum>100</Maximum>
+			<Size>2</Size>
+			<Label lang="en">Change of Wattage surpassed</Label>
+			<Help lang="en"><![CDATA[Auto report is sent when the change of wattage surpasses the set percentage (0 = disabled)]]></Help>		
+		</Parameter>
+
+
+	</Configuration>
+
+	<Associations>
+		<Group>
+			<Index>1</Index>
+			<Maximum>1</Maximum>
+			<Label lang="en">Lifeline</Label>
+			<SetToController>true</SetToController>
+		</Group>
+		<Group>
+			<Index>2</Index>
+			<Maximum>4</Maximum>
+			<Label lang="en">On/Off control (Button on the mini-plug)</Label>
+		</Group>
+	</Associations>
+</Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -434,6 +434,15 @@
         </Product>
         <Product>
             <Reference>
+                <Type>0004</Type>
+                <Id>0006</Id>
+            </Reference>
+            <Model>AN181</Model>
+            <Label lang="en">Miniplug On/Off with meter function</Label>
+            <ConfigFile>everspring/an181.xml</ConfigFile>
+        </Product>
+        <Product>
+            <Reference>
                 <Type>0101</Type>
                 <Id>0001</Id>
             </Reference>


### PR DESCRIPTION
Please add support for the Everspring AN181 Mini-plug with meter function (Gen5). 

My pull request is slightly different from the database at www.cd-jackson.com:
- My xml-file is named an181.xml since "AN181" is the device name, not "AN1812" (AN181-2 means it is the german type plug, AN181-6 the French and so on)
- My file has maximum 4 allowed associations for group 2 (tested and also according to the manual)
