### PR TITLE
MODBUS: Add support for int32_swap, uint32_swap and float32_swap data types

### DIFF
--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/ModbusBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/ModbusBindingProvider.java
@@ -47,13 +47,17 @@ public interface ModbusBindingProvider extends BindingProvider {
     static final public String VALUE_TYPE_INT32 = "int32";
     static final public String VALUE_TYPE_UINT32 = "uint32";
     static final public String VALUE_TYPE_FLOAT32 = "float32";
+    static final public String VALUE_TYPE_INT32_SWAP = "int32_swap";
+    static final public String VALUE_TYPE_UINT32_SWAP = "uint32_swap";
+    static final public String VALUE_TYPE_FLOAT32_SWAP = "float32_swap";
 
     static final String[] VALUE_TYPES = { VALUE_TYPE_BIT, VALUE_TYPE_INT8, VALUE_TYPE_UINT8, VALUE_TYPE_INT16,
-            VALUE_TYPE_UINT16, VALUE_TYPE_INT32, VALUE_TYPE_UINT32, VALUE_TYPE_FLOAT32 };
+            VALUE_TYPE_UINT16, VALUE_TYPE_INT32, VALUE_TYPE_UINT32, VALUE_TYPE_FLOAT32, VALUE_TYPE_INT32_SWAP,
+            VALUE_TYPE_UINT32_SWAP, VALUE_TYPE_FLOAT32_SWAP };
 
     /**
      * Returns Modbus item configuration
-     * 
+     *
      * @param itemName item name
      * @return Modbus item configuration
      */

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
@@ -163,6 +163,22 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider>i
             buff.put(registers[index * 2 + 0].toBytes());
             buff.put(registers[index * 2 + 1].toBytes());
             return new DecimalType(buff.order(ByteOrder.BIG_ENDIAN).getFloat(0));
+        } else if (type.equals(ModbusBindingProvider.VALUE_TYPE_INT32_SWAP)) {
+            ByteBuffer buff = ByteBuffer.allocate(4);
+            buff.put(registers[index * 2 + 1].toBytes());
+            buff.put(registers[index * 2 + 0].toBytes());
+            return new DecimalType(buff.order(ByteOrder.BIG_ENDIAN).getInt(0));
+        } else if (type.equals(ModbusBindingProvider.VALUE_TYPE_UINT32_SWAP)) {
+            ByteBuffer buff = ByteBuffer.allocate(8);
+            buff.position(4);
+            buff.put(registers[index * 2 + 1].toBytes());
+            buff.put(registers[index * 2 + 0].toBytes());
+            return new DecimalType(buff.order(ByteOrder.BIG_ENDIAN).getLong(0));
+        } else if (type.equals(ModbusBindingProvider.VALUE_TYPE_FLOAT32_SWAP)) {
+            ByteBuffer buff = ByteBuffer.allocate(4);
+            buff.put(registers[index * 2 + 1].toBytes());
+            buff.put(registers[index * 2 + 0].toBytes());
+            return new DecimalType(buff.order(ByteOrder.BIG_ENDIAN).getFloat(0));
         } else {
             throw new IllegalArgumentException();
         }


### PR DESCRIPTION
This pull request Fixes #3558 by adding new value types that have the words swapped, such as uint32_swap, float32_swap, etc

(see https://github.com/openhab/openhab/issues/3558)

If this change is accepted the wiki will need to be updated to document these changes