### PR TITLE
[weather] Quiesce repeatedly logged stacktraces

### DIFF
--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/gfx/WeatherTokenResolver.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/gfx/WeatherTokenResolver.java
@@ -73,7 +73,7 @@ public class WeatherTokenResolver implements TokenResolver {
                 throw new RuntimeException("Invalid weather token: " + tokenName);
             }
         } catch (Exception ex) {
-            logger.error(ex.getMessage(), ex);
+            logger.warn(ex.getMessage());
             return null;
         }
     }
@@ -174,7 +174,7 @@ public class WeatherTokenResolver implements TokenResolver {
 
     /**
      * Helper class with the parts of a token.
-     * 
+     *
      * @author Gerhard Riegler
      * @since 1.6.0
      */


### PR DESCRIPTION
The weather binding can spam openhab.log with stack traces at ERROR level, when it would be sufficient to instead log the exception message at WARN level.