### PR TITLE
Onkyo Binding multiple devices status update fix

### DIFF
--- a/bundles/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoBinding.java
+++ b/bundles/binding/org.openhab.binding.onkyo/src/main/java/org/openhab/binding/onkyo/internal/OnkyoBinding.java
@@ -347,12 +347,17 @@ public class OnkyoBinding extends AbstractBinding<OnkyoBindingProvider>
 
                     for (String cmd : values.keySet()) {
                         String[] commandParts = values.get(cmd).split(":");
+                        String deviceId = commandParts[0];
                         String deviceCmd = commandParts[1];
+
+                        if (!deviceConfig.deviceId.equals(deviceId)) {
+                            continue;
+                        }
 
                         boolean match = false;
                         if (deviceCmd.startsWith(ADVANCED_COMMAND_KEY)) {
-                            // skip advanced command key and compare 3 first character
-                            if (data.startsWith(deviceCmd.substring(1, 4))) {
+                            // skip advanced command key and compare remaining characters
+                            if (data.startsWith(deviceCmd.substring(1))) {
                                 match = true;
                             }
                         } else {
@@ -363,7 +368,6 @@ public class OnkyoBinding extends AbstractBinding<OnkyoBindingProvider>
                                 if (data.startsWith(eiscpCmd.substring(0, 3))) {
                                     match = true;
                                 }
-
                             } catch (Exception e) {
                                 logger.error("Unrecognized command '" + deviceCmd + "'", e);
                             }
@@ -380,7 +384,6 @@ public class OnkyoBinding extends AbstractBinding<OnkyoBindingProvider>
             }
         }
     }
-
     /**
      * Convert receiver value to OpenHAB state.
      *


### PR DESCRIPTION
Fixes #4255 regarding problems with status updates when multiple devices are configured and fixes #4240 regarding advanced command status updates. There was no check to match the device ID against the device ID in the binding specification, so status updates from devices were being posted to items bound to different devices. A full comparison (instead of the first three characters) was also added for advanced command keys as three characters is not enough to distinguish advanced commands. This caused status updates to be written to the wrong item.

Signed-off-by: Pete Vavaroutsos<pete@vavaroutsos.com> (github: vavaroutsos)