### PR TITLE
Fix issue reported in #4239

### DIFF
--- a/bundles/binding/org.openhab.binding.iec6205621meter/src/main/java/org/openhab/binding/iec6205621meter/internal/Iec6205621MeterGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.iec6205621meter/src/main/java/org/openhab/binding/iec6205621meter/internal/Iec6205621MeterGenericBindingProvider.java
@@ -28,9 +28,9 @@ import org.slf4j.LoggerFactory;
  * Here are some examples for valid binding configuration strings:
  *
  * <ul>
- * <li><code>{ iec6205621meter="meter1:1.8.1" }</code> - shows the tarif 1 counter value of 'meter1'</li>
- * <li><code>{ iec6205621meter="meter1:1.8.2" }</code> - shows the tarif 1 counter value of 'meter1'</li>
- * <li><code>{  iec6205621meter="meter2:16.7" }</code> - shows the current power usage value of 'meter2'</li>
+ * <li><code>{ iec6205621meter="meter1;1.8.1" }</code> - shows the tarif 1 counter value of 'meter1'</li>
+ * <li><code>{ iec6205621meter="meter1;1.8.2" }</code> - shows the tarif 1 counter value of 'meter1'</li>
+ * <li><code>{ iec6205621meter="meter2;16.7" }</code> - shows the current power usage value of 'meter2'</li>
  * </ul>
  * 
  * @author Peter Kreutzer
@@ -72,7 +72,7 @@ public class Iec6205621MeterGenericBindingProvider extends AbstractGenericBindin
             throws BindingConfigParseException {
         super.processBindingConfiguration(context, item, bindingConfig);
         Iec6205621MeterBindingConfig config = new Iec6205621MeterBindingConfig();
-        StringTokenizer tokenizer = new StringTokenizer(bindingConfig.trim(), ":");
+        StringTokenizer tokenizer = new StringTokenizer(bindingConfig.trim(), ";");
         String[] tokens = new String[tokenizer.countTokens()];
         for (int i = 0; i < tokens.length; i++) {
             tokens[i] = tokenizer.nextToken();


### PR DESCRIPTION
IEC-62056-21 Binding: Support for ISKRA MT174 OBIS Codes 
OBIS code of the format A-B:C.D.E*F conflict with item configuration in which conflicts with separation string in item configuration