### PR TITLE
Corrected handling of changed modbus values

### DIFF
--- a/bundles/binding/org.openhab.binding.modbus/OSGI-INF/modbusbinding.xml
+++ b/bundles/binding/org.openhab.binding.modbus/OSGI-INF/modbusbinding.xml
@@ -26,4 +26,7 @@
    <reference bind="addBindingProvider"  cardinality="1..n" 
       interface="org.openhab.binding.modbus.ModbusBindingProvider" name="ModbusBindingProvider"
       policy="dynamic" unbind="removeBindingProvider"/>
+    <reference bind="setItemRegistry" cardinality="0..1" 
+      interface="org.openhab.core.items.ItemRegistry" name="ItemRegistry" 
+      policy="dynamic" unbind="unsetItemRegistry"/>
 </scr:component>

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusGenericBindingProvider.java
@@ -29,15 +29,15 @@ import org.slf4j.LoggerFactory;
  *
  * 1) single coil/register per item
  * Switch MySwitch "My Modbus Switch" (ALL) {modbus="slave1:5"}
- * 
+ *
  * This binds MySwitch to modbus slave defined as "slave1" in openhab.config reading/writing to the coil 5
  *
  * 2) separate coils/registers for reading and writing
  * Switch MySwitch "My Modbus Switch" (ALL) {modbus="slave1:<6:>7"}
- * 
+ *
  * In this case coil 6 is used as status coil (readonly) and commands are put to coil 7 by setting coil 7 to true.
  * You hardware should then set coil 7 back to false to allow further commands processing.
- * 
+ *
  * @author Dmitry Krasnov
  * @since 1.1.0
  */
@@ -51,7 +51,7 @@ public class ModbusGenericBindingProvider extends AbstractGenericBindingProvider
      */
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.openhab.model.item.binding.BindingConfigReader#getBindingType()
      */
     @Override
@@ -97,10 +97,10 @@ public class ModbusGenericBindingProvider extends AbstractGenericBindingProvider
 
     /**
      * Checks if the bindingConfig contains a valid binding type and returns an appropriate instance.
-     * 
+     *
      * @param item
      * @param bindingConfig
-     * 
+     *
      * @throws BindingConfigParseException if bindingConfig is no valid binding type
      */
     protected ModbusBindingConfig parseBindingConfig(Item item, String bindingConfig)
@@ -110,7 +110,7 @@ public class ModbusGenericBindingProvider extends AbstractGenericBindingProvider
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.openhab.binding.modbus.tcp.master.ModbusBindingProvider#getConfig(java.lang.String)
      */
     @Override
@@ -120,7 +120,7 @@ public class ModbusGenericBindingProvider extends AbstractGenericBindingProvider
 
     /**
      * ModbusBindingConfig stores configuration of the item bound to Modbus
-     * 
+     *
      * @author dbkrasn
      * @since 1.1.0
      */
@@ -137,29 +137,21 @@ public class ModbusGenericBindingProvider extends AbstractGenericBindingProvider
          */
         String slaveName;
         /**
-         * OpenHAB Item to be configured
+         * Name of openHAB Item to be configured
          */
-        private Item item = null;
-
-        public Item getItem() {
-            return item;
-        }
-
-        State getItemState() {
-            return item.getState();
-        }
+        private String itemName = null;
 
         /**
          * Calculates new item state based on the new boolean value, current item state and item class
          * Used with item bound to "coil" type slaves
-         * 
+         *
          * @param b new boolean value
          * @param c class of the current item state
          * @param itemClass class of the item
-         * 
+         *
          * @return new item state
          */
-        protected State translateBoolean2State(boolean b) {
+        protected State translateBoolean2State(boolean b, Item item) {
 
             Class<? extends State> c = item.getState().getClass();
             Class<? extends Item> itemClass = item.getClass();
@@ -183,13 +175,13 @@ public class ModbusGenericBindingProvider extends AbstractGenericBindingProvider
 
         /**
          * Constructor for config object
-         * 
+         *
          * @param item
          * @param config
          * @throws BindingConfigParseException if
          */
-        ModbusBindingConfig(Item item, String config) throws BindingConfigParseException {
-            this.item = item;
+        public ModbusBindingConfig(Item item, String config) throws BindingConfigParseException {
+            this.itemName = item.getName();
 
             try {
                 String[] items = config.split(":");
@@ -210,7 +202,7 @@ public class ModbusGenericBindingProvider extends AbstractGenericBindingProvider
 
         /**
          * Parses register reference string and assigns values to readRegister and writeRegister
-         * 
+         *
          * @param item
          * @throws BindingConfigParseException if register description is invalid
          */

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusSlave.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusSlave.java
@@ -86,10 +86,10 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
 
     /**
      * A multiplier for the raw incoming data
-     * 
+     *
      * @note rawMultiplier can also be used for divisions, by simply
      *       setting the value smaller than zero.
-     * 
+     *
      *       E.g.:
      *       - data/100 ... rawDataMultiplier=0.01
      */
@@ -97,6 +97,21 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
 
     private Object storage;
     protected ModbusTransaction transaction = null;
+
+    /**
+     * Does the binding post updates even when the item did not change it's state?
+     *
+     * default is "false"
+     */
+    private boolean updateUnchangedItems = false;
+
+    public boolean isUpdateUnchangedItems() {
+        return updateUnchangedItems;
+    }
+
+    public void setUpdateUnchangedItems(boolean updateUnchangedItems) {
+        this.updateUnchangedItems = updateUnchangedItems;
+    }
 
     /**
      * @param slave slave name from cfg file used for item binding
@@ -108,7 +123,7 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
     /**
      * writes data to Modbus device corresponding to OpenHAB command
      * works only with types "coil" and "holding"
-     * 
+     *
      * @param command OpenHAB command received
      * @param readRegister data from readRegister are used to define value to write to the device
      * @param writeRegister register address to write new data to
@@ -125,7 +140,7 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
     /**
      * Calculates boolean value that will be written to the device as a result of OpenHAB command
      * Used with item bound to "coil" type slaves
-     * 
+     *
      * @param command OpenHAB command received by the item
      * @return new boolean value to be written to the device
      */
@@ -147,7 +162,7 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
 
     /**
      * Performs physical write to device when slave type is "coil"
-     * 
+     *
      * @param command command received from OpenHAB
      * @param readRegister reference to the register that stores current value
      * @param writeRegister register reference to write data to
@@ -167,7 +182,7 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
 
     /**
      * Performs physical write to device when slave type is "holding" using Modbus FC06 function
-     * 
+     *
      * @param command command received from OpenHAB
      * @param readRegister reference to the register that stores current value
      * @param writeRegister register reference to write data to
@@ -241,7 +256,7 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
 
     /**
      * Sends boolean (bit) data to the device using Modbus FC05 function
-     * 
+     *
      * @param writeRegister
      * @param b
      */
@@ -264,7 +279,7 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
 
     /**
      * Reads data from the connected device and updates items with the new data
-     * 
+     *
      * @param binding ModbusBindig that stores providers information
      */
     public void update(ModbusBinding binding) {
@@ -320,7 +335,7 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
     /**
      * Updates OpenHAB item with data read from slave device
      * works only for type "coil" and "holding"
-     * 
+     *
      * @param binding ModbusBinding
      * @param item item to update
      */
@@ -337,7 +352,7 @@ public abstract class ModbusSlave implements ModbusSlaveConnection {
 
     /**
      * Executes Modbus transaction that reads data from the device and returns response data
-     * 
+     *
      * @param request describes what data are requested from the device
      * @return response data
      */


### PR DESCRIPTION
The current modbus implementation reports items as updated at every poll cycle even if the value actually did not change. For setups with many modbus items (mine has about 200) and poll cycles of 500ms this simply overloads the CPU of my system. The code already tries to post updates only on changed values, but there is an error as only the very first value is stored but then never updated. This fix corrects this behaviour.

