### PR TITLE
[mios] Install MAP and REGEX transformation dependencies for OH2

### DIFF
--- a/features/openhab-addons-verify/pom.xml
+++ b/features/openhab-addons-verify/pom.xml
@@ -86,6 +86,7 @@
                                 <descriptor>mvn:org.eclipse.smarthome/karaf/${esh.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.eclipse.smarthome/karaf-tp/${esh.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.openhab.core/openhab-core/${ohc.version}/xml/features</descriptor>
+                                <descriptor>mvn:org.openhab.core/openhab-esh-addons/${ohc.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.openhab.addons/openhab-addons/${project.version}/xml/features</descriptor>
                             </descriptors>
                             <distribution>org.apache.karaf.features:framework</distribution>

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -262,6 +262,8 @@
   <feature name="openhab-binding-mios" description="MiOS Binding" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>
+    <feature>openhab-transformation-regex</feature>
+    <feature>openhab-transformation-map</feature>
     <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.mios/${project.version}</bundle>
     <configfile finalname="${openhab.conf}/services/mios.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/mios</configfile>
     <configfile finalname="${openhab.conf}/transform/miosArmedCommand.map" override="true">mvn:${project.groupId}/openhab-addons-external/${project.version}/map/mios-armedcommand</configfile>


### PR DESCRIPTION
The MiOS Binding internally uses the MAP and REGEX transformation
services.  This change ensures that OH2 will install those deps
when the MiOS Binding is deployed.

Also tweaks #4308 to add the other component for complete feature
verification.  See discussion in openhab/openhab-distro#163

Signed-off-by: Mark Clark <mr.guessed@gmail.com> (github: mrguessed)