### PR TITLE
Fix #4320 by restoring the htmlescape.

### DIFF
--- a/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/PageRenderer.java
+++ b/bundles/ui/org.openhab.ui.webapp/src/main/java/org/openhab/ui/webapp/internal/render/PageRenderer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016, openHAB.org and others.
+ * Copyright (c) 2010-2015, openHAB.org and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -73,7 +73,7 @@ public class PageRenderer extends AbstractWidgetRenderer {
 		if(label.contains("[") && label.endsWith("]")) {
 			label = label.replace("[", "").replace("]", "");
 		}
-		snippet = StringUtils.replace(snippet, "%label%", label);
+		snippet = StringUtils.replace(snippet, "%label%", StringEscapeUtils.escapeHtml(label));
 		snippet = StringUtils.replace(snippet, "%servletname%", WebAppServlet.SERVLET_PATH);
 		snippet = StringUtils.replace(snippet, "%sitemap%", sitemap);
 


### PR DESCRIPTION
This should allow the classic UI to show items containing the ampersand character again.