### PR TITLE
[mios] Improve logging output of MiOS Item Generator output.

### DIFF
--- a/bundles/binding/org.openhab.binding.mios/examples/scripts/miosTransform.sh
+++ b/bundles/binding/org.openhab.binding.mios/examples/scripts/miosTransform.sh
@@ -2,7 +2,8 @@
 
 if [ "$#" != "1" ]
 then
-    echo "Usage: $0 <openHAB-MiOSUnitName>"
+    echo "Usage:   $0 <openHAB-MiOSUnitName>"
+    echo "Example: $0 house"
     exit 1
 else
     MIOS_UNIT="${1}"; export MIOS_UNIT
@@ -10,18 +11,18 @@ else
     MIOS_ITEM_FILE="${MIOS_UNIT}.items"; export MIOS_ITEM_FILE
 fi
 
-echo "Transforming MiOS Unit Metadata from ${MIOS_IN}..."
+echo "INFO: Transforming MiOS Unit Metadata from ${MIOS_IN}..."
 xsltproc --stringparam MIOS_UNIT "${MIOS_UNIT}" --output "${MIOS_ITEM_FILE}" miosTransform.xslt "${MIOS_IN}"
 
 if [ "$?" == "0" ]
 then
-    echo "Metadata Transformed into ${MIOS_ITEM_FILE}!"
+    echo "INFO: Metadata Transformed into openHAB Item file ${MIOS_ITEM_FILE}!"
 else
-    echo "Failed to Transform, Check for bogus XML in ${MIOS_IN}."
+    echo "ERROR: Failed to Transform, Check for bogus XML in ${MIOS_IN}."
     exit 1
 fi
 
-echo "Duplicate Item names requiring manual fixes:"
+echo "INFO: Processing for any Duplicate Item names"
 lastItemName=""
 grep -v ^$ "${MIOS_ITEM_FILE}" | grep -v "^/" | sort -k 2 | while read -r line; do
     read -r itemType itemName _ <<< "$line"
@@ -33,3 +34,12 @@ grep -v ^$ "${MIOS_ITEM_FILE}" | grep -v "^/" | sort -k 2 | while read -r line; 
     fi
 done
 
+if [ "${lastItemName}" == "" ];
+then
+    echo "INFO: Your generated openHAB Item file (${MIOS_ITEM_FILE}) is good to go!"
+else
+    echo "WARN: The duplicate openHAB Item names above must be manually corrected in the generated openHAB Item file (${MIOS_ITEM_FILE})"
+fi
+
+
+echo "INFO: Remember to configure your MiOS Unit Name ('${1}') openhab.cfg (openHAB 1.x), or mios.cfg (openHAB 2.x)"


### PR DESCRIPTION
The [MiOS Item Generator](https://github.com/openhab/openhab/wiki/MiOS-Binding#item-generation--mios-item-generator) builds an openHAB Items file using the metadata from a MiOS/Vera Unit.

In some cases, users were confused by the output of the tool and this lead to issues in the subsequent configuration steps.

This PR adds further logging/output to guide the user in the configuration.

Signed-off-by: Mark Clark <mr.guessed@gmail.com> (github: mrguessed)