### PR TITLE
FHT: Implement support for valve FHT8v

### DIFF
--- a/bundles/binding/org.openhab.binding.fht/src/main/java/org/openhab/binding/fht/internal/FHTBinding.java
+++ b/bundles/binding/org.openhab.binding.fht/src/main/java/org/openhab/binding/fht/internal/FHTBinding.java
@@ -205,9 +205,11 @@ public class FHTBinding extends AbstractActiveBinding<FHTBindingProvider>impleme
         if (config != null) {
             if (Datapoint.DESIRED_TEMP == config.getDatapoint() && command instanceof DecimalType) {
                 setDesiredTemperature(config, (DecimalType) command);
+            } else if (Datapoint.VALVE == config.getDatapoint() && command instanceof DecimalType) {
+                setValvePosition(config, (DecimalType) command);
             } else {
                 logger.error(
-                        "You can only manipulate the desired temperature via commands, all other data points are read only");
+                        "You can only manipulate the desired temperature or valve position via commands, all other data points are read only");
             }
         }
     }
@@ -223,6 +225,20 @@ public class FHTBinding extends AbstractActiveBinding<FHTBindingProvider>impleme
             temperatureCommandQueue.put(config.getFullAddress(), commandItem);
         } else {
             logger.error("The desired temperature is outside of the valid range");
+        }
+    }
+
+    private void setValvePosition(FHTBindingConfig config, DecimalType command) {
+        double valvePosition = command.doubleValue();
+        if ((valvePosition >= 0.0) && (valvePosition <= 100.0)) {
+            int temp = (int) (valvePosition * 2.55);
+
+            FHTDesiredTemperatureCommand commandItem = new FHTDesiredTemperatureCommand(config.getFullAddress(), "26"
+                            + ((Integer.toHexString(temp).length() == 1)?"0":"") + Integer.toHexString(temp));
+            logger.debug("Queuing new desired valve position");
+            temperatureCommandQueue.put(config.getFullAddress(), commandItem);
+        } else {
+            logger.error("The desired valve position is outside of the valid range (0.0 - 100.0%)");
         }
     }
 


### PR DESCRIPTION
This patch allows openhab to control FHT8v valves directly without the need of a FHT80b controller. See also http://www.fhemwiki.de/wiki/FHT_8v_direkt_ansprechen (German page that describes doing so for/with the help of the FHEM project).