### PR TITLE
Ignore IntelliJ IDEA files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ distribution/openhabhome/etc/rrd4j/*.rrd
 *~
 features/*/src/main/history
 itemDump.txt
+
+# IntelliJ files
+**/.idea
+**/*.iml


### PR DESCRIPTION
By default IntelliJ stores its project/workspace files and metadata under the project parent directory.  This commit simply ensures that GIT will ignore these files and prevent them from being committed to source control.