### PR TITLE
Z-Wave: new reference ID for Fortrezz MIMOlite (US 908 MHz)

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -2884,6 +2884,10 @@
                 <Type>453</Type>
                 <Id>110</Id>
             </Reference>
+            <Reference>
+                <Type>453</Type>
+                <Id>111</Id>
+            </Reference>
             <Model>MIMOlite</Model>
             <Label lang="en">Digital or Analog Voltage input and/or Dry Contact
                 Relay


### PR DESCRIPTION
Z-Wave:
- Added new reference ID for Fortrezz MIMOlite (US 908 MHz) 

I purchased a new Fortrezz MIMOlite however after device inclusion, it's reported device reference ID was not listed in the Z-Wave device database.   