### PR TITLE
#4404 Added GPIO Binding and IO to 1.x compatibility bundle for OH2

### DIFF
--- a/bundles/binding/org.openhab.binding.gpio/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.gpio/ESH-INF/binding/binding.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="gpio"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
+
+    <name>GPIO Binding</name>
+    <description>This is the binding for gpio.</description>
+    <author>Dancho Penev</author>
+    
+    <config-description>
+        <parameter name="sysfs" type="text">
+            <label>sysfs mount path</label>
+            <description>Optional directory path where "sysfs" pseudo file system is mounted, when isn't specified it will be determined automatically if "procfs" is mounted.</description>
+            <default>/sys</default>
+        </parameter>
+        <parameter name="debounce" type="integer">
+            <label>Debounce interval</label>
+            <description>Optional time interval in miliseconds when pin interrupts are ignored to prevent bounce effect, mainly on buttons. Global option for all pins, can be overwritten per pin in item configuration.</description>
+            <default>0</default>
+        </parameter>
+        <parameter name="force" type="boolean">
+            <label>Forcibly take pin</label>
+            <description>Boolean controlling whether already exported pin should be forcibly taken under control of openHAB. Usefull after unclean shutdown. May cause serious issue if other software/system is also controlling GPIO and there is a configuration mistake for pin name/number.</description>
+            <default>false</default>
+        </parameter>
+    </config-description>
+
+</binding:binding>

--- a/bundles/binding/org.openhab.binding.gpio/build.properties
+++ b/bundles/binding/org.openhab.binding.gpio/build.properties
@@ -1,6 +1,7 @@
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
+               ESH-INF/,\
                OSGI-INF/
 source.. = src/main/java/,\
            src/main/resources/

--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -48,6 +48,7 @@
                                 <artifact><file>src/main/resources/conf/freeswitch.cfg</file><type>cfg</type><classifier>freeswitch</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/garadget.cfg</file><type>cfg</type><classifier>garadget</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/gc100ir.cfg</file><type>cfg</type><classifier>gc100ir</classifier></artifact>
+                                <artifact><file>src/main/resources/conf/gpio.cfg</file><type>cfg</type><classifier>gpio</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/heatmiser.cfg</file><type>cfg</type><classifier>heatmiser</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/homematic.cfg</file><type>cfg</type><classifier>homematic</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/http.cfg</file><type>cfg</type><classifier>http</classifier></artifact>

--- a/features/openhab-addons-external/src/main/resources/conf/gpio.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/gpio.cfg
@@ -1,0 +1,16 @@
+################################### GPIO Binding ######################################
+
+# Optional directory path where "sysfs" pseudo file system is mounted, when isn't
+# specified it will be determined automatically if "procfs" is mounted
+#sysfs=/sys
+
+# Optional time interval in miliseconds when pin interrupts are ignored to
+# prevent bounce effect, mainly on buttons. Global option for all pins, can be
+# overwritten per pin in item configuration. Default value if omitted: 0
+#debounce=10
+
+# Boolean controlling whether already exported pin should be forcibly taken under
+# control of openHAB. Usefull after unclean shutdown. May cause serios issue if
+# other software/system is also controlling GPIO and there is a configuration
+# mistake for pin name/number. Default value if omitted: false.
+#force=true

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -202,6 +202,13 @@
     <feature>openhab-runtime-compat1x</feature>
     <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.gc100ir/${project.version}</bundle>
   </feature>
+  
+  <feature name="openhab-binding-gpio" description="GPIO Binding" version="${project.version}">
+    <feature>openhab-runtime-base</feature>
+    <feature>openhab-runtime-compat1x</feature>
+    <feature>openhab-io-gpio</feature>
+    <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.gpio/${project.version}</bundle>
+  </feature>
 
   <feature name="openhab-binding-heatmiser" description="Heatmiser Binding" version="${project.version}">
     <feature>openhab-runtime-base</feature>
@@ -600,6 +607,11 @@
   </feature>
 
   <!-- shared features, not end user facing -->
+  <feature name="openhab-io-gpio" description="GPIO IO" version="${project.version}">
+    <feature>openhab-runtime-base</feature>
+    <feature>openhab-runtime-compat1x</feature>
+    <bundle start-level="80">mvn:org.openhab.io/org.openhab.io.gpio/${project.version}</bundle>
+  </feature>
 
   <feature name="openhab-transport-cul" description="CUL Transport" version="${project.version}">
     <feature>openhab-runtime-base</feature>


### PR DESCRIPTION
Followed instructions here:

https://github.com/openhab/openhab-distro/blob/master/docs/sources/features/compatibilitylayer.md#how-to-add-a-successfully-tested-1x-add-on-to-the-distribution

Included meta-information for Paper UI configuration.

Closes #4404 