### PR TITLE
DSC Alarm: Fix Premature Setting of Partition Arm Mode Item

### DIFF
--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/DSCAlarmBindingConfig.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/DSCAlarmBindingConfig.java
@@ -28,8 +28,7 @@ public class DSCAlarmBindingConfig implements BindingConfig {
      * @param zoneId the ZoneId of the item
      * @param itemType the DSC Alarm Item Type.
      */
-    public DSCAlarmBindingConfig(DSCAlarmDeviceType dscAlarmDeviceType, int partitionId, int zoneId,
-            DSCAlarmItemType dscAlarmItemType) {
+    public DSCAlarmBindingConfig(DSCAlarmDeviceType dscAlarmDeviceType, int partitionId, int zoneId, DSCAlarmItemType dscAlarmItemType) {
         this.dscAlarmDeviceType = dscAlarmDeviceType;
         this.partitionId = partitionId;
         this.zoneId = zoneId;

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmActiveBinding.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmActiveBinding.java
@@ -44,8 +44,7 @@ import org.slf4j.LoggerFactory;
  * @since 1.6.0
  */
 
-public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBindingProvider>
-        implements ManagedService, DSCAlarmEventListener, DSCAlarmActionProvider {
+public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBindingProvider>implements ManagedService, DSCAlarmEventListener, DSCAlarmActionProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(DSCAlarmActiveBinding.class);
 
@@ -100,8 +99,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
      * New items or items needing to be refreshed get added to refreshmao
      * the worker thread will refresh and remove them
      */
-    private Map<String, DSCAlarmBindingConfig> dscAlarmUpdateMap = Collections
-            .synchronizedMap(new HashMap<String, DSCAlarmBindingConfig>());
+    private Map<String, DSCAlarmBindingConfig> dscAlarmUpdateMap = Collections.synchronizedMap(new HashMap<String, DSCAlarmBindingConfig>());
     private DSCAlarmItemUpdate dscAlarmItemUpdate = new DSCAlarmItemUpdate();
     private int itemCount = 0;
     private boolean itemHasChanged = false;
@@ -193,8 +191,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
             DSCAlarmBindingProvider dscAlarmBindingProvider = (DSCAlarmBindingProvider) provider;
 
             if (dscAlarmBindingProvider != null) {
-                DSCAlarmBindingConfig dscAlarmBindingConfig = dscAlarmBindingProvider
-                        .getDSCAlarmBindingConfig(itemName);
+                DSCAlarmBindingConfig dscAlarmBindingConfig = dscAlarmBindingProvider.getDSCAlarmBindingConfig(itemName);
                 if (dscAlarmBindingConfig != null) {
                     dscAlarmUpdateMap.put(itemName, dscAlarmBindingConfig);
                 }
@@ -221,8 +218,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
                 int zoneId;
                 int cmd;
 
-                logger.debug("internalReceiveCommand():  Item Name: {} Command: {} Item Device Type: {}", itemName,
-                        command, dscAlarmDeviceType);
+                logger.debug("internalReceiveCommand():  Item Name: {} Command: {} Item Device Type: {}", itemName, command, dscAlarmDeviceType);
 
                 if (connected) {
                     switch (dscAlarmDeviceType) {
@@ -233,8 +229,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
                                         closeConnection();
                                         if (!connected) {
                                             dscAlarmItemUpdate.setConnected(false);
-                                            dscAlarmItemUpdate.updateDeviceProperties(item, dscAlarmBindingConfig, 0,
-                                                    "Disconnected");
+                                            dscAlarmItemUpdate.updateDeviceProperties(item, dscAlarmBindingConfig, 0, "Disconnected");
                                         }
                                     }
                                     break;
@@ -295,43 +290,21 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
                             switch (dscAlarmBindingConfig.getDSCAlarmItemType()) {
                                 case PARTITION_ARM_MODE:
                                     if (command.toString().equals("0")) {
-                                        if (api.sendCommand(APICode.PartitionDisarmControl,
-                                                String.valueOf(partitionId))) {
-                                            dscAlarmItemUpdate.updateDeviceProperties(item, dscAlarmBindingConfig, 0,
-                                                    "Partition Disarmed");
-                                        }
+                                        api.sendCommand(APICode.PartitionDisarmControl, String.valueOf(partitionId));
                                     } else if (command.toString().equals("1")) {
-                                        if (api.sendCommand(APICode.PartitionArmControlAway,
-                                                String.valueOf(partitionId))) {
-                                            dscAlarmItemUpdate.updateDeviceProperties(item, dscAlarmBindingConfig, 1,
-                                                    "Partition Armed (Away)");
-                                        }
+                                        api.sendCommand(APICode.PartitionArmControlAway, String.valueOf(partitionId));
                                     } else if (command.toString().equals("2")) {
-                                        if (api.sendCommand(APICode.PartitionArmControlStay,
-                                                String.valueOf(partitionId))) {
-                                            dscAlarmItemUpdate.updateDeviceProperties(item, dscAlarmBindingConfig, 2,
-                                                    "Partition Armed (Stay)");
-                                        }
+                                        api.sendCommand(APICode.PartitionArmControlStay, String.valueOf(partitionId));
                                     } else if (command.toString().equals("3")) {
-                                        if (api.sendCommand(APICode.PartitionArmControlZeroEntryDelay,
-                                                String.valueOf(partitionId))) {
-                                            dscAlarmItemUpdate.updateDeviceProperties(item, dscAlarmBindingConfig, 3,
-                                                    "Partition Armed (Zero Entry Delay)");
-                                        }
+                                        api.sendCommand(APICode.PartitionArmControlZeroEntryDelay, String.valueOf(partitionId));
                                     } else if (command.toString().equals("4")) {
-                                        if (api.sendCommand(APICode.PartitionArmControlWithUserCode,
-                                                String.valueOf(partitionId))) {
-                                            dscAlarmItemUpdate.updateDeviceProperties(item, dscAlarmBindingConfig, 4,
-                                                    "Partition Armed (With User Code)");
-                                        }
+                                        api.sendCommand(APICode.PartitionArmControlWithUserCode, String.valueOf(partitionId));
                                     }
                                     break;
                                 default:
                                     break;
                             }
 
-                            dscAlarmUpdateMap.put(itemName, dscAlarmBindingConfig);
-                            processUpdateMap();
                             break;
                         case ZONE:
                             partitionId = dscAlarmBindingConfig.getPartitionId();
@@ -339,18 +312,14 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
                             switch (dscAlarmBindingConfig.getDSCAlarmItemType()) {
                                 case ZONE_BYPASS_MODE:
                                     if (command.toString().equals("0")) {
-                                        String data = String.valueOf(partitionId) + "*1" + String.format("%02d", zoneId)
-                                                + "#";
+                                        String data = String.valueOf(partitionId) + "*1" + String.format("%02d", zoneId) + "#";
                                         if (api.sendCommand(APICode.KeySequence, data)) {
-                                            dscAlarmItemUpdate.updateDeviceProperties(item, dscAlarmBindingConfig, 0,
-                                                    "Zone Armed");
+                                            dscAlarmItemUpdate.updateDeviceProperties(item, dscAlarmBindingConfig, 0, "Zone Armed");
                                         }
                                     } else if (command.toString().equals("1")) {
-                                        String data = String.valueOf(partitionId) + "*1" + String.format("%02d", zoneId)
-                                                + "#";
+                                        String data = String.valueOf(partitionId) + "*1" + String.format("%02d", zoneId) + "#";
                                         if (api.sendCommand(APICode.KeySequence, data)) {
-                                            dscAlarmItemUpdate.updateDeviceProperties(item, dscAlarmBindingConfig, 1,
-                                                    "Zone Bypassed");
+                                            dscAlarmItemUpdate.updateDeviceProperties(item, dscAlarmBindingConfig, 1, "Zone Bypassed");
                                         }
                                     }
                                     break;
@@ -372,8 +341,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
                                     openConnection();
                                     if (connected) {
                                         dscAlarmItemUpdate.setConnected(true);
-                                        dscAlarmItemUpdate.updateDeviceProperties(item, dscAlarmBindingConfig, 1,
-                                                "Connected");
+                                        dscAlarmItemUpdate.updateDeviceProperties(item, dscAlarmBindingConfig, 1, "Connected");
                                     }
                                 }
                             }
@@ -507,8 +475,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 
             if (StringUtils.isNotBlank((String) config.get("suppressAcknowledgementMsgs"))) {
                 try {
-                    suppressAcknowledgementMsgs = Boolean
-                            .parseBoolean((String) config.get("suppressAcknowledgementMsgs"));
+                    suppressAcknowledgementMsgs = Boolean.parseBoolean((String) config.get("suppressAcknowledgementMsgs"));
                 } catch (NumberFormatException numberFormatException) {
                     suppressAcknowledgementMsgs = false;
                     logger.error("updated(): Error parsing 'suppressAcknowledgementMsgs'. This must be boolean!");
@@ -776,7 +743,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
     private void updateItemType(DSCAlarmItemType dscAlarmItemType, int partitionId, int zoneId, int propertyState) {
         String itemName = "";
         itemName = getItemName(dscAlarmItemType, partitionId, zoneId);
-        logger.debug("updateTriggerItem(): Item Name: {} Partition: {} Zone: {}", itemName, partitionId, zoneId);
+        logger.debug("updateItemType(): Item Name: {} Partition: {} Zone: {}", itemName, partitionId, zoneId);
 
         if (itemName != "") {
             updateDeviceProperties(itemName, propertyState, "");
@@ -898,8 +865,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
             if (config != null) {
                 Item item = getItem(itemName);
                 if (item != null) {
-                    DSCAlarmDeviceProperties dsclarmDeviceProperties = dscAlarmItemUpdate.getDeviceProperties(item,
-                            config);
+                    DSCAlarmDeviceProperties dsclarmDeviceProperties = dscAlarmItemUpdate.getDeviceProperties(item, config);
 
                     if (dsclarmDeviceProperties != null) {
 
@@ -929,10 +895,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
     private void keypadLEDStateEventHandler(EventObject event) {
         DSCAlarmEvent dscAlarmEvent = (DSCAlarmEvent) event;
         APIMessage apiMessage = dscAlarmEvent.getAPIMessage();
-        DSCAlarmItemType[] dscAlarmItemTypes = { DSCAlarmItemType.KEYPAD_READY_LED, DSCAlarmItemType.KEYPAD_ARMED_LED,
-                DSCAlarmItemType.KEYPAD_MEMORY_LED, DSCAlarmItemType.KEYPAD_BYPASS_LED,
-                DSCAlarmItemType.KEYPAD_TROUBLE_LED, DSCAlarmItemType.KEYPAD_PROGRAM_LED,
-                DSCAlarmItemType.KEYPAD_FIRE_LED, DSCAlarmItemType.KEYPAD_BACKLIGHT_LED };
+        DSCAlarmItemType[] dscAlarmItemTypes = { DSCAlarmItemType.KEYPAD_READY_LED, DSCAlarmItemType.KEYPAD_ARMED_LED, DSCAlarmItemType.KEYPAD_MEMORY_LED, DSCAlarmItemType.KEYPAD_BYPASS_LED, DSCAlarmItemType.KEYPAD_TROUBLE_LED, DSCAlarmItemType.KEYPAD_PROGRAM_LED, DSCAlarmItemType.KEYPAD_FIRE_LED, DSCAlarmItemType.KEYPAD_BACKLIGHT_LED };
 
         String itemName;
         APICode apiCode = APICode.getAPICodeValue(apiMessage.getAPICode());
@@ -974,11 +937,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
     private void verboseTroubleStatusHandler(EventObject event) {
         DSCAlarmEvent dscAlarmEvent = (DSCAlarmEvent) event;
         APIMessage apiMessage = dscAlarmEvent.getAPIMessage();
-        DSCAlarmItemType[] dscAlarmItemTypes = { DSCAlarmItemType.PANEL_SERVICE_REQUIRED,
-                DSCAlarmItemType.PANEL_AC_TROUBLE, DSCAlarmItemType.PANEL_TELEPHONE_TROUBLE,
-                DSCAlarmItemType.PANEL_FTC_TROUBLE, DSCAlarmItemType.PANEL_ZONE_FAULT,
-                DSCAlarmItemType.PANEL_ZONE_TAMPER, DSCAlarmItemType.PANEL_ZONE_LOW_BATTERY,
-                DSCAlarmItemType.PANEL_TIME_LOSS };
+        DSCAlarmItemType[] dscAlarmItemTypes = { DSCAlarmItemType.PANEL_SERVICE_REQUIRED, DSCAlarmItemType.PANEL_AC_TROUBLE, DSCAlarmItemType.PANEL_TELEPHONE_TROUBLE, DSCAlarmItemType.PANEL_FTC_TROUBLE, DSCAlarmItemType.PANEL_ZONE_FAULT, DSCAlarmItemType.PANEL_ZONE_TAMPER, DSCAlarmItemType.PANEL_ZONE_LOW_BATTERY, DSCAlarmItemType.PANEL_TIME_LOSS };
 
         String itemName;
 
@@ -1037,6 +996,14 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 
                 break;
             case SystemError: /* 502 */
+                int errorCode = Integer.parseInt(apiData);
+
+                if (errorCode == 23 || errorCode == 24) {
+                    for (int i = 1; i < 9; i++) {
+                        updateItemType(DSCAlarmItemType.PARTITION_ARM_MODE, i, 0, 0);
+                    }
+                }
+
                 dscAlarmItemType = DSCAlarmItemType.PANEL_SYSTEM_ERROR;
                 break;
             case KeypadLEDState: /* 510 */
@@ -1055,7 +1022,6 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
             case PartitionReady: /* 650 */
             case PartitionNotReady: /* 651 */
             case PartitionReadyForceArming: /* 653 */
-            case FailureToArm: /* 672 */
             case SystemArmingInProgress: /* 674 */
                 dscAlarmItemType = DSCAlarmItemType.PARTITION_STATUS;
                 break;
@@ -1111,32 +1077,32 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
             case FireKeyAlarm: /* 621 */
                 state = 1;
             case FireKeyRestored: /* 622 */
-                updateItemType(DSCAlarmItemType.PANEL_FIRE_KEY_ALARM, apiMessage.getPartition(), apiMessage.getZone(),
-                        state);
+                updateItemType(DSCAlarmItemType.PANEL_FIRE_KEY_ALARM, apiMessage.getPartition(), apiMessage.getZone(), state);
                 break;
             case PanicKeyAlarm: /* 625 */
                 state = 1;
             case PanicKeyRestored: /* 626 */
-                updateItemType(DSCAlarmItemType.PANEL_PANIC_KEY_ALARM, apiMessage.getPartition(), apiMessage.getZone(),
-                        state);
+                updateItemType(DSCAlarmItemType.PANEL_PANIC_KEY_ALARM, apiMessage.getPartition(), apiMessage.getZone(), state);
                 break;
             case AuxiliaryKeyAlarm: /* 625 */
                 state = 1;
             case AuxiliaryKeyRestored: /* 626 */
-                updateItemType(DSCAlarmItemType.PANEL_AUX_KEY_ALARM, apiMessage.getPartition(), apiMessage.getZone(),
-                        state);
+                updateItemType(DSCAlarmItemType.PANEL_AUX_KEY_ALARM, apiMessage.getPartition(), apiMessage.getZone(), state);
                 break;
             case AuxiliaryInputAlarm: /* 625 */
                 state = 1;
             case AuxiliaryInputAlarmRestored: /* 631 */
-                updateItemType(DSCAlarmItemType.PANEL_AUX_INPUT_ALARM, apiMessage.getPartition(), apiMessage.getZone(),
-                        state);
+                updateItemType(DSCAlarmItemType.PANEL_AUX_INPUT_ALARM, apiMessage.getPartition(), apiMessage.getZone(), state);
                 break;
             case EntryDelayInProgress: /* 656 */
                 updateItemType(DSCAlarmItemType.PARTITION_ENTRY_DELAY, apiMessage.getPartition(), -1, 1);
                 break;
             case ExitDelayInProgress: /* 656 */
                 updateItemType(DSCAlarmItemType.PARTITION_EXIT_DELAY, apiMessage.getPartition(), -1, 1);
+                break;
+            case FailureToArm: /* 672 */
+                updateItemType(DSCAlarmItemType.PARTITION_ARM_MODE, partitionId, 0, 0);
+                dscAlarmItemType = DSCAlarmItemType.PARTITION_STATUS;
                 break;
             case UserClosing: /* 700 */
             case SpecialClosing: /* 701 */
@@ -1247,8 +1213,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
                                 }
                                 break;
                             case PARTITION_EVENT:
-                                if (partitionId == config.getPartitionId()
-                                        && dscAlarmItemType == config.getDSCAlarmItemType()) {
+                                if (partitionId == config.getPartitionId() && dscAlarmItemType == config.getDSCAlarmItemType()) {
                                     itemName = iName;
                                     found = true;
                                 }
@@ -1289,8 +1254,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
 
     @Override
     public boolean sendDSCAlarmCommand(String command, String data) {
-        logger.debug("sendDSCAlarmCommand(): Attempting to send DSC Alarm Command: command - {} - data: {}", command,
-                data);
+        logger.debug("sendDSCAlarmCommand(): Attempting to send DSC Alarm Command: command - {} - data: {}", command, data);
 
         try {
             APICode apiCode = APICode.getAPICodeValue(command);

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmGenericBindingProvider.java
@@ -61,8 +61,7 @@ public class DSCAlarmGenericBindingProvider extends AbstractGenericBindingProvid
      * {@inheritDoc}
      */
     @Override
-    public void processBindingConfiguration(String context, Item item, String bindingConfig)
-            throws BindingConfigParseException {
+    public void processBindingConfiguration(String context, Item item, String bindingConfig) throws BindingConfigParseException {
 
         String[] sections = bindingConfig.split(":");
 
@@ -104,13 +103,11 @@ public class DSCAlarmGenericBindingProvider extends AbstractGenericBindingProvid
         }
 
         if (dscAlarmItemType == null) {
-            logger.error("processBindingConfiguration(): {}: DSC Alarm Item Type is NULL! Item Not Added!",
-                    item.getName());
+            logger.error("processBindingConfiguration(): {}: DSC Alarm Item Type is NULL! Item Not Added!", item.getName());
             return;
         }
 
-        DSCAlarmBindingConfig config = new DSCAlarmBindingConfig(dscAlarmDeviceType, partitionId, zoneId,
-                dscAlarmItemType);
+        DSCAlarmBindingConfig config = new DSCAlarmBindingConfig(dscAlarmDeviceType, partitionId, zoneId, dscAlarmItemType);
         addBindingConfig(item, config);
 
         super.processBindingConfiguration(context, item, bindingConfig);

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmItemUpdate.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmItemUpdate.java
@@ -82,8 +82,7 @@ public class DSCAlarmItemUpdate {
      * @param eventPublisher
      * @param event
      */
-    public synchronized void updateDeviceItem(Item item, DSCAlarmBindingConfig config, EventPublisher eventPublisher,
-            DSCAlarmEvent event) {
+    public synchronized void updateDeviceItem(Item item, DSCAlarmBindingConfig config, EventPublisher eventPublisher, DSCAlarmEvent event) {
         logger.debug("updateDeviceItem(): Item Name: {}", item.getName());
 
         if (config != null) {
@@ -181,8 +180,7 @@ public class DSCAlarmItemUpdate {
      * @param state
      * @param description
      */
-    public synchronized void updateDeviceProperties(Item item, DSCAlarmBindingConfig config, int state,
-            String description) {
+    public synchronized void updateDeviceProperties(Item item, DSCAlarmBindingConfig config, int state, String description) {
         logger.debug("updateDeviceProperties(): Item Name: {}", item.getName());
 
         if (config != null) {

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/connector/DSCAlarmConnectorType.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/connector/DSCAlarmConnectorType.java
@@ -15,6 +15,6 @@ package org.openhab.binding.dscalarm.internal.connector;
  * @since 1.6.0
  */
 public enum DSCAlarmConnectorType {
-	SERIAL,
-	TCP;
+    SERIAL,
+    TCP;
 }

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/connector/TCPConnector.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/connector/TCPConnector.java
@@ -34,210 +34,200 @@ import org.slf4j.LoggerFactory;
  * @since 1.6.0
  */
 public class TCPConnector implements DSCAlarmConnector {
-	private static final Logger logger = LoggerFactory.getLogger(TCPConnector.class);
+    private static final Logger logger = LoggerFactory.getLogger(TCPConnector.class);
 
-	String ipAddress = "";
-	int tcpPort;
-	int connectTimeout;
-	private Socket tcpSocket = null;
-	private OutputStreamWriter tcpOutput = null;
-	private BufferedReader tcpInput = null;
-	private TCPListener TCPListener = null;
-	private DSCAlarmConnectorType connectorType = DSCAlarmConnectorType.TCP;
-	private static boolean connected = false;
-	private static List<DSCAlarmEventListener> _listeners = new ArrayList<DSCAlarmEventListener>();
+    String ipAddress = "";
+    int tcpPort;
+    int connectTimeout;
+    private Socket tcpSocket = null;
+    private OutputStreamWriter tcpOutput = null;
+    private BufferedReader tcpInput = null;
+    private TCPListener TCPListener = null;
+    private DSCAlarmConnectorType connectorType = DSCAlarmConnectorType.TCP;
+    private static boolean connected = false;
+    private static List<DSCAlarmEventListener> _listeners = new ArrayList<DSCAlarmEventListener>();
 
-	/**
-	 * Constructor.
-	 **/
-	public TCPConnector(String ip, int port, int timeout) {
-		ipAddress = ip;
-		tcpPort = port;
-		connectTimeout = timeout;
-	}
+    /**
+     * Constructor.
+     **/
+    public TCPConnector(String ip, int port, int timeout) {
+        ipAddress = ip;
+        tcpPort = port;
+        connectTimeout = timeout;
+    }
 
-	/**
-	 * Returns Connector Type
-	 **/
-	public DSCAlarmConnectorType getConnectorType() {
-		return connectorType;
-	}
+    /**
+     * Returns Connector Type
+     **/
+    public DSCAlarmConnectorType getConnectorType() {
+        return connectorType;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 **/
-	public void write(String writeString) {
+    /**
+     * {@inheritDoc}
+     **/
+    public void write(String writeString) {
         try {
-        	tcpOutput.write(writeString);
+            tcpOutput.write(writeString);
             tcpOutput.flush();
-    		logger.debug("write(): Message Sent: {}",writeString);
-        }catch (IOException ioException) {
-        	logger.error("write(): {}",ioException);
-			connected = false;
+            logger.debug("write(): Message Sent: {}", writeString);
+        } catch (IOException ioException) {
+            logger.error("write(): {}", ioException);
+            connected = false;
         } catch (Exception exception) {
-        	logger.error("write(): Unable to write to socket: {} ", exception);
-			connected = false;
+            logger.error("write(): Unable to write to socket: {} ", exception);
+            connected = false;
         }
     }
 
-	/**
-	 * {@inheritDoc}
-	 **/
-   public String read() {
+    /**
+     * {@inheritDoc}
+     **/
+    public String read() {
         String message = "";
 
         try {
-        	message = tcpInput.readLine();
-    		logger.debug("read(): Message Received: {}",message);
-        }
-        catch (IOException ioException) {
-			logger.error("read(): IO Exception: ", ioException);
-			connected = false;
-        }
-        catch (Exception exception) {
-			logger.error("read(): Exception: ", exception);
-			connected = false;
+            message = tcpInput.readLine();
+            logger.debug("read(): Message Received: {}", message);
+        } catch (IOException ioException) {
+            logger.error("read(): IO Exception: ", ioException);
+            connected = false;
+        } catch (Exception exception) {
+            logger.error("read(): Exception: ", exception);
+            connected = false;
         }
 
         return message;
 
     }
 
-	/**
-	 * {@inheritDoc}
-	 **/
-   public void open() {
+    /**
+     * {@inheritDoc}
+     **/
+    public void open() {
         try {
-        	tcpSocket = new Socket();
+            tcpSocket = new Socket();
             SocketAddress TPIsocketAddress = new InetSocketAddress(ipAddress, tcpPort);
             tcpSocket.connect(TPIsocketAddress, connectTimeout);
-			tcpOutput = new OutputStreamWriter(tcpSocket.getOutputStream(), "US-ASCII");
+            tcpOutput = new OutputStreamWriter(tcpSocket.getOutputStream(), "US-ASCII");
             tcpInput = new BufferedReader(new InputStreamReader(tcpSocket.getInputStream()));
             connected = true;
 
-			//Start the TCP Listener
-	    	TCPListener = new TCPListener();
-	    	TCPListener.start();
-        }
-        catch (UnknownHostException exception) {
-			logger.error("open(): Unknown Host Exception: ", exception);
+            // Start the TCP Listener
+            TCPListener = new TCPListener();
+            TCPListener.start();
+        } catch (UnknownHostException exception) {
+            logger.error("open(): Unknown Host Exception: ", exception);
             connected = false;
-        }
-		catch (SocketException socketException) {
-			logger.error("open(): Socket Exception: ", socketException);
+        } catch (SocketException socketException) {
+            logger.error("open(): Socket Exception: ", socketException);
             connected = false;
-        }
-		catch (IOException ioException) {
-			logger.error("open(): IO Exception: ", ioException);
+        } catch (IOException ioException) {
+            logger.error("open(): IO Exception: ", ioException);
             connected = false;
-        }
-        catch (Exception exception) {
-			logger.error("open(): Exception: ", exception);
+        } catch (Exception exception) {
+            logger.error("open(): Exception: ", exception);
             connected = false;
         }
     }
 
-	 /**
-	  * Handles an incoming  message
-	  *
-	  * @param incomingMessage
-	  */
-	 public synchronized void handleIncomingMessage(String incomingMessage) {
-		APIMessage Message = new APIMessage(incomingMessage);
-		logger.debug("handleIncomingMessage(): Message received: {} - {}",incomingMessage,Message.toString());
+    /**
+     * Handles an incoming message
+     *
+     * @param incomingMessage
+     */
+    public synchronized void handleIncomingMessage(String incomingMessage) {
+        APIMessage Message = new APIMessage(incomingMessage);
+        logger.debug("handleIncomingMessage(): Message received: {} - {}", incomingMessage, Message.toString());
 
-		DSCAlarmEvent event = new DSCAlarmEvent(this);
-		event.dscAlarmEventMessage(Message);
+        DSCAlarmEvent event = new DSCAlarmEvent(this);
+        event.dscAlarmEventMessage(Message);
 
-		// send message to event listeners
-		try {
-			Iterator<DSCAlarmEventListener> iterator = _listeners.iterator();
+        // send message to event listeners
+        try {
+            Iterator<DSCAlarmEventListener> iterator = _listeners.iterator();
 
-			while (iterator.hasNext()) {
-				((DSCAlarmEventListener) iterator.next()).dscAlarmEventRecieved(event);
-			}
+            while (iterator.hasNext()) {
+                ((DSCAlarmEventListener) iterator.next()).dscAlarmEventRecieved(event);
+            }
 
-		} catch (Exception e) {
-			logger.error("handleIncomingMessage(): Event listener invoking error", e);
-		}
-	 }
-
-
-	/**
-	 * {@inheritDoc}
-	 **/
-	 public boolean isConnected() {
-		 return connected;
-	 }
-
-	/**
-	 * {@inheritDoc}
-	 **/
-	 public void close() {
-		try {
-			if (tcpSocket != null) {
-				tcpSocket.close();
-				tcpSocket = null;
-			}
-			if (tcpInput != null) {
-				tcpInput.close();
-				tcpInput = null;
-			}
-			if (tcpOutput != null) {
-				tcpOutput.close();
-				tcpOutput = null;
-			}
-			connected = false;
-			logger.debug("close(): Closed TCP Connection!");
-		}
-		catch (IOException ioException) {
-			logger.error("close(): Unable to close connection - " + ioException.getMessage());
-		}
-        catch (Exception exception) {
-        	logger.error("close(): Error closing connection - " + exception.getMessage());
+        } catch (Exception e) {
+            logger.error("handleIncomingMessage(): Event listener invoking error", e);
         }
-	 }
+    }
 
-	/**
-	 * {@inheritDoc}
-	 **/
-	public synchronized void addEventListener(DSCAlarmEventListener listener) {
-		_listeners.add(listener);
-	}
+    /**
+     * {@inheritDoc}
+     **/
+    public boolean isConnected() {
+        return connected;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 **/
-	public synchronized void removeEventListener(DSCAlarmEventListener listener) {
-		_listeners.remove(listener);
-	}
+    /**
+     * {@inheritDoc}
+     **/
+    public void close() {
+        try {
+            if (tcpSocket != null) {
+                tcpSocket.close();
+                tcpSocket = null;
+            }
+            if (tcpInput != null) {
+                tcpInput.close();
+                tcpInput = null;
+            }
+            if (tcpOutput != null) {
+                tcpOutput.close();
+                tcpOutput = null;
+            }
+            connected = false;
+            logger.debug("close(): Closed TCP Connection!");
+        } catch (IOException ioException) {
+            logger.error("close(): Unable to close connection - " + ioException.getMessage());
+        } catch (Exception exception) {
+            logger.error("close(): Error closing connection - " + exception.getMessage());
+        }
+    }
 
-	/**
-	 * TCPMessageListener Thread. Receives  messages from the DSC Alarm Panel API.
-	 */
-	private class TCPListener extends Thread {
-		private final Logger logger = LoggerFactory.getLogger(TCPListener.class);
+    /**
+     * {@inheritDoc}
+     **/
+    public synchronized void addEventListener(DSCAlarmEventListener listener) {
+        _listeners.add(listener);
+    }
 
-		public TCPListener() {
-		}
+    /**
+     * {@inheritDoc}
+     **/
+    public synchronized void removeEventListener(DSCAlarmEventListener listener) {
+        _listeners.remove(listener);
+    }
 
-		/**
-		 * Run method. Runs the MessageListener thread
-		 */
-		@Override
-		public void run() {
-			String messageLine;
+    /**
+     * TCPMessageListener Thread. Receives messages from the DSC Alarm Panel API.
+     */
+    private class TCPListener extends Thread {
+        private final Logger logger = LoggerFactory.getLogger(TCPListener.class);
 
-			try {
-				while(connected) {
-					if((messageLine = read()) != null) {
-						handleIncomingMessage(messageLine);
-					}
-				}
-			}
-			catch(Exception e) {
-				logger.error("TCPListener(): Unable to read message: ", e);
-			}
-		}
-	}
+        public TCPListener() {
+        }
+
+        /**
+         * Run method. Runs the MessageListener thread
+         */
+        @Override
+        public void run() {
+            String messageLine;
+
+            try {
+                while (connected) {
+                    if ((messageLine = read()) != null) {
+                        handleIncomingMessage(messageLine);
+                    }
+                }
+            } catch (Exception e) {
+                logger.error("TCPListener(): Unable to read message: ", e);
+            }
+        }
+    }
 }

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/DSCAlarmDevice.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/DSCAlarmDevice.java
@@ -38,8 +38,7 @@ public abstract class DSCAlarmDevice {
      * @param config
      * @param publisher
      */
-    public abstract void handleEvent(Item item, DSCAlarmBindingConfig config, EventPublisher publisher,
-            DSCAlarmEvent event);
+    public abstract void handleEvent(Item item, DSCAlarmBindingConfig config, EventPublisher publisher, DSCAlarmEvent event);
 
     /**
      * Update a DSC Alarm Device Property

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Panel.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Panel.java
@@ -69,8 +69,7 @@ public class Panel extends DSCAlarmDevice {
                         publisher.postUpdate(item.getName(), new StringType(str));
                         break;
                     case PANEL_SYSTEM_ERROR:
-                        str = String.format("%03d", panelProperties.getSystemErrorCode()) + ": "
-                                + panelProperties.getSystemErrorDescription();
+                        str = String.format("%03d", panelProperties.getSystemErrorCode()) + ": " + panelProperties.getSystemErrorDescription();
                         publisher.postUpdate(item.getName(), new StringType(str));
                         break;
                     case PANEL_TIME:
@@ -209,8 +208,7 @@ public class Panel extends DSCAlarmDevice {
                                 systemErrorCode = Integer.parseInt(apiMessage.getAPIData());
                                 panelProperties.setSystemErrorCode(systemErrorCode);
                                 panelProperties.setSystemErrorDescription(apiMessage.getError());
-                                str = String.format("%03d", panelProperties.getSystemErrorCode()) + ": "
-                                        + panelProperties.getSystemErrorDescription();
+                                str = String.format("%03d", panelProperties.getSystemErrorCode()) + ": " + panelProperties.getSystemErrorDescription();
                                 publisher.postUpdate(item.getName(), new StringType(str));
                             }
                             break;

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Zone.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/model/Zone.java
@@ -146,8 +146,7 @@ public class Zone extends DSCAlarmDevice {
                             break;
                         case ZONE_GENERAL_STATUS:
                             zoneProperties.setState(StateType.GENERAL_STATE, (tpiCode == 609) ? 1 : 0, strStatus);
-                            publisher.postUpdate(item.getName(), (zoneProperties.getState(StateType.GENERAL_STATE) == 1)
-                                    ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
+                            publisher.postUpdate(item.getName(), (zoneProperties.getState(StateType.GENERAL_STATE) == 1) ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
                             break;
                         default:
                             logger.debug("handleEvent(): Zone item not updated.");

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
@@ -239,8 +239,7 @@ public class API {
             logger.error("open(): Unable to Make API Connection!");
         }
 
-        logger.debug("open(): Connected = {}, Connection Type: {}, Interface Type: {}", connected ? true : false,
-                connectorType, interfaceType);
+        logger.debug("open(): Connected = {}, Connection Type: {}, Interface Type: {}", connected ? true : false, connectorType, interfaceType);
 
         return connected;
     }
@@ -320,15 +319,12 @@ public class API {
                 break;
             case CommandOutputControl: /* 020 */
                 if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
-                    logger.error(
-                            "sendCommand(): Partition number must be a single character string from 1 to 8, it was: "
-                                    + apiData[0]);
+                    logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: " + apiData[0]);
                     break;
                 }
 
                 if (apiData[1] == null || !apiData[1].matches("[1-4]")) {
-                    logger.error("sendCommand(): Output number must be a single character string from 1 to 4, it was: "
-                            + apiData[1]);
+                    logger.error("sendCommand(): Output number must be a single character string from 1 to 4, it was: " + apiData[1]);
                     break;
                 }
 
@@ -343,9 +339,7 @@ public class API {
             case PartitionArmControlStay: /* 031 */
             case PartitionArmControlZeroEntryDelay: /* 032 */
                 if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
-                    logger.error(
-                            "sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}",
-                            apiData[0]);
+                    logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}", apiData[0]);
                     break;
                 }
                 data = apiData[0];
@@ -354,15 +348,12 @@ public class API {
             case PartitionArmControlWithUserCode: /* 033 */
             case PartitionDisarmControl: /* 040 */
                 if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
-                    logger.error(
-                            "sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}",
-                            apiData[0]);
+                    logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}", apiData[0]);
                     break;
                 }
 
                 if (dscAlarmUserCode == null || dscAlarmUserCode.length() < 4 || dscAlarmUserCode.length() > 6) {
-                    logger.error("sendCommand(): User Code is invalid, must be between 4 and 6 chars: {}",
-                            dscAlarmUserCode);
+                    logger.error("sendCommand(): User Code is invalid, must be between 4 and 6 chars: {}", dscAlarmUserCode);
                     break;
                 }
 
@@ -389,15 +380,12 @@ public class API {
                 break;
             case TriggerPanicAlarm: /* 060 */
                 if (apiData[0] == null || !apiData[0].matches("[1-8]")) {
-                    logger.error(
-                            "sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}",
-                            apiData[0]);
+                    logger.error("sendCommand(): Partition number must be a single character string from 1 to 8, it was: {}", apiData[0]);
                     break;
                 }
 
                 if (apiData[1] == null || !apiData[1].matches("[1-3]")) {
-                    logger.error("sendCommand(): FAPcode must be a single character string from 1 to 3, it was: {}",
-                            apiData[1]);
+                    logger.error("sendCommand(): FAPcode must be a single character string from 1 to 3, it was: {}", apiData[1]);
                     break;
                 }
                 data = apiData[0] + apiData[1];
@@ -405,9 +393,7 @@ public class API {
                 break;
             case KeyStroke: /* 070 */
                 if (apiData[0] == null || apiData[0].length() != 1 || !apiData[0].matches("[0-9]|A|#|\\*")) {
-                    logger.error(
-                            "sendCommand(): \'keystroke\' must be a single character string from 0 to 9, *, #, or A, it was: {}",
-                            apiData[0]);
+                    logger.error("sendCommand(): \'keystroke\' must be a single character string from 0 to 9, *, #, or A, it was: {}", apiData[0]);
                     break;
                 }
                 data = apiData[0];
@@ -419,9 +405,7 @@ public class API {
                 }
 
                 if (apiData[0] == null || apiData[0].length() > 6 || !apiData[0].matches("(\\d|#|\\*)+")) {
-                    logger.error(
-                            "sendCommand(): \'keysequence\' must be a string of up to 6 characters consiting of 0 to 9, *, or #, it was: {}",
-                            apiData[0]);
+                    logger.error("sendCommand(): \'keysequence\' must be a string of up to 6 characters consiting of 0 to 9, *, or #, it was: {}", apiData[0]);
                     break;
                 }
                 data = apiData[0];
@@ -429,8 +413,7 @@ public class API {
                 break;
             case CodeSend: /* 200 */
                 if (dscAlarmUserCode == null || dscAlarmUserCode.length() < 4 || dscAlarmUserCode.length() > 6) {
-                    logger.error("sendCommand(): Access Code is invalid, must be between 4 and 6 chars: {}",
-                            apiData[0]);
+                    logger.error("sendCommand(): Access Code is invalid, must be between 4 and 6 chars: {}", apiData[0]);
                     break;
                 }
                 data = dscAlarmUserCode;

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/APIMessage.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/APIMessage.java
@@ -181,8 +181,7 @@ public class APIMessage {
                         break;
                     case LoginResponse: /* 505 */
                         apiName = "Login Interaction";
-                        apiDescription = apiCodeReceived
-                                + ": Login response (failed=0, success=1, time out=2, password request=3).";
+                        apiDescription = apiCodeReceived + ": Login response (failed=0, success=1, time out=2, password request=3).";
                         break;
                     case KeypadLEDState: /* 510 */
                         apiName = "Keypad LED State - Partition 1 Only";
@@ -191,8 +190,7 @@ public class APIMessage {
                         break;
                     case KeypadLEDFlashState: /* 511 */
                         apiName = "Keypad LED Flash State - Partition 1 Only";
-                        apiDescription = apiCodeReceived
-                                + ": A change of state in the Partition 1 keypad LEDs as to whether to flash or not.";
+                        apiDescription = apiCodeReceived + ": A change of state in the Partition 1 keypad LEDs as to whether to flash or not.";
                         apiMessageType = APIMessageType.KEYPAD_EVENT;
                         break;
                     case TimeDateBroadcast: /* 550 */
@@ -214,8 +212,7 @@ public class APIMessage {
                         break;
                     case ThermostatSetPoints: /* 563 */
                         apiName = "Thermostat Set Points";
-                        apiDescription = apiCodeReceived
-                                + ": Cooling and heating set points and the thermostat number.";
+                        apiDescription = apiCodeReceived + ": Cooling and heating set points and the thermostat number.";
                         break;
                     case BroadcastLabels: /* 570 */
                         apiName = "Broadcast Labels";
@@ -447,21 +444,18 @@ public class APIMessage {
                         partition = Integer.parseInt(apiMessage.substring(3, 4));
                         user = apiMessage.substring(4);
                         apiName = apiName.concat(": " + user);
-                        apiDescription = apiCodeReceived + ": Partition " + String.valueOf(partition)
-                                + " has been armed by user " + user + ".";
+                        apiDescription = apiCodeReceived + ": Partition " + String.valueOf(partition) + " has been armed by user " + user + ".";
                         apiMessageType = APIMessageType.PARTITION_EVENT;
                         break;
                     case SpecialClosing: /* 701 */
                         apiName = "Special Closing";
-                        apiDescription = apiCodeReceived
-                                + ": A partition has been armed by one of the following methods: Quick Arm, Auto Arm, Keyswitch, DLS software, Wireless Key.";
+                        apiDescription = apiCodeReceived + ": A partition has been armed by one of the following methods: Quick Arm, Auto Arm, Keyswitch, DLS software, Wireless Key.";
                         partition = Integer.parseInt(apiMessage.substring(3, 4));
                         apiMessageType = APIMessageType.PARTITION_EVENT;
                         break;
                     case PartialClosing: /* 702 */
                         apiName = "Partial Closing";
-                        apiDescription = apiCodeReceived
-                                + ": A partition has been armed but one or more zones have been bypassed.";
+                        apiDescription = apiCodeReceived + ": A partition has been armed but one or more zones have been bypassed.";
                         partition = Integer.parseInt(apiMessage.substring(3, 4));
                         apiMessageType = APIMessageType.PARTITION_EVENT;
                         break;
@@ -470,14 +464,12 @@ public class APIMessage {
                         partition = Integer.parseInt(apiMessage.substring(3, 4));
                         user = apiMessage.substring(4);
                         apiName = apiName.concat(": " + user);
-                        apiDescription = apiCodeReceived + ": Partition " + String.valueOf(partition)
-                                + " has been disarmed by user " + user + ".";
+                        apiDescription = apiCodeReceived + ": Partition " + String.valueOf(partition) + " has been disarmed by user " + user + ".";
                         apiMessageType = APIMessageType.PARTITION_EVENT;
                         break;
                     case SpecialOpening: /* 751 */
                         apiName = "Special Opening";
-                        apiDescription = apiCodeReceived
-                                + ": A partition has been disarmed by one of the following methods: Quick Arm, Auto Arm, Keyswitch, DLS software, Wireless Key.";
+                        apiDescription = apiCodeReceived + ": A partition has been disarmed by one of the following methods: Quick Arm, Auto Arm, Keyswitch, DLS software, Wireless Key.";
                         partition = Integer.parseInt(apiMessage.substring(3, 4));
                         apiMessageType = APIMessageType.PARTITION_EVENT;
                         break;
@@ -500,8 +492,7 @@ public class APIMessage {
                         break;
                     case SystemBellTrouble: /* 806 */
                         apiName = "System Bell Trouble";
-                        apiDescription = apiCodeReceived
-                                + ": An open circuit has been detected across the bell terminals.";
+                        apiDescription = apiCodeReceived + ": An open circuit has been detected across the bell terminals.";
                         break;
                     case SystemBellTroubleRestore: /* 807 */
                         apiName = "System Bell Trouble Restore";
@@ -525,13 +516,11 @@ public class APIMessage {
                         break;
                     case FTCTrouble: /* 814 */
                         apiName = "FTC Trouble";
-                        apiDescription = apiCodeReceived
-                                + ": The panel has failed to communicate successfully to the monitoring station.";
+                        apiDescription = apiCodeReceived + ": The panel has failed to communicate successfully to the monitoring station.";
                         break;
                     case BufferNearFull: /* 816 */
                         apiName = "Buffer Near Full";
-                        apiDescription = apiCodeReceived
-                                + ": The panel event buffer is 75% full from when it was last uploaded to DLS.";
+                        apiDescription = apiCodeReceived + ": The panel event buffer is 75% full from when it was last uploaded to DLS.";
                         break;
                     case GeneralDeviceLowBattery: /* 821 */
                         apiName = "General Device Low Battery";
@@ -560,8 +549,7 @@ public class APIMessage {
                         break;
                     case HandheldKeypadLowBatteryTroubleRestore: /* ("828 */
                         apiName = "Handheld Keypad Low Battery Trouble Restore";
-                        apiDescription = apiCodeReceived
-                                + ": A handhekd keypad low battery condition has been restored.";
+                        apiDescription = apiCodeReceived + ": A handhekd keypad low battery condition has been restored.";
                         zone = Integer.parseInt(apiMessage.substring(3));
                         break;
                     case GeneralSystemTamper: /* 829 */
@@ -600,8 +588,7 @@ public class APIMessage {
                         break;
                     case VerboseTroubleStatus: /* 849 */
                         apiName = "Verbose Trouble Status";
-                        apiDescription = apiCodeReceived
-                                + ": a trouble appears on the system and roughly every 5 minutes until the trouble is cleared.";
+                        apiDescription = apiCodeReceived + ": a trouble appears on the system and roughly every 5 minutes until the trouble is cleared.";
                         break;
                     case KeybusFault: /* 896 */
                         apiName = "Keybus Fault";
@@ -669,8 +656,7 @@ public class APIMessage {
                         break;
                 }
 
-                logger.debug("parseAPIMessage(): Message Received ({}) - Code: {}, Name: {}, Description: {}, Data: {}",
-                        apiMessage, apiCodeReceived, apiName, apiDescription, data);
+                logger.debug("parseAPIMessage(): Message Received ({}) - Code: {}, Name: {}, Description: {}, Data: {}", apiMessage, apiCodeReceived, apiName, apiDescription, data);
             } else {
                 logger.debug("parseAPIMessage(): Invalid Message Received");
             }


### PR DESCRIPTION
The binding would prematurely set the item `PARTITION_ARM_MODE` when issuing a partition arm command.  This would sometimes show the partition as being armed when it actually wasn't.  This fixes that situation by only setting the item when a verification message is received from the alarm system.  This issue was brought to light on the openHAB community website [here](https://community.openhab.org/t/dsc-partition-arm-mode/11012).