### PR TITLE
Network Health - Made log message more clear

### DIFF
--- a/bundles/binding/org.openhab.binding.networkhealth/src/main/java/org/openhab/binding/networkhealth/internal/NetworkHealthBinding.java
+++ b/bundles/binding/org.openhab.binding.networkhealth/src/main/java/org/openhab/binding/networkhealth/internal/NetworkHealthBinding.java
@@ -90,12 +90,13 @@ public class NetworkHealthBinding extends AbstractActiveBinding<NetworkHealthBin
                 try {
                     success = Ping.checkVitality(hostname, port, timeout);
 
-                    if(success)
+                    if(success) {
                         logger.debug("established connection [host '{}' port '{}' timeout '{}']",
                             new Object[] { hostname, port, timeout });
-                    else
+                    } else {
                         logger.debug("couldn't establish connection [host '{}' port '{}' timeout '{}']",
                             new Object[] { hostname, port, timeout });
+                    }
                 } catch (SocketTimeoutException se) {
                     logger.debug("timed out while connecting [host '{}' port '{}' timeout '{}']",
                             new Object[] { hostname, port, timeout });

--- a/bundles/binding/org.openhab.binding.networkhealth/src/main/java/org/openhab/binding/networkhealth/internal/NetworkHealthBinding.java
+++ b/bundles/binding/org.openhab.binding.networkhealth/src/main/java/org/openhab/binding/networkhealth/internal/NetworkHealthBinding.java
@@ -90,10 +90,14 @@ public class NetworkHealthBinding extends AbstractActiveBinding<NetworkHealthBin
                 try {
                     success = Ping.checkVitality(hostname, port, timeout);
 
-                    logger.debug("established connection [host '{}' port '{}' timeout '{}']",
+                    if(success)
+                        logger.debug("established connection [host '{}' port '{}' timeout '{}']",
+                            new Object[] { hostname, port, timeout });
+                    else
+                        logger.debug("couldn't established connection [host '{}' port '{}' timeout '{}']",
                             new Object[] { hostname, port, timeout });
                 } catch (SocketTimeoutException se) {
-                    logger.debug("timed out while connecting to host '{}' port '{}' timeout '{}'",
+                    logger.debug("timed out while connecting [host '{}' port '{}' timeout '{}']",
                             new Object[] { hostname, port, timeout });
                 } catch (IOException ioe) {
                     logger.debug("couldn't establish network connection [host '{}' port '{}' timeout '{}']",

--- a/bundles/binding/org.openhab.binding.networkhealth/src/main/java/org/openhab/binding/networkhealth/internal/NetworkHealthBinding.java
+++ b/bundles/binding/org.openhab.binding.networkhealth/src/main/java/org/openhab/binding/networkhealth/internal/NetworkHealthBinding.java
@@ -94,7 +94,7 @@ public class NetworkHealthBinding extends AbstractActiveBinding<NetworkHealthBin
                         logger.debug("established connection [host '{}' port '{}' timeout '{}']",
                             new Object[] { hostname, port, timeout });
                     else
-                        logger.debug("couldn't established connection [host '{}' port '{}' timeout '{}']",
+                        logger.debug("couldn't establish connection [host '{}' port '{}' timeout '{}']",
                             new Object[] { hostname, port, timeout });
                 } catch (SocketTimeoutException se) {
                     logger.debug("timed out while connecting [host '{}' port '{}' timeout '{}']",


### PR DESCRIPTION
Previuosly the log message always stated, that a host is reachable, independent of the return code of the checkVitality function.
This could lead to confusion in trying to debug on error.
Also reformated a log message to fit into the general design of the package.