### PR TITLE
Fixed AD2USB Commands Send

### DIFF
--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBinding.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBinding.java
@@ -306,6 +306,7 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
 				m_port.disableReceiveFraming();
 				m_port.disableReceiveThreshold();
 				m_reader = new BufferedReader(new InputStreamReader(m_port.getInputStream()));
+				m_writer = new BufferedWriter(new OutputStreamWriter(m_port.getOutputStream()));
 				logger.info("connected to serial port: {}", m_serialDeviceName);
 				startMsgReader();
 			} else {


### PR DESCRIPTION
Added m_writer initialization when used on Serial Port

This has been tested with an AD2USB device and now works like a charm, thanks to Bernd for his work on this plugin and to the rest of the OpenHAB community.