### PR TITLE
[TA-CMI Binding]: Added support for more data types, rudimentary support for the whole protocol

### DIFF
--- a/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/TACmiGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/TACmiGenericBindingProvider.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  * @author Timo Wendt
+ * @author Wolfgang Klimt
  * @since 1.8.0
  */
 public class TACmiGenericBindingProvider extends AbstractGenericBindingProvider implements TACmiBindingProvider {
@@ -70,28 +71,23 @@ public class TACmiGenericBindingProvider extends AbstractGenericBindingProvider 
     public void processBindingConfiguration(String context, Item item, String bindingConfig)
             throws BindingConfigParseException {
         super.processBindingConfiguration(context, item, bindingConfig);
-        TACmiBindingConfig config = new TACmiBindingConfig();
-
+        TACmiBindingConfig config;
         logger.debug("Processing binding configuration: '{}'", bindingConfig);
 
         final String[] configParts = bindingConfig.split("#");
         switch (configParts.length) {
             case 3:
-                config.canNode = configParts[0];
-                config.portType = configParts[1];
-                config.portNumber = Integer.parseInt(configParts[2]);
+                config = new TACmiBindingConfig(Integer.parseInt(configParts[0]), configParts[1],
+                        Integer.parseInt(configParts[2]), null, bindingConfig);
                 break;
             case 4:
-                config.canNode = configParts[0];
-                config.portType = configParts[1];
-                config.portNumber = Integer.parseInt(configParts[2]);
-                config.measureType = TACmiMeasureType.fromString(configParts[3]);
+                config = new TACmiBindingConfig(Integer.parseInt(configParts[0]), configParts[1],
+                        Integer.parseInt(configParts[2]), TACmiMeasureType.fromString(configParts[3]), bindingConfig);
                 break;
             default:
                 throw new BindingConfigParseException(
                         "A TACmi binding configuration must consist of three or four parts - please verify your *.items file");
         }
-        config.configurationString = bindingConfig;
 
         logger.debug("Adding Binding configuration: {}", config);
 
@@ -100,21 +96,30 @@ public class TACmiGenericBindingProvider extends AbstractGenericBindingProvider 
 
     /**
      * This is a helper class holding binding specific configuration details
-     * 
+     *
      * @author Timo Wendt
      * @since 1.7.0
      */
     class TACmiBindingConfig implements BindingConfig {
-        String canNode;
+        int canNode;
         String portType;
         int portNumber;
         TACmiMeasureType measureType;
         String configurationString;
 
+        public TACmiBindingConfig(int canNode, String portType, int portNumber, TACmiMeasureType measureType,
+                String configurationString) {
+            this.canNode = canNode;
+            this.portType = portType;
+            this.portNumber = portNumber;
+            this.measureType = measureType;
+            this.configurationString = configurationString;
+        }
+
         @Override
         public String toString() {
-            return "NetatmoBindingConfig [canNode=" + this.canNode + ", portType=" + this.portType + ", portNumber="
-                    + this.portNumber + ", measure=" + this.measureType.getMeasure() + "]";
+            return "TACmiBindingConfig [canNode=" + this.canNode + ", portType=" + this.portType + ", portNumber="
+                    + this.portNumber + ", measure=" + this.measureType.getTypeValue() + "]";
         }
     }
 
@@ -133,7 +138,7 @@ public class TACmiGenericBindingProvider extends AbstractGenericBindingProvider 
     @Override
     public int getCanNode(String itemName) {
         final TACmiBindingConfig config = (TACmiBindingConfig) this.bindingConfigs.get(itemName);
-        return config != null ? Integer.parseInt(config.canNode) : null;
+        return config != null ? config.canNode : 0;
     }
 
     /**
@@ -151,7 +156,7 @@ public class TACmiGenericBindingProvider extends AbstractGenericBindingProvider 
     @Override
     public int getPortNumber(String itemName) {
         final TACmiBindingConfig config = (TACmiBindingConfig) this.bindingConfigs.get(itemName);
-        return config != null ? config.portNumber : null;
+        return config != null ? config.portNumber : 0;
     }
 
     /**

--- a/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/TACmiMeasureType.java
+++ b/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/TACmiMeasureType.java
@@ -9,44 +9,85 @@
 package org.openhab.binding.tacmi.internal;
 
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This enum holds all the different measures and states available to be
- * retrieved by the TACmi binding Not the complete list yet.
- * 
+ * retrieved by the TACmi binding, including the scale factors needed to convert the received values to the real
+ * numbers.
+ *
  * @author Timo Wendt
+ * @author Wolfgang Klimt
  * @since 1.8.0
  */
 public enum TACmiMeasureType {
-    NONE(0),
-    TEMPERATURE(1),
-    SECONDS(4),
-    UNSUPPORTED(-1);
+    NONE(0, 0),
+    TEMPERATURE(1, 1),
+    UNKNOWN2(2, 0),
+    UNKNOWN3(3, 0),
+    SECONDS(4, 0),
+    UNKNOWN5(5, 0),
+    UNKNOWN6(6, 0),
+    UNKNOWN7(7, 0),
+    UNKNOWN8(8, 0),
+    UNKNOWN9(9, 0),
+    KILOWATT(10, 1),
+    KILOWATTHOURS(11, 1),
+    MEGAWATTHOURS(12, 0),
+    UNKNOWN13(13, 0),
+    UNKNOWN14(14, 0),
+    UNKNOWN15(15, 0),
+    UNKNOWN16(16, 0),
+    UNKNOWN17(17, 0),
+    UNKNOWN18(18, 0),
+    UNKNOWN19(19, 0),
+    UNKNOWN20(20, 0),
+    UNKNOWN21(21, 0),
 
-    int measure;
+    UNSUPPORTED(-1, 0);
 
-    private TACmiMeasureType(int measure) {
-        this.measure = measure;
+    private int typeval;
+    private int scale;
+
+    private static final Logger logger = LoggerFactory.getLogger(TACmiMeasureType.class);
+
+    private TACmiMeasureType(int typeval, int scale) {
+        this.typeval = typeval;
+        this.scale = scale;
     }
 
-    public int getMeasure() {
-        return measure;
+    public int getTypeValue() {
+        return typeval;
+    }
+
+    public int getScale() {
+        return scale;
     }
 
     /**
      * Return the measure type for the specified name.
-     * 
+     *
      * @param measure
      * @return
      */
     public static TACmiMeasureType fromString(String measure) {
         if (!StringUtils.isEmpty(measure)) {
-            for (TACmiMeasureType measureType : TACmiMeasureType.values()) {
-                if (measureType.toString().equalsIgnoreCase(measure)) {
-                    return measureType;
-                }
-            }
+            return TACmiMeasureType.valueOf(measure.toUpperCase());
         }
         throw new IllegalArgumentException("Invalid measure: " + measure);
+    }
+
+    /**
+     * Return measure type for a specific int value
+     */
+    public static TACmiMeasureType fromInt(int type) {
+        for (TACmiMeasureType mtype : TACmiMeasureType.values()) {
+            if (mtype.getTypeValue() == type) {
+                return mtype;
+            }
+        }
+        logger.warn("Received unexpected measure type {}", type);
+        return TACmiMeasureType.UNSUPPORTED;
     }
 }

--- a/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/message/AnalogMessage.java
+++ b/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/message/AnalogMessage.java
@@ -17,8 +17,47 @@ import org.slf4j.Logger;
  *    1        2      3       4       5       6        7      8       9       10     11     12     13      14
  *    0        1      2       3       4       5        6      7       8        9     10     11     12      13
  * canNode 1|2|3|4 1.lower 1.upper 2.lower 2.upper 3.lower 3.upper 4.lower 4.upper 1.type 2.type 3.type 4.type
+ *
+ * possible values for type according to the documentation are 1 to 21.
+ *
+ * The documentation says for the types:
+ *
+ * 1: Degree Celsius
+ * 2: Watts per square meter
+ * 3: liters per hour
+ * 4: seconds
+ * 5: minutes
+ * 6: liters per pulse
+ * 7: Kelvin
+ * 8: Percent
+ * 9: Kilowatt
+ * 10: Megawatthours
+ * 11: Kilowatthours
+ * 12: Volt
+ * 13: Milliampere
+ * 14: hours
+ * 15: days
+ * 16: pulses
+ * 17: Kiloohm
+ * 18: Kilometers per hour
+ * 19: Hertz
+ * 20: liters per minute
+ * 21: bar
+ *
+ * However, reality shows that the documentation is partly not accurate. An UVR1611 device uses:
+ *
+ * 1: Degree Celsius
+ * 4: Seconds
+ * 10: Kilowatt
+ * 11: Megawatthours
+ * 12: Kilowatthours
+ *
+ * so we don't rely on the documentation.
+ *
  * @author Timo Wendt
+ * @author Wolfgang Klimt
  * @since 1.7.0
+ * @see TACmiMeasureType.java
  */
 
 /**
@@ -27,13 +66,14 @@ import org.slf4j.Logger;
  * CAN Input port. Creation of new message is not implemented so far.
  *
  * @author Timo Wendt
+ * @author Wolfgang Klimt
  * @since 1.8.0
  */
 public final class AnalogMessage extends Message {
 
     /**
      * Used to parse the data received from the CMI.
-     * 
+     *
      * @param raw
      */
     public AnalogMessage(byte[] raw) {
@@ -48,12 +88,12 @@ public final class AnalogMessage extends Message {
         super(canNode, (byte) podNumber);
         logger.debug("AnalogMessage: canNode: {}, podNumber: {}, value: {}, type: {}", this.canNode, this.podNumber,
                 value, measureType);
-        setValue(0, value.intValue(), measureType.getMeasure());
+        setValue(0, value.intValue(), measureType.getTypeValue());
     }
 
     /**
      * Get the value for the specified port number.
-     * 
+     *
      * @param portNumber
      * @return
      */
@@ -67,7 +107,7 @@ public final class AnalogMessage extends Message {
     /**
      * Check if message contains a value for the specified port number. It
      * doesn't matter though if the port has a value of 0.
-     * 
+     *
      * @param portNumber
      * @return
      */

--- a/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/message/AnalogValue.java
+++ b/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/message/AnalogValue.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
  * This class handles analog values as used in the analog message.
  *
  * @author Timo Wendt
+ * @author Wolfgang Klimt
  * @since 1.8.0
  */
 public final class AnalogValue {
@@ -30,17 +31,13 @@ public final class AnalogValue {
      * Create new AnalogValue with specified value and type
      */
     public AnalogValue(int rawValue, int type) {
-        switch (type) {
-            case 1:
-                measureType = TACmiMeasureType.TEMPERATURE;
-                value = new BigDecimal(rawValue).movePointLeft(1);
-                break;
-            case 4:
-                measureType = TACmiMeasureType.SECONDS;
-                value = new BigDecimal(rawValue);
-                break;
-            default:
-                measureType = TACmiMeasureType.UNSUPPORTED;
+        measureType = TACmiMeasureType.fromInt(type);
+        value = new BigDecimal(rawValue).movePointLeft(measureType.getScale());
+        if (measureType.equals(TACmiMeasureType.UNSUPPORTED)) {
+            logger.warn("Unsupported measure type {}, value is {}", type, value);
+        } else {
+            logger.debug("Got measure: type {}, raw value {}, converted: {}, {}", type, rawValue, measureType.name(),
+                    value);
         }
     }
 }


### PR DESCRIPTION
The TA CMI protocol supports 21 different analog value types according to the documentation. I found out that the documentation is not completely accurate, but by analyzing the network traffic I was able to figure out how to support at least kilowatt, kilowatthours and megawatthours. The code also adds generic dummy values for all other value types so that it is easy to add them as soon as somebody discovers them with their device.

Coments welcome; binding jar attached for testing
[org.openhab.binding.tacmi-1.9.0-SNAPSHOT.jar.zip](https://github.com/openhab/openhab/files/299288/org.openhab.binding.tacmi-1.9.0-SNAPSHOT.jar.zip)
