### PR TITLE
[mios] openHAB2 delayed startup/reload improvements under compat layer.

### DIFF
--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosUnit.java
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/MiosUnit.java
@@ -53,11 +53,15 @@ public class MiosUnit {
     private static final int CONFIG_DISABLE_ERROR_COUNT = 0;
     private static final int CONFIG_DEFAULT_ERROR_COUNT = 1;
 
+    private static final int CONFIG_MIN_STARTUP_DELAY = 0;
+    private static final int CONFIG_DEFAULT_STARTUP_DELAY = 5000;
+
     private String name = null;
     private String hostname = CONFIG_DEFAULT_HOSTNAME;
     private int port = CONFIG_DEFAULT_PORT;
     private int timeout = CONFIG_DEFAULT_TIMEOUT;
     private int minimumDelay = CONFIG_DEFAULT_MINIMUM_DELAY;
+    private int startupDelay = CONFIG_DEFAULT_STARTUP_DELAY;
 
     private int refreshCount = CONFIG_DEFAULT_REFRESH_COUNT;
     private int errorCount = CONFIG_DEFAULT_ERROR_COUNT;
@@ -73,7 +77,7 @@ public class MiosUnit {
 
     /**
      * Get the Hostname setting for the MiOS unit configuration.
-     * 
+     *
      * @return the Hostname/IP associated with this Unit
      */
     public String getHostname() {
@@ -82,9 +86,9 @@ public class MiosUnit {
 
     /**
      * Get the Port setting for the MiOS unit configuration.
-     * 
+     *
      * The default Port for a MiOS Unit is 3480, but this can be overridden in config as needed.
-     * 
+     *
      * @return the Port associated with the MiOS Unit.
      */
     public int getPort() {
@@ -93,9 +97,9 @@ public class MiosUnit {
 
     /**
      * Get the Timeout setting for the MiOS Unit configuration.
-     * 
+     *
      * If this configuration is not specified, then it will default to 60000ms.
-     * 
+     *
      * @return the Timeout of the MiOS Unit, in milliseconds.
      */
     public int getTimeout() {
@@ -104,9 +108,9 @@ public class MiosUnit {
 
     /**
      * Get the Minimum time, in ms, that the MiOS Unit should wait/delay in order to "bundle" changes in their response.
-     * 
+     *
      * If this configuration is not specified, then it will default to 0ms, or no-delay.
-     * 
+     *
      * @return the Minimum Delay for dealing with the MiOS Unit, in milliseconds.
      */
     public int getMinimumDelay() {
@@ -114,14 +118,25 @@ public class MiosUnit {
     }
 
     /**
+     * Get the Startup delay time, in ms, the MiOS Binding should wait before starting it's event loop.
+     *
+     * If this configuration is not specified, then it will default to 0ms, or no-delay.
+     *
+     * @return the Minimum Delay for dealing with the MiOS Unit, in milliseconds.
+     */
+    public int getStartupDelay() {
+        return startupDelay;
+    }
+
+    /**
      * Get the Refresh Count setting for the MiOS Unit configuration.
-     * 
+     *
      * This setting is used to control how often (loop cycles) should be performed loading incremental data, before a
      * full-refresh of data should be performed from the MiOS Unit under control.
-     * 
+     *
      * If this setting is not specified, it will default to never performing the full-refresh on the MiOS Unit
      * (internally, a 0 value).
-     * 
+     *
      * @return the Full Refresh cycle count. A value of 0 will disable the Full Refresh from occurring.
      */
     public int getRefreshCount() {
@@ -130,14 +145,14 @@ public class MiosUnit {
 
     /**
      * Get the Error Count setting for the MiOS Unit configuration.
-     * 
+     *
      * This setting is used to control how many errors are permitted, in attempting to retrieve data from the MiOS Unit,
      * prior to forcing a full-refresh. By default, this logic is disabled (a 0 value), but it can be reset so that
      * errors in the retrieval will trigger a full data-set to be fetched.
-     * 
+     *
      * If this setting is not specified, it will default to never performing the full-refresh on the MiOS Unit
      * (internally, a 0 value).
-     * 
+     *
      * @return the Error count. A value of 0 will disable the Full Refresh from occurring upon errors.
      */
     public int getErrorCount() {
@@ -146,7 +161,7 @@ public class MiosUnit {
 
     /**
      * Set the Hostname of the MiOS Unit configuration.
-     * 
+     *
      * @param hostname
      *            the hostname to use for this MiOS Unit configuration.
      */
@@ -156,7 +171,7 @@ public class MiosUnit {
 
     /**
      * Set the Port of the MiOS Unit configuration.
-     * 
+     *
      * @param port
      *            the port to use for this MiOS Unit configuration.
      */
@@ -166,7 +181,7 @@ public class MiosUnit {
 
     /**
      * Set the Timeout of the MiOS Unit configuration.
-     * 
+     *
      * @param timeout
      *            the timeout to set for any connections associated with this MiOS Unit.
      */
@@ -180,13 +195,13 @@ public class MiosUnit {
 
     /**
      * Set the Minimum Delay of the MiOS Unit configuration.
-     * 
+     *
      * @param delay
      *            the minimum delay, in ms, to use for any connections associated with this MiOS Unit.
      */
     public void setMinimumDelay(int delay) {
         if (delay < CONFIG_MIN_MINIMUM_DELAY) {
-            logger.warn("Minimum Delay of {} below minimum permitted, {] used.", minimumDelay,
+            logger.warn("Minimum Delay of {} below minimum permitted, {} used.", minimumDelay,
                     CONFIG_MIN_MINIMUM_DELAY);
             delay = CONFIG_MIN_MINIMUM_DELAY;
         }
@@ -194,8 +209,23 @@ public class MiosUnit {
     }
 
     /**
+     * Set the Startup Delay of the MiOS Unit configuration.
+     *
+     * @param delay
+     *            the minimum delay, in ms, to use for any connections associated with this MiOS Unit.
+     */
+    public void setStartupDelay(int delay) {
+        if (delay < CONFIG_MIN_STARTUP_DELAY) {
+            logger.warn("Startup Delay of {} below minimum permitted, {} used.", startupDelay,
+                    CONFIG_MIN_STARTUP_DELAY);
+            delay = CONFIG_MIN_STARTUP_DELAY;
+        }
+        this.startupDelay = delay;
+    }
+
+    /**
      * Set the Refresh Count of the MiOS Unit configuration.
-     * 
+     *
      * @param count
      *            the number of loop/cycles before a Full-data refresh is performed from the MiOS Unit. A value of 0
      *            disables the refresh processing.
@@ -210,7 +240,7 @@ public class MiosUnit {
 
     /**
      * Set the Error Count of the MiOS Unit configuration.
-     * 
+     *
      * @param errors
      *            the number of error loop/cycles before a Full-data refresh is performed from the MiOS Unit. A value of
      *            0 disables the processing.
@@ -225,19 +255,19 @@ public class MiosUnit {
 
     /**
      * Get the name of the MiOS Unit configuration.
-     * 
+     *
      * Each MiOS Unit has a name within the configuration properties. If it's not named, then the "default" name is
      * "default".
      * <p>
-     * 
+     *
      * Otherwise, the name is that specified in the openHAB configuration.
      * <p>
-     * 
+     *
      * eg. <tt>mios:venice.hostname=venice.myhouse.example.com</tt>
      * <p>
-     * 
+     *
      * In this case, the MiOS Unit name is "<tt>venice</tt>".
-     * 
+     *
      * @return the name of this MiOS Unit.
      */
     public String getName() {
@@ -246,14 +276,14 @@ public class MiosUnit {
 
     /**
      * Provide any unit-specific prefix to a given property name.
-     * 
-     * Internally this method is used to augment a "MiOS Unit neutral" property string with the name of <i>this<i/> MiOS
+     *
+     * Internally this method is used to augment a "MiOS Unit neutral" property string with the name of <i>this</i> MiOS
      * Unit.
      * <p>
-     * 
+     *
      * In many cases, the code that builds the property string isn't aware of the MiOS Unit that it's part of, and the
      * MiOS Unit needs to be added on later.
-     * 
+     *
      * @param property
      *            an unformatted property name.
      * @return the property name, with the prefix for this MiOS Unit.


### PR DESCRIPTION
Under the compat1x layer of OH 2, the MiOS binding was seeing a different startup sequence than when run natively under OH 1.x.

This change adds a delay to the startup processing to allow Item loading to stabilize before attempting to load data from the MiOS Unit, to avoid the sequencing issues.

Community discussion:
* https://community.openhab.org/t/openhab2-new-issue-with-the-startup-process-mios-binding/8320

Signed-off-by: Mark Clark <mr.guessed@gmail.com> (github: mrguessed)