### PR TITLE
[modbus test] Fix JDK version

### DIFF
--- a/bundles/binding/org.openhab.binding.modbus.test/.classpath
+++ b/bundles/binding/org.openhab.binding.modbus.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry exported="true" kind="lib" path="lib/mockito-all-1.10.19.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/slf4j-simple-1.7.5.jar"/>

--- a/bundles/binding/org.openhab.binding.modbus.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.modbus.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tests for Modbus Binding
 Bundle-SymbolicName: org.openhab.binding.modbus.test
 Bundle-Version: 1.9.0.qualifier
 Fragment-Host: org.openhab.binding.modbus
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit
 Bundle-Vendor: openHAB.org
 Bundle-ClassPath: lib/mockito-all-1.10.19.jar,


### PR DESCRIPTION
A test uses a JDK 1.7 AssertionError constructor, but project was set to require only Java6.  Clears error in Eclipse IDE.