### PR TITLE
add description to state 19 in novelan heatpump binding

### DIFF
--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/i18n/Messages.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/i18n/Messages.java
@@ -36,6 +36,7 @@ public class Messages extends NLS {
     public static String HeatPumpBinding_SERVICE_WATER_EXT;
     public static String HeatPumpBinding_FLOW_MONITORING;
     public static String HeatPumpBinding_ZWE_OPERATION;
+    public static String HeatPumpBinding_SERVICE_WATER_ADDITIONAL_HEATING;
 
     static {
         // initialize resource bundle

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/i18n/messages.properties
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/i18n/messages.properties
@@ -19,3 +19,4 @@ HeatPumpBinding_HEATING_EXT=heating ext.
 HeatPumpBinding_SERVICE_WATER_EXT=service water ext.
 HeatPumpBinding_FLOW_MONITORING=flow monitoring
 HeatPumpBinding_ZWE_OPERATION=ZWE operation
+HeatPumpBinding_SERVICE_WATER_ADDITIONAL_HEATING=service water add. heating

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/i18n/messages_de.properties
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/i18n/messages_de.properties
@@ -19,3 +19,4 @@ HeatPumpBinding_HEATING_EXT=Heizen Ext.
 HeatPumpBinding_SERVICE_WATER_EXT=Brauchwasser Ext.
 HeatPumpBinding_FLOW_MONITORING=Durchflussueberwachung
 HeatPumpBinding_ZWE_OPERATION=ZWE Betrieb
+HeatPumpBinding_SERVICE_WATER_ADDITIONAL_HEATING=Warmw. Nachheizung

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
@@ -353,6 +353,7 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
                 break;
             case 19:
                 returnValue = Messages.HeatPumpBinding_SERVICE_WATER_ADDITIONAL_HEATING;
+                break;
             default:
                 logger.info(
                         "found new value for reverse engineering !!!! No idea what the heatpump will do in state {}.", //$NON-NLS-1$

--- a/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/src/main/java/org/openhab/binding/novelanheatpump/internal/HeatPumpBinding.java
@@ -351,6 +351,8 @@ public class HeatPumpBinding extends AbstractActiveBinding<HeatPumpBindingProvid
             case 17:
                 returnValue = Messages.HeatPumpBinding_ZWE_OPERATION;
                 break;
+            case 19:
+                returnValue = Messages.HeatPumpBinding_SERVICE_WATER_ADDITIONAL_HEATING;
             default:
                 logger.info(
                         "found new value for reverse engineering !!!! No idea what the heatpump will do in state {}.", //$NON-NLS-1$


### PR DESCRIPTION
The heatpump binding throws a "found new value for reverse engineering" for state 19 at my openhab system. My heatpump shows "Warmw. Nachheizung" at this time. So I added this information to the novelan binding.