### PR TITLE
[WeatherBinding] Add log messages for invalid configurations

### DIFF
--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/bus/WeatherBinding.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/bus/WeatherBinding.java
@@ -44,7 +44,7 @@ public class WeatherBinding extends AbstractBinding<WeatherBindingProvider>imple
     }
 
     /**
-     * Set providers in WeatherContext and generates metadata from the weater
+     * Sets providers in WeatherContext and generates metadata from the weather
      * model annotations.
      */
     @Override
@@ -71,15 +71,22 @@ public class WeatherBinding extends AbstractBinding<WeatherBindingProvider>imple
      */
     @Override
     public void updated(Dictionary<String, ?> config) throws ConfigurationException {
-        if (config != null) {
-            context.getJobScheduler().stop();
+        if (config == null) {
+            logger.warn("Unable to find any configuration settings for weather binding. Check openhab.cfg.");
+            throw new ConfigurationException("weather", "Unable to find any configuration settings for weather binding. Check openhab.cfg.");
+        }
 
-            context.getConfig().parse(config);
-            context.getConfig().dump();
+        context.getJobScheduler().stop();
 
-            if (context.getConfig().isValid()) {
-                context.getJobScheduler().restart();
-            }
+        context.getConfig().parse(config);
+        context.getConfig().dump();
+
+        if (context.getConfig().isValid()) {
+            context.getJobScheduler().restart();
+        }
+        else {
+            logger.warn("Unable to restart weather job because weather configuration is not valid. Check openhab.cfg.");
+            throw new ConfigurationException("weather", "Unable to restart weather job because weather configuration is not valid. Check openhab.cfg.");
         }
     }
 
@@ -96,8 +103,15 @@ public class WeatherBinding extends AbstractBinding<WeatherBindingProvider>imple
      */
     @Override
     public void allBindingsChanged(BindingProvider provider) {
+        if (!context.getConfig().finishedParsing() ) {
+            return;
+        }
+
         if (context.getConfig().isValid()) {
             context.getJobScheduler().restart();
+        }
+        else {
+            logger.warn("All bindings changed, but unable to restart weather job because weather configuration is not valid. Check openhab.cfg.");
         }
     }
 
@@ -106,10 +120,18 @@ public class WeatherBinding extends AbstractBinding<WeatherBindingProvider>imple
      */
     @Override
     public void bindingChanged(BindingProvider provider, String itemName) {
+        if (!context.getConfig().finishedParsing() ) {
+            return;
+        }
+
         if (context.getConfig().isValid()) {
             if (provider instanceof WeatherBindingProvider) {
                 context.getJobScheduler().restart();
             }
+        }
+        else {
+            logger.debug("Binding for item '{}' changed, but unable to restart weather job "
+                        +" because weather configuration is not valid. Check openhab.cfg.", itemName);
         }
         super.bindingChanged(provider, itemName);
     }

--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/bus/WeatherBinding.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/bus/WeatherBinding.java
@@ -73,7 +73,8 @@ public class WeatherBinding extends AbstractBinding<WeatherBindingProvider>imple
     public void updated(Dictionary<String, ?> config) throws ConfigurationException {
         if (config == null) {
             logger.warn("Unable to find any configuration settings for weather binding. Check openhab.cfg.");
-            throw new ConfigurationException("weather", "Unable to find any configuration settings for weather binding. Check openhab.cfg.");
+            throw new ConfigurationException("weather",
+                    "Unable to find any configuration settings for weather binding. Check openhab.cfg.");
         }
 
         context.getJobScheduler().stop();
@@ -83,10 +84,10 @@ public class WeatherBinding extends AbstractBinding<WeatherBindingProvider>imple
 
         if (context.getConfig().isValid()) {
             context.getJobScheduler().restart();
-        }
-        else {
+        } else {
             logger.warn("Unable to restart weather job because weather configuration is not valid. Check openhab.cfg.");
-            throw new ConfigurationException("weather", "Unable to restart weather job because weather configuration is not valid. Check openhab.cfg.");
+            throw new ConfigurationException("weather",
+                    "Unable to restart weather job because weather configuration is not valid. Check openhab.cfg.");
         }
     }
 
@@ -103,15 +104,15 @@ public class WeatherBinding extends AbstractBinding<WeatherBindingProvider>imple
      */
     @Override
     public void allBindingsChanged(BindingProvider provider) {
-        if (!context.getConfig().finishedParsing() ) {
+        if (!context.getConfig().finishedParsing()) {
             return;
         }
 
         if (context.getConfig().isValid()) {
             context.getJobScheduler().restart();
-        }
-        else {
-            logger.warn("All bindings changed, but unable to restart weather job because weather configuration is not valid. Check openhab.cfg.");
+        } else {
+            logger.warn(
+                    "All bindings changed, but unable to restart weather job because weather configuration is not valid. Check openhab.cfg.");
         }
     }
 
@@ -120,7 +121,7 @@ public class WeatherBinding extends AbstractBinding<WeatherBindingProvider>imple
      */
     @Override
     public void bindingChanged(BindingProvider provider, String itemName) {
-        if (!context.getConfig().finishedParsing() ) {
+        if (!context.getConfig().finishedParsing()) {
             return;
         }
 
@@ -128,10 +129,9 @@ public class WeatherBinding extends AbstractBinding<WeatherBindingProvider>imple
             if (provider instanceof WeatherBindingProvider) {
                 context.getJobScheduler().restart();
             }
-        }
-        else {
+        } else {
             logger.debug("Binding for item '{}' changed, but unable to restart weather job "
-                        +" because weather configuration is not valid. Check openhab.cfg.", itemName);
+                    + " because weather configuration is not valid. Check openhab.cfg.", itemName);
         }
         super.bindingChanged(provider, itemName);
     }

--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/common/WeatherConfig.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/common/WeatherConfig.java
@@ -70,10 +70,11 @@ public class WeatherConfig {
     public void parse(Dictionary<String, ?> properties) throws ConfigurationException {
         parseCompleted = false;
         valid = false;
-        if (properties == null ) {
+        if (properties == null) {
             parseCompleted = true;
             logger.warn("No configuration found for the weather binding. Check openhab.cfg.");
-            throw new ConfigurationException("weather", "No configuration found for the weather binding. Check openhab.cfg.");
+            throw new ConfigurationException("weather",
+                    "No configuration found for the weather binding. Check openhab.cfg.");
         }
 
         Enumeration<String> keys = properties.keys();
@@ -93,15 +94,15 @@ public class WeatherConfig {
             if (!lc.isValid()) {
                 parseCompleted = true;
                 logger.warn("Incomplete location config for locationId '{}'. Check openhab.cfg.", lc.getLocationId());
-                throw new ConfigurationException("weather", "Incomplete location config for locationId '"
-                        + lc.getLocationId() + "'. Check openhab.cfg.");
+                throw new ConfigurationException("weather",
+                        "Incomplete location config for locationId '" + lc.getLocationId() + "'. Check openhab.cfg.");
             }
 
             if (lc.getProviderName() != ProviderName.YAHOO && !providerConfigs.containsKey(lc.getProviderName())) {
                 parseCompleted = true;
                 logger.warn("No apikey found for provider '{}'. Check openhab.cfg.", lc.getProviderName());
-                throw new ConfigurationException("weather", "No apikey found for provider '" + lc.getProviderName()
-                        + "'. Check openhab.cfg.");
+                throw new ConfigurationException("weather",
+                        "No apikey found for provider '" + lc.getProviderName() + "'. Check openhab.cfg.");
             }
         }
 
@@ -110,8 +111,8 @@ public class WeatherConfig {
             if (!pc.isValid()) {
                 parseCompleted = true;
                 logger.warn("Invalid apikey config for provider '{}'. Check openhab.cfg.", pc.getProviderName());
-                throw new ConfigurationException("weather", "Invalid apikey config for provider '"
-                        + pc.getProviderName() + "'. Check openhab.cfg.");
+                throw new ConfigurationException("weather",
+                        "Invalid apikey config for provider '" + pc.getProviderName() + "'. Check openhab.cfg.");
             }
         }
 
@@ -245,7 +246,7 @@ public class WeatherConfig {
     }
 
     /**
-     *
+     * Returns true if the parse routine is not currently in progress.
      */
     public boolean finishedParsing() {
         return parseCompleted;

--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/common/WeatherConfig.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/common/WeatherConfig.java
@@ -42,14 +42,14 @@ import org.slf4j.LoggerFactory;
  * #weather:location.<locationId1>.provider=
  * #weather:location.<locationId1>.woeid=      (required for Yahoo provider)
  * #weather:location.<locationId1>.language=
- * #weather:location.<locationId1>.updateInterval=
+ * #weather:location.<locationId1>.updateInterval= (optional, defaults to 240)
  *
  * #weather:location.<locationId2>.latitude=   (not required for Yahoo provider)
  * #weather:location.<locationId2>.longitude=  (not required for Yahoo provider)
  * #weather:location.<locationId2>.provider=
  * #weather:location.<locationId2>.woeid=      (required for Yahoo provider)
  * #weather:location.<locationId2>.language=
- * #weather:location.<locationId2>.updateInterval=
+ * #weather:location.<locationId2>.updateInterval= (optional, defaults to 240)
  * </pre>
  *
  * @author Gerhard Riegler
@@ -61,48 +61,63 @@ public class WeatherConfig {
     private Map<ProviderName, ProviderConfig> providerConfigs = new HashMap<ProviderName, ProviderConfig>();
     private Map<String, LocationConfig> locationConfigs = new HashMap<String, LocationConfig>();
 
-    private boolean valid = false;
+    private boolean valid;
+    private boolean parseCompleted;
 
     /**
      * Parses and validates the properties in openhab.cfg.
      */
     public void parse(Dictionary<String, ?> properties) throws ConfigurationException {
+        parseCompleted = false;
         valid = false;
-        if (properties != null) {
-            Enumeration<String> keys = properties.keys();
-            while (keys.hasMoreElements()) {
-                String key = keys.nextElement();
-
-                String value = StringUtils.trimToNull((String) properties.get(key));
-                if (StringUtils.startsWithIgnoreCase(key, "apikey")) {
-                    parseApiKey(key, value);
-                } else if (StringUtils.startsWithIgnoreCase(key, "location")) {
-                    parseLocation(key, value);
-                }
-            }
-
-            // check all LocationConfigs
-            for (LocationConfig lc : locationConfigs.values()) {
-                if (!lc.isValid()) {
-                    throw new ConfigurationException("weather", "Incomplete location config for locationId '"
-                            + lc.getLocationId() + "', please check your openhab.cfg!");
-                }
-                if (lc.getProviderName() != ProviderName.YAHOO && !providerConfigs.containsKey(lc.getProviderName())) {
-                    throw new ConfigurationException("weather", "No apikey found for provider '" + lc.getProviderName()
-                            + "', please check your openhab.cfg!");
-                }
-            }
-
-            // check all ProviderConfigs
-            for (ProviderConfig pc : providerConfigs.values()) {
-                if (!pc.isValid()) {
-                    throw new ConfigurationException("weather", "Invalid apikey config for provider '"
-                            + pc.getProviderName() + "', please check your openhab.cfg!");
-                }
-            }
-
-            valid = locationConfigs.size() > 0;
+        if (properties == null ) {
+            parseCompleted = true;
+            logger.warn("No configuration found for the weather binding. Check openhab.cfg.");
+            throw new ConfigurationException("weather", "No configuration found for the weather binding. Check openhab.cfg.");
         }
+
+        Enumeration<String> keys = properties.keys();
+        while (keys.hasMoreElements()) {
+            String key = keys.nextElement();
+
+            String value = StringUtils.trimToNull((String) properties.get(key));
+            if (StringUtils.startsWithIgnoreCase(key, "apikey")) {
+                parseApiKey(key, value);
+            } else if (StringUtils.startsWithIgnoreCase(key, "location")) {
+                parseLocation(key, value);
+            }
+        }
+
+        // check all LocationConfigs
+        for (LocationConfig lc : locationConfigs.values()) {
+            if (!lc.isValid()) {
+                parseCompleted = true;
+                logger.warn("Incomplete location config for locationId '{}'. Check openhab.cfg.", lc.getLocationId());
+                throw new ConfigurationException("weather", "Incomplete location config for locationId '"
+                        + lc.getLocationId() + "'. Check openhab.cfg.");
+            }
+
+            if (lc.getProviderName() != ProviderName.YAHOO && !providerConfigs.containsKey(lc.getProviderName())) {
+                parseCompleted = true;
+                logger.warn("No apikey found for provider '{}'. Check openhab.cfg.", lc.getProviderName());
+                throw new ConfigurationException("weather", "No apikey found for provider '" + lc.getProviderName()
+                        + "'. Check openhab.cfg.");
+            }
+        }
+
+        // check all ProviderConfigs
+        for (ProviderConfig pc : providerConfigs.values()) {
+            if (!pc.isValid()) {
+                parseCompleted = true;
+                logger.warn("Invalid apikey config for provider '{}'. Check openhab.cfg.", pc.getProviderName());
+                throw new ConfigurationException("weather", "Invalid apikey config for provider '"
+                        + pc.getProviderName() + "'. Check openhab.cfg.");
+            }
+        }
+
+        valid = locationConfigs.size() > 0;
+        parseCompleted = true;
+        logger.debug("Parsing of weather configuration settings completed.");
     }
 
     /**
@@ -110,13 +125,13 @@ public class WeatherConfig {
      */
     private void parseLocation(String key, String value) throws ConfigurationException {
         if (value == null) {
-            throw new ConfigurationException("weather", "Empty property '" + key + "', please check your openhab.cfg!");
+            logger.warn("Weather location setting '{}' has no value. Check openhab.cfg.", key);
+            return;
         }
 
         String locationId = StringUtils.substringBetween(key, ".");
-        if (locationId == null) {
-            throw new ConfigurationException("weather",
-                    "Malformed location property '" + key + "', please check your openhab.cfg!");
+        if (StringUtils.isBlank(locationId)) {
+            logger.warn("Weather location setting '{}' is missing its location. Check openhab.cfg.", key);
         }
 
         LocationConfig lc = locationConfigs.get(locationId);
@@ -142,8 +157,7 @@ public class WeatherConfig {
         } else if (StringUtils.equalsIgnoreCase(keyId, "name")) {
             lc.setName(value);
         } else {
-            throw new ConfigurationException("weather",
-                    "Unknown configuration key '" + key + "', please check your openhab.cfg!");
+            logger.debug("Unknown weather configuration setting '{}'. Check openhab.cfg.", key);
         }
     }
 
@@ -151,6 +165,11 @@ public class WeatherConfig {
      * Parses the properties for a provider config.
      */
     private void parseApiKey(String key, String value) throws ConfigurationException {
+        if (value == null) {
+            logger.warn("Weather apikey setting '{}' has no value. Check openhab.cfg.", key);
+            return;
+        }
+
         String provider = PropertyResolver.last(key);
         ProviderName providerName = getProviderName(provider);
 
@@ -167,8 +186,7 @@ public class WeatherConfig {
         } else if (StringUtils.equalsIgnoreCase(keyId, "apikey2")) {
             pConfig.setApiKey2(value);
         } else {
-            throw new ConfigurationException("weather",
-                    "Unknown configuration key '" + key + "', please check your openhab.cfg!");
+            logger.debug("Unknown configuration key '{}'. Check openhab.cfg.", key);
         }
     }
 
@@ -179,8 +197,9 @@ public class WeatherConfig {
         try {
             return Double.parseDouble(value);
         } catch (Exception ex) {
+            logger.warn("Parameter '{}' empty or in wrong format ('{}'). Check openhab.cfg.", key, value);
             throw new ConfigurationException("weather",
-                    "Parameter '" + key + "' empty or in wrong format, please check your openhab.cfg!");
+                    "Parameter '" + key + "' empty or in wrong format ('" + value + "'). Check openhab.cfg.");
         }
     }
 
@@ -190,8 +209,9 @@ public class WeatherConfig {
     private ProviderName getProviderName(String name) throws ConfigurationException {
         ProviderName providerName = ProviderName.parse(name);
         if (providerName == null) {
+            logger.warn("Provider with name '{}' not found. Check openhab.cfg.", name);
             throw new ConfigurationException("weather",
-                    "Provider with name '" + name + "' not found, please check your openhab.cfg!");
+                    "Provider with name '" + name + "' not found. Check openhab.cfg.");
         }
         return providerName;
     }
@@ -222,6 +242,13 @@ public class WeatherConfig {
      */
     public boolean isValid() {
         return valid;
+    }
+
+    /**
+     *
+     */
+    public boolean finishedParsing() {
+        return parseCompleted;
     }
 
     /**

--- a/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/common/WeatherConfig.java
+++ b/bundles/binding/org.openhab.binding.weather/src/main/java/org/openhab/binding/weather/internal/common/WeatherConfig.java
@@ -186,7 +186,7 @@ public class WeatherConfig {
         } else if (StringUtils.equalsIgnoreCase(keyId, "apikey2")) {
             pConfig.setApiKey2(value);
         } else {
-            logger.debug("Unknown configuration key '{}'. Check openhab.cfg.", key);
+            logger.warn("Unknown configuration key '{}'. Check openhab.cfg.", key);
         }
     }
 


### PR DESCRIPTION
In order to prevent silent failures of the weather binding (see #4337), record appropriate log messages.

Also prevent duplicate warnings on binding change.
