### PR TITLE
[http] allow String.format to be optional to avoid conflicts

### DIFF
--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -768,13 +768,17 @@ logging:pattern=%date{ISO8601} - %-25logger: %msg%n
 # (optional, defaults to 1000)
 #http:granularity=
 
+# whether to substitute the current time or state value into the URL
+# (optional, defaults to true)
+#http:format=
+
 # configuration of the first cache item
-# http:<id1>.url=
-# http:<id1>.updateInterval=
+#http:<id1>.url=
+#http:<id1>.updateInterval=
 
 # configuration of the second cache item
-# http:<id2>.url=
-# http:<id2>.updateInterval=
+#http:<id2>.url=
+#http:<id2>.updateInterval=
 
 ############################# Fritz!Box Binding #######################################
 #

--- a/features/openhab-addons-external/src/main/resources/conf/http.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/http.cfg
@@ -5,10 +5,14 @@
 # (optional, defaults to 1000)
 #granularity=
 
+# whether to substitute the current time or state value into the URL
+# (optional, defaults to true)
+#format=
+
 # configuration of the first cache item
-# <id1>.url=
-# <id1>.updateInterval=
+#<id1>.url=
+#<id1>.updateInterval=
 
 # configuration of the second cache item  
-# <id2>.url=
-# <id2>.updateInterval=
+#<id2>.url=
+#<id2>.updateInterval=


### PR DESCRIPTION
For user-specified URLs that happen to contain sprintf-style formatting strings, the binding would attempt to substitute the current time and/or item state.  But this may not be what the user wants, instead preferring to use the URL as given.  A conflict can easily happen when the URL contains escaped characters, like "http://sample/?This%20string%20is$5%20a%problem," and so the user would want to suppress the sprintf-style formatting.

This PR adds an optional configuration property called `format` that is `true` by default, for backward compatibility.

See #4459 and [the forum](https://community.openhab.org/t/help-with-transforming-google-maps-distance-matrix-api-data/11390).

Signed-off-by: John Cocula <john@cocula.com>