### PR TITLE
Extend error logging on retry failure

### DIFF
--- a/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulMsgHandler.java
+++ b/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulMsgHandler.java
@@ -275,7 +275,7 @@ public class MaxCulMsgHandler implements CULListener {
                     logger.debug("Retransmitting packet " + qi.msg.msgCount + " attempt " + qi.retryCount);
                     sendMessage(qi.msg, qi);
                 } else {
-                    logger.error("Transmission of packet " + qi.msg.msgCount + " failed 3 times");
+                    logger.error("Transmission of packet " + qi.msg.msgCount + " failed 3 times, message was " + qi.msg.msgType + " to address " + qi.msg.dstAddrStr + " => " + qi.msg.rawMsg);
                 }
             }
         }

--- a/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulMsgHandler.java
+++ b/bundles/binding/org.openhab.binding.maxcul/src/main/java/org/openhab/binding/maxcul/internal/MaxCulMsgHandler.java
@@ -275,7 +275,7 @@ public class MaxCulMsgHandler implements CULListener {
                     logger.debug("Retransmitting packet " + qi.msg.msgCount + " attempt " + qi.retryCount);
                     sendMessage(qi.msg, qi);
                 } else {
-                    logger.error("Transmission of packet " + qi.msg.msgCount + " failed 3 times, message was " + qi.msg.msgType + " to address " + qi.msg.dstAddrStr + " => " + qi.msg.rawMsg);
+                    logger.error("Transmission of packet {} failed 3 times, message was: {} to address {} => {}",  qi.msg.msgCount, qi.msg.msgType, qi.msg.dstAddrStr, qi.msg.rawMsg);
                 }
             }
         }


### PR DESCRIPTION
Add the raw message content to retry failure messages, allowing a level of diagnosis as to which valve is the one that is failing.