### PR TITLE
Add a Data value selector that doesn't include RFXCOM headers

### DIFF
--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComValueSelector.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/RFXComValueSelector.java
@@ -29,6 +29,7 @@ import org.openhab.core.library.items.SwitchItem;
 public enum RFXComValueSelector {
 
     RAW_DATA("RawData", StringItem.class),
+    DATA("Data", StringItem.class),
     SHUTTER("Shutter", RollershutterItem.class),
     COMMAND("Command", SwitchItem.class),
     MOOD("Mood", NumberItem.class),

--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessage.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComUndecodedRFMessage.java
@@ -73,7 +73,10 @@ public class RFXComUndecodedRFMessage extends RFXComBaseMessage {
         }
     }
 
-    private final static List<RFXComValueSelector> supportedValueSelectors = Arrays.asList(RFXComValueSelector.RAW_DATA);
+    private final static List<RFXComValueSelector> supportedValueSelectors = Arrays.asList(
+        RFXComValueSelector.RAW_DATA,
+        RFXComValueSelector.DATA
+    );
 
     public SubType subType = SubType.UNKNOWN;
     private byte[] rawData = new byte[0];
@@ -140,18 +143,15 @@ public class RFXComUndecodedRFMessage extends RFXComBaseMessage {
         org.openhab.core.types.State state = UnDefType.UNDEF;
 
         if (valueSelector.getItemClass() == StringItem.class) {
-
             if (valueSelector == RFXComValueSelector.RAW_DATA) {
-
                 state = new StringType(DatatypeConverter.printHexBinary(rawMessage));
-
+            } else if (valueSelector == RFXComValueSelector.DATA) {
+                state = new StringType(DatatypeConverter.printHexBinary(rawData));
             } else {
                 throw new RFXComException("Can't convert " + valueSelector + " to StringItem");
             }
         } else {
-
             throw new RFXComException("Can't convert " + valueSelector + " to " + valueSelector.getItemClass());
-
         }
 
         return state;


### PR DESCRIPTION
The Undecoded implementation only has one value selector, RawData. This updates the item state with the full message.

I'd like to introduce a "Data" value selector, which drops the header from the message. The bytes of the header are:
1. Length - not required as we get a byte array of the right length anyway.
2. Type (Undecoded) - Not required as we know the item is undecoded from the items file.
3. Subtype - This could potentially be of use to someone, but it wasn't in my case, and RawData is still an option.
4. Sequence number, this changes consistently, unlikely to be required.

I have devices that just spit out their ID as a message and nothing else, by using the Data selector instead of the RawData selector, I get a consistent output (without sequence), which means my rules file can detect the state update really easily. With RawData, the value would change every time so would need more work.