### PR TITLE
refactor to reflect ability to connect to plm via tcp

### DIFF
--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/IOStream.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/IOStream.java
@@ -109,6 +109,8 @@ public abstract class IOStream {
      *
      * /hub/myinsteonhub.mydomain.com:9761
      *
+     * /tcp/serialportserver.mydomain.com:port (serial port exposed via tcp, eg. ser2net)
+     *
      * @param config
      * @return reference to IOStream
      */
@@ -117,7 +119,7 @@ public abstract class IOStream {
         if (config.startsWith("/hub2/")) {
             return makeHub2014Stream(config);
         } else if (config.startsWith("/hub/") || config.startsWith("/tcp/")) {
-            return makeOldHubStream(config);
+            return makeTCPStream(config);
         } else {
             return new SerialIOStream(config);
         }
@@ -152,7 +154,7 @@ public abstract class IOStream {
         return new HubIOStream(hp.host, hp.port, pollTime, user, pass);
     }
 
-    private static TcpIOStream makeOldHubStream(String config) {
+    private static TcpIOStream makeTCPStream(String config) {
         config = config.substring(5); // Get rid of the /hub/ part
         String[] parts = config.split(","); // split off options at the end, if any
         String[] hostPort = parts[0].split(":");

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/IOStream.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/IOStream.java
@@ -13,7 +13,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import org.openhab.binding.insteonplm.internal.driver.hub.HubIOStream;
-import org.openhab.binding.insteonplm.internal.driver.hub.OldHubIOStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +32,7 @@ public abstract class IOStream {
 
     /**
      * read data from iostream
-     * 
+     *
      * @param b byte array (output)
      * @param offset offset for placement into byte array
      * @param readSize size to read
@@ -60,7 +59,7 @@ public abstract class IOStream {
 
     /**
      * Write data to iostream
-     * 
+     *
      * @param b byte array to write
      */
     public void write(byte[] b) {
@@ -81,7 +80,7 @@ public abstract class IOStream {
 
     /**
      * Opens the IOStream
-     * 
+     *
      * @return true if open was successful, false if not
      */
     public abstract boolean open();
@@ -93,7 +92,7 @@ public abstract class IOStream {
 
     /**
      * reconnects the stream
-     * 
+     *
      * @return true if reconnect succeeded
      */
     private synchronized boolean reconnect() {
@@ -103,13 +102,13 @@ public abstract class IOStream {
 
     /**
      * Creates an IOStream from an allowed config string:
-     * 
+     *
      * /dev/ttyXYZ (serial port like e.g. usb: /dev/ttyUSB0 or alias /dev/insteon)
-     * 
+     *
      * /hub2/user:password@myinsteonhub.mydomain.com:25105,poll_time=1000 (insteon hub2 (2014))
-     * 
+     *
      * /hub/myinsteonhub.mydomain.com:9761
-     * 
+     *
      * @param config
      * @return reference to IOStream
      */
@@ -117,7 +116,7 @@ public abstract class IOStream {
     public static IOStream s_create(String config) {
         if (config.startsWith("/hub2/")) {
             return makeHub2014Stream(config);
-        } else if (config.startsWith("/hub/")) {
+        } else if (config.startsWith("/hub/") || config.startsWith("/tcp/")) {
             return makeOldHubStream(config);
         } else {
             return new SerialIOStream(config);
@@ -153,12 +152,12 @@ public abstract class IOStream {
         return new HubIOStream(hp.host, hp.port, pollTime, user, pass);
     }
 
-    private static OldHubIOStream makeOldHubStream(String config) {
+    private static TcpIOStream makeOldHubStream(String config) {
         config = config.substring(5); // Get rid of the /hub/ part
         String[] parts = config.split(","); // split off options at the end, if any
         String[] hostPort = parts[0].split(":");
         HostPort hp = new HostPort(hostPort, 9761);
-        return new OldHubIOStream(hp.host, hp.port);
+        return new TcpIOStream(hp.host, hp.port);
     }
 
     private static class HostPort {

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/TcpIOStream.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/TcpIOStream.java
@@ -16,8 +16,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Implements IOStream for the older hubs (pre 2014)
- * 
+ * Implements IOStream for the older hubs (pre 2014).
+ * Also works for serial ports exposed via tcp, eg. ser2net
+ *
  * @author Bernd Pfrommer
  * @since 1.7.0
  *
@@ -31,7 +32,7 @@ public class TcpIOStream extends IOStream {
 
     /**
      * Constructor
-     * 
+     *
      * @param host host name of hub device
      * @param port port to connect to
      */

--- a/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/TcpIOStream.java
+++ b/bundles/binding/org.openhab.binding.insteonplm/src/main/java/org/openhab/binding/insteonplm/internal/driver/TcpIOStream.java
@@ -6,13 +6,12 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.openhab.binding.insteonplm.internal.driver.hub;
+package org.openhab.binding.insteonplm.internal.driver;
 
 import java.io.IOException;
 import java.net.Socket;
 import java.net.UnknownHostException;
 
-import org.openhab.binding.insteonplm.internal.driver.IOStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,8 +22,8 @@ import org.slf4j.LoggerFactory;
  * @since 1.7.0
  *
  */
-public class OldHubIOStream extends IOStream {
-    private static final Logger logger = LoggerFactory.getLogger(OldHubIOStream.class);
+public class TcpIOStream extends IOStream {
+    private static final Logger logger = LoggerFactory.getLogger(TcpIOStream.class);
 
     private String m_host = null;
     private int m_port = -1;
@@ -36,7 +35,7 @@ public class OldHubIOStream extends IOStream {
      * @param host host name of hub device
      * @param port port to connect to
      */
-    public OldHubIOStream(String host, int port) {
+    public TcpIOStream(String host, int port) {
         m_host = host;
         m_port = port;
     }


### PR DESCRIPTION
renamed OldHubIOStream to TcpIOStream to reflect its usability with programs such as ser2net.

refactored factory method in IOStream to allow tcp as a prefix within
config