### PR TITLE
Fix #4515 (NPE for digital items in TA-CMI binding)

### DIFF
--- a/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/TACmiGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.tacmi/src/main/java/org/openhab/binding/tacmi/internal/TACmiGenericBindingProvider.java
@@ -112,7 +112,12 @@ public class TACmiGenericBindingProvider extends AbstractGenericBindingProvider 
             this.canNode = canNode;
             this.portType = portType;
             this.portNumber = portNumber;
-            this.measureType = measureType;
+            if (measureType == null) {
+                this.measureType = TACmiMeasureType.NONE;
+            } else {
+                this.measureType = measureType;
+            }
+
             this.configurationString = configurationString;
         }
 


### PR DESCRIPTION
As discussed in #4515, this change fixes the NPE.