### PR TITLE
Modbus binding: do not read out-of-bounds discrete inputs/coils

### DIFF
--- a/bundles/binding/org.openhab.binding.modbus.test/src/test/java/org/openhab/binding/modbus/internal/ErroringQueriesTestCase.java
+++ b/bundles/binding/org.openhab.binding.modbus.test/src/test/java/org/openhab/binding/modbus/internal/ErroringQueriesTestCase.java
@@ -85,15 +85,17 @@ public class ErroringQueriesTestCase extends TestCaseSupport {
      * - two discrete inputs
      *
      * Items are follows
-     * - first coil (Item1) -> no output since coil query should fail
-     * - both coils (Item2 and Item3) -> should have valid output
+     * - first (index=0) coil (Item1) -> no output since coil query should fail
+     * - index=1 discrete (Item2) should be OK
+     * - index=2 discrete (Item3) no event transmitted, item readIndex out of bounds. WARN logged
      */
-    @Test(expected = ExpectedFailure.class)
+    @Test
     public void testReadingTooMuchTwoSlaves()
             throws UnknownHostException, ConfigurationException, BindingConfigParseException {
         spi.addDigitalOut(new SimpleDigitalOut(true));
         spi.addDigitalIn(new SimpleDigitalIn(true));
-        spi.addDigitalIn(new SimpleDigitalIn(false));
+        spi.addDigitalIn(new SimpleDigitalIn(true));
+        spi.addDigitalIn(new SimpleDigitalIn(true));
 
         binding = new ModbusBinding();
         Dictionary<String, Object> config = newLongPollBindingConfig();
@@ -120,13 +122,8 @@ public class ErroringQueriesTestCase extends TestCaseSupport {
 
         verify(eventPublisher, never()).postCommand(null, null);
         verify(eventPublisher, never()).sendCommand(null, null);
-        try {
-            verify(eventPublisher).postUpdate("Item2", OnOffType.ON);
-            verify(eventPublisher).postUpdate("Item3", OnOffType.OFF);
-            verifyNoMoreInteractions(eventPublisher);
-        } catch (AssertionError e) {
-            throw new ExpectedFailure();
-        }
+        verify(eventPublisher).postUpdate("Item2", OnOffType.ON);
+        verifyNoMoreInteractions(eventPublisher);
     }
 
 }

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
@@ -60,7 +60,7 @@ import net.wimpi.modbus.util.SerialParameters;
  * @author Dmitry Krasnov
  * @since 1.1.0
  */
-public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider>implements ManagedService {
+public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider> implements ManagedService {
 
     private static final long DEFAULT_POLL_INTERVAL = 200;
 
@@ -339,6 +339,15 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider>i
                     boolean state = coils.getBit(config.readIndex);
                     State newState = config.translateBoolean2State(state);
                     ModbusSlave slave = modbusSlaves.get(slaveName);
+
+                    if (config.readIndex >= slave.getLength()) {
+                        logger.warn(
+                                "Item '{}' read index '{}' is out-of-bounds. Slave '{}' has been configured "
+                                        + "to read only '{}' bits. Check your configuration!",
+                                itemName, config.readIndex, slaveName, slave.getLength());
+                        continue;
+                    }
+
                     if (slave.isUpdateUnchangedItems() || !newState.equals(config.getState())) {
                         eventPublisher.postUpdate(itemName, newState);
                         config.setState(newState);


### PR DESCRIPTION
Solves #4574