### PR TITLE
[Modbus] Read errors now emit UNDEF (configurable)

### DIFF
--- a/bundles/binding/org.openhab.binding.modbus.test/src/test/java/org/openhab/binding/modbus/internal/ErroringQueriesTestCase.java
+++ b/bundles/binding/org.openhab.binding.modbus.test/src/test/java/org/openhab/binding/modbus/internal/ErroringQueriesTestCase.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.openhab.binding.modbus.ModbusBindingProvider;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.types.UnDefType;
 import org.openhab.model.item.binding.BindingConfigParseException;
 import org.osgi.service.cm.ConfigurationException;
 
@@ -70,6 +71,35 @@ public class ErroringQueriesTestCase extends TestCaseSupport {
         waitForConnectionsReceived(1);
         waitForRequests(1);
 
+        verifyNoMoreInteractions(eventPublisher);
+    }
+
+    @Test
+    public void testReadingTooMuchWithPostUndef()
+            throws UnknownHostException, ConfigurationException, BindingConfigParseException {
+        spi.addDigitalIn(new SimpleDigitalIn(true));
+        spi.addDigitalOut(new SimpleDigitalOut(true));
+        spi.addDigitalOut(new SimpleDigitalOut(false));
+
+        binding = new ModbusBinding();
+        Dictionary<String, Object> config = newLongPollBindingConfig();
+        addSlave(config, SLAVE_NAME, ModbusBindingProvider.TYPE_DISCRETE, null, 0, 2);
+        putSlaveConfigParameter(config, serverType, SLAVE_NAME, "postundefinedonreaderror", "true");
+        binding.updated(config);
+
+        // Configure items
+        final ModbusGenericBindingProvider provider = new ModbusGenericBindingProvider();
+        provider.processBindingConfiguration("test.items", new SwitchItem("Item1"),
+                String.format("%s:%d", SLAVE_NAME, 0));
+        binding.setEventPublisher(eventPublisher);
+        binding.addBindingProvider(provider);
+
+        binding.execute();
+
+        waitForConnectionsReceived(1);
+        waitForRequests(1);
+
+        verify(eventPublisher).postUpdate("Item1", UnDefType.UNDEF);
         verifyNoMoreInteractions(eventPublisher);
     }
 

--- a/bundles/binding/org.openhab.binding.modbus.test/src/test/java/org/openhab/binding/modbus/internal/TestCaseSupport.java
+++ b/bundles/binding/org.openhab.binding.modbus.test/src/test/java/org/openhab/binding/modbus/internal/TestCaseSupport.java
@@ -148,19 +148,20 @@ public class TestCaseSupport {
         return InetAddress.getLocalHost();
     }
 
-    private static Dictionary<String, Object> addSlave(Dictionary<String, Object> config, String protocol,
+    private static Dictionary<String, Object> addSlave(Dictionary<String, Object> config, ServerType serverType,
             String connection, String slaveName, String type, String valuetype, int slaveId, int start, int length) {
         /**
          * Add a modbus slave to config
          */
-        config.put(String.format("%s.%s.connection", protocol, slaveName), connection);
-        config.put(String.format("%s.%s.id", protocol, slaveName), String.valueOf(slaveId));
-        config.put(String.format("%s.%s.type", protocol, slaveName), type);
+        putSlaveConfigParameter(config, serverType, slaveName, "connection", connection);
+        putSlaveConfigParameter(config, serverType, slaveName, "id", String.valueOf(slaveId));
+        putSlaveConfigParameter(config, serverType, slaveName, "type", type);
+
         if (valuetype != null) {
-            config.put(String.format("%s.%s.valuetype", protocol, slaveName), valuetype);
+            putSlaveConfigParameter(config, serverType, slaveName, "valuetype", valuetype);
         }
-        config.put(String.format("%s.%s.start", protocol, slaveName), String.valueOf(start));
-        config.put(String.format("%s.%s.length", protocol, slaveName), String.valueOf(length));
+        putSlaveConfigParameter(config, serverType, slaveName, "start", String.valueOf(start));
+        putSlaveConfigParameter(config, serverType, slaveName, "length", String.valueOf(length));
         return config;
     }
 
@@ -169,19 +170,14 @@ public class TestCaseSupport {
      */
     protected Dictionary<String, Object> addSlave(Dictionary<String, Object> config, String slaveName, String type,
             String valuetype, int start, int length) throws UnknownHostException {
-        String protocol = null;
         String connection;
         if (ServerType.TCP.equals(serverType)) {
             int port = tcpModbusPort;
-            protocol = "tcp";
             connection = String.format("%s:%d", localAddress().getHostAddress(), port);
         } else if (ServerType.UDP.equals(serverType)) {
             int port = udpModbusPort;
-            protocol = "udp";
             connection = String.format("%s:%d", localAddress().getHostAddress(), port);
         } else if (ServerType.SERIAL.equals(serverType)) {
-            protocol = "serial";
-
             connection = String.format("%s:%d:%d:%s:%s:%s", SERIAL_PARAMETERS_CLIENT.getPortName(),
                     SERIAL_PARAMETERS_CLIENT.getBaudRate(), SERIAL_PARAMETERS_CLIENT.getDatabits(),
                     SERIAL_PARAMETERS_CLIENT.getParityString(), SERIAL_PARAMETERS_CLIENT.getStopbitsString(),
@@ -190,7 +186,20 @@ public class TestCaseSupport {
             throw new NotImplementedException();
         }
 
-        return addSlave(config, protocol, connection, slaveName, type, valuetype, 1, start, length);
+        return addSlave(config, serverType, connection, slaveName, type, valuetype, 1, start, length);
+    }
+
+    protected static void putSlaveConfigParameter(Dictionary<String, Object> config, ServerType serverType,
+            String slaveName, String paramName, String paramValue) {
+        String protocol = null;
+        if (ServerType.TCP.equals(serverType)) {
+            protocol = "tcp";
+        } else if (ServerType.UDP.equals(serverType)) {
+            protocol = "udp";
+        } else if (ServerType.SERIAL.equals(serverType)) {
+            protocol = "serial";
+        }
+        config.put(String.format("%s.%s.%s", protocol, slaveName, paramName), paramValue);
     }
 
     protected static Dictionary<String, Object> newLongPollBindingConfig() {

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
@@ -60,7 +60,7 @@ import net.wimpi.modbus.util.SerialParameters;
  * @author Dmitry Krasnov
  * @since 1.1.0
  */
-public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider>implements ManagedService {
+public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider> implements ManagedService {
 
     private static final long DEFAULT_POLL_INTERVAL = 200;
 
@@ -86,7 +86,7 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider>i
     private static final String TCP_PREFIX = "tcp";
     private static final String SERIAL_PREFIX = "serial";
 
-    private static final String VALID_CONFIG_KEYS = "connection|id|start|length|type|valuetype|rawdatamultiplier|writemultipleregisters|updateunchangeditems";
+    private static final String VALID_CONFIG_KEYS = "connection|id|start|length|type|valuetype|rawdatamultiplier|writemultipleregisters|updateunchangeditems|postundefinedonreaderror";
     private static final Pattern EXTRACT_MODBUS_CONFIG_PATTERN = Pattern.compile(
             "^(" + TCP_PREFIX + "|" + UDP_PREFIX + "|" + SERIAL_PREFIX + "|)\\.(.*?)\\.(" + VALID_CONFIG_KEYS + ")$");
 
@@ -224,6 +224,33 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider>i
             }
 
             if (slave.isUpdateUnchangedItems() || !newState.equals(config.getState())) {
+                eventPublisher.postUpdate(itemName, newState);
+                config.setState(newState);
+            }
+        }
+    }
+
+    /**
+     * Posts update event to OpenHAB bus for all types of slaves when there is a read error
+     *
+     * @param binding ModbusBinding to get item configuration from BindingProviding
+     * @param error
+     * @param itemName item to update
+     */
+    protected void internalUpdateReadErrorItem(String slaveName, Exception error, String itemName) {
+        State newState = UnDefType.UNDEF;
+        for (ModbusBindingProvider provider : providers) {
+            if (!provider.providesBindingFor(itemName)) {
+                continue;
+            }
+            ModbusBindingConfig config = provider.getConfig(itemName);
+            if (!config.slaveName.equals(slaveName)) {
+                continue;
+            }
+
+            ModbusSlave slave = modbusSlaves.get(slaveName);
+            if (slave.isPostUndefinedOnReadError()
+                    && (slave.isUpdateUnchangedItems() || !newState.equals(config.getState()))) {
                 eventPublisher.postUpdate(itemName, newState);
                 config.setState(newState);
             }
@@ -576,6 +603,8 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider>i
                         modbusSlave.setRawDataMultiplier(Double.valueOf(value.toString()));
                     } else if ("updateunchangeditems".equals(configKey)) {
                         modbusSlave.setUpdateUnchangedItems(Boolean.valueOf(value.toString()));
+                    } else if ("postundefinedonreaderror".equals(configKey)) {
+                        modbusSlave.setPostUndefinedOnReadError(Boolean.valueOf(value.toString()));
                     } else {
                         throw new ConfigurationException(configKey,
                                 "the given configKey '" + configKey + "' is unknown");

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusConnectionException.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusConnectionException.java
@@ -1,0 +1,19 @@
+package org.openhab.binding.modbus.internal;
+
+import org.openhab.binding.modbus.internal.pooling.ModbusSlaveEndpoint;
+
+@SuppressWarnings("serial")
+public class ModbusConnectionException extends Exception {
+
+    private ModbusSlaveEndpoint endpoint;
+
+    public ModbusConnectionException(ModbusSlaveEndpoint endpoint) {
+        this.endpoint = endpoint;
+
+    }
+
+    public ModbusSlaveEndpoint getEndpoint() {
+        return endpoint;
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusGenericBindingProvider.java
@@ -140,7 +140,10 @@ public class ModbusGenericBindingProvider extends AbstractGenericBindingProvider
          */
         String slaveName;
         /**
-         * State of Item
+         * State of Item. Initialized to null so that
+         * UnDefType.UNDEF (which might be transmitted
+         * in case of errors)
+         * is considered unequal to the initial value.
          */
         private State state = null;
 

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusSlave.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusSlave.java
@@ -23,6 +23,7 @@ import org.openhab.core.types.Command;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.wimpi.modbus.ModbusException;
 import net.wimpi.modbus.io.ModbusTransaction;
 import net.wimpi.modbus.msg.ModbusRequest;
 import net.wimpi.modbus.msg.ModbusResponse;
@@ -104,6 +105,7 @@ public abstract class ModbusSlave {
     private double rawDataMultiplier = 1.0;
 
     private Object storage;
+    private Exception readError;
     protected ModbusTransaction transaction = null;
 
     /**
@@ -113,13 +115,12 @@ public abstract class ModbusSlave {
      */
     private boolean updateUnchangedItems = false;
 
-    public boolean isUpdateUnchangedItems() {
-        return updateUnchangedItems;
-    }
-
-    public void setUpdateUnchangedItems(boolean updateUnchangedItems) {
-        this.updateUnchangedItems = updateUnchangedItems;
-    }
+    /**
+     * Does the binding post UNDEF update event when read fails
+     *
+     * default is "false"
+     */
+    private boolean postUndefinedOnReadError = false;
 
     /**
      * @param slave slave name from cfg file used for item binding
@@ -138,11 +139,14 @@ public abstract class ModbusSlave {
      * @param config
      */
     public void executeCommand(Command command, ModbusBindingConfig config) {
-        if (ModbusBindingProvider.TYPE_COIL.equals(getType())) {
-            setCoil(command, config);
-        }
-        if (ModbusBindingProvider.TYPE_HOLDING.equals(getType())) {
-            setRegister(command, config);
+        try {
+            if (ModbusBindingProvider.TYPE_COIL.equals(getType())) {
+                setCoil(command, config);
+            } else if (ModbusBindingProvider.TYPE_HOLDING.equals(getType())) {
+                setRegister(command, config);
+            }
+        } catch (Exception e) {
+            // Error already logged, just continue as normal
         }
     }
 
@@ -174,8 +178,12 @@ public abstract class ModbusSlave {
      *
      * @param command command received from OpenHAB
      * @param config
+     * @throws ModbusConnectionException when connection cannot be established
+     * @throws ModbusException ModbusIOException on IO errors, ModbusSlaveException with protocol level exceptions
+     * @throws ModbusUnexpectedTransactionIdException when response transaction id does not match the request
      */
-    private void setCoil(Command command, ModbusBindingConfig config) {
+    private void setCoil(Command command, ModbusBindingConfig config)
+            throws ModbusConnectionException, ModbusException, ModbusUnexpectedTransactionIdException {
         int writeRegister = config.writeIndex;
         boolean b = translateCommand2Boolean(command);
         doSetCoil(getStart() + writeRegister, b);
@@ -186,8 +194,12 @@ public abstract class ModbusSlave {
      *
      * @param command command received from OpenHAB
      * @param config
+     * @throws ModbusConnectionException when connection cannot be established
+     * @throws ModbusException ModbusIOException on IO errors, ModbusSlaveException with protocol level exceptions
+     * @throws ModbusUnexpectedTransactionIdException when response transaction id does not match the request
      */
-    protected void setRegister(Command command, ModbusBindingConfig config) {
+    protected void setRegister(Command command, ModbusBindingConfig config)
+            throws ModbusConnectionException, ModbusException, ModbusUnexpectedTransactionIdException {
         int readIndex = config.readIndex;
         int writeRegister = getStart() + config.writeIndex;
 
@@ -274,33 +286,54 @@ public abstract class ModbusSlave {
      *
      * @param writeRegister
      * @param b
+     * @throws ModbusUnexpectedTransactionIdException
+     * @throws ModbusException
+     * @throws ModbusConnectionException
      */
-    public void doSetCoil(int writeRegister, boolean b) {
+    public void doSetCoil(int writeRegister, boolean b)
+            throws ModbusConnectionException, ModbusException, ModbusUnexpectedTransactionIdException {
         ModbusRequest request = new WriteCoilRequest(writeRegister, b);
         request.setUnitID(getId());
         logger.debug("ModbusSlave ({}): FC05 ref={} value={}", name, writeRegister, b);
         executeWriteRequest(request);
     }
 
-    private void executeWriteRequest(ModbusRequest request) {
+    /**
+     *
+     * @param request
+     * @throws ModbusConnectionException when connection cannot be established
+     * @throws ModbusException ModbusIOException on IO errors, ModbusSlaveException with protocol level exceptions
+     * @throws ModbusUnexpectedTransactionIdException when response transaction id does not match the request
+     */
+    private void executeWriteRequest(ModbusRequest request)
+            throws ModbusConnectionException, ModbusException, ModbusUnexpectedTransactionIdException {
         ModbusSlaveEndpoint endpoint = getEndpoint();
         ModbusSlaveConnection connection = null;
         try {
             connection = getConnection(endpoint);
             if (connection == null) {
                 logger.warn("ModbusSlave ({}): not connected -- aborting request {}", name, request);
-                return;
+                throw new ModbusConnectionException(endpoint);
             }
             transaction.setRequest(request);
             try {
                 transaction.execute();
             } catch (Exception e) {
+                // Note, one could catch ModbusIOException and ModbusSlaveException if more detailed
+                // exception handling is required. For now, all exceptions are handled the same way with writes.
                 logger.error("ModbusSlave ({}): error when executing write request ({}): {}", name, request,
                         e.getMessage());
                 invalidate(endpoint, connection);
                 // set connection to null such that it is not returned to pool
                 connection = null;
-                return;
+                throw e;
+            }
+            ModbusResponse response = transaction.getResponse();
+            if ((response.getTransactionID() != transaction.getTransactionID()) && !response.isHeadless()) {
+                logger.warn(
+                        "ModbusSlave ({}): Transaction id of the response does not match request {}.  Endpoint {}. Connection: {}. Ignoring response.",
+                        name, request, endpoint, connection);
+                throw new ModbusUnexpectedTransactionIdException();
             }
         } finally {
             returnConnection(endpoint, connection);
@@ -361,60 +394,53 @@ public abstract class ModbusSlave {
         try {
 
             Object local = null;
-
-            if (ModbusBindingProvider.TYPE_COIL.equals(getType())) {
-                ModbusRequest request = new ReadCoilsRequest(getStart(), getLength());
-                if (this instanceof ModbusSerialSlave) {
-                    request.setHeadless();
+            Exception localReadError = null;
+            try {
+                if (ModbusBindingProvider.TYPE_COIL.equals(getType())) {
+                    ModbusRequest request = new ReadCoilsRequest(getStart(), getLength());
+                    if (this instanceof ModbusSerialSlave) {
+                        request.setHeadless();
+                    }
+                    ReadCoilsResponse response = (ReadCoilsResponse) getModbusData(request);
+                    local = response.getCoils();
+                } else if (ModbusBindingProvider.TYPE_DISCRETE.equals(getType())) {
+                    ModbusRequest request = new ReadInputDiscretesRequest(getStart(), getLength());
+                    ReadInputDiscretesResponse response = (ReadInputDiscretesResponse) getModbusData(request);
+                    local = response.getDiscretes();
+                } else if (ModbusBindingProvider.TYPE_HOLDING.equals(getType())) {
+                    ModbusRequest request = new ReadMultipleRegistersRequest(getStart(), getLength());
+                    ReadMultipleRegistersResponse response = (ReadMultipleRegistersResponse) getModbusData(request);
+                    local = response.getRegisters();
+                } else if (ModbusBindingProvider.TYPE_INPUT.equals(getType())) {
+                    ModbusRequest request = new ReadInputRegistersRequest(getStart(), getLength());
+                    ReadInputRegistersResponse response = (ReadInputRegistersResponse) getModbusData(request);
+                    local = response.getRegisters();
                 }
-                request.setUnitID(id);
-                ReadCoilsResponse response = (ReadCoilsResponse) getModbusData(request);
-                if (response == null) {
-                    // use debug level logging since getModbusData has already logged the reason
-                    logger.debug("Could not read from the slave");
-                    return;
-                }
-                local = response.getCoils();
-            } else if (ModbusBindingProvider.TYPE_DISCRETE.equals(getType())) {
-                ModbusRequest request = new ReadInputDiscretesRequest(getStart(), getLength());
-                ReadInputDiscretesResponse response = (ReadInputDiscretesResponse) getModbusData(request);
-                // use debug level logging since getModbusData has already logged the reason
-                if (response == null) {
-                    logger.debug("Could not read from the slave");
-                    return;
-                }
-                local = response.getDiscretes();
-            } else if (ModbusBindingProvider.TYPE_HOLDING.equals(getType())) {
-                ModbusRequest request = new ReadMultipleRegistersRequest(getStart(), getLength());
-                ReadMultipleRegistersResponse response = (ReadMultipleRegistersResponse) getModbusData(request);
-                // use debug level logging since getModbusData has already logged the reason
-                if (response == null) {
-                    logger.debug("Could not read from the slave");
-                    return;
-                }
-                local = response.getRegisters();
-            } else if (ModbusBindingProvider.TYPE_INPUT.equals(getType())) {
-                ModbusRequest request = new ReadInputRegistersRequest(getStart(), getLength());
-                ReadInputRegistersResponse response = (ReadInputRegistersResponse) getModbusData(request);
-                // use debug level logging since getModbusData has already logged the reason
-                if (response == null) {
-                    logger.debug("Could not read from the slave");
-                    return;
-                }
-                local = response.getRegisters();
+            } catch (ModbusException e) {
+                // Logging already done in getModbusData
+                localReadError = e;
+            } catch (ModbusConnectionException e) {
+                // Logging already done in getModbusData
+                localReadError = e;
+            } catch (ModbusUnexpectedTransactionIdException e) {
+                // Logging already done in getModbusData
+                localReadError = e;
             }
+
             if (storage == null) {
                 storage = local;
+                readError = localReadError;
             } else {
                 synchronized (storage) {
                     storage = local;
+                    readError = localReadError;
                 }
             }
             Collection<String> items = binding.getItemNames();
             for (String item : items) {
                 updateItem(binding, item);
             }
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             logger.error("ModbusSlave ({}) error getting response from slave", name, e);
         }
 
@@ -428,14 +454,25 @@ public abstract class ModbusSlave {
      * @param item item to update
      */
     private void updateItem(ModbusBinding binding, String item) {
-        if (ModbusBindingProvider.TYPE_COIL.equals(getType())
-                || ModbusBindingProvider.TYPE_DISCRETE.equals(getType())) {
-            binding.internalUpdateItem(name, (BitVector) storage, item);
+        if (readError == null) {
+            if (ModbusBindingProvider.TYPE_COIL.equals(getType())
+                    || ModbusBindingProvider.TYPE_DISCRETE.equals(getType())) {
+                binding.internalUpdateItem(name, (BitVector) storage, item);
+            } else if (ModbusBindingProvider.TYPE_HOLDING.equals(getType())
+                    || ModbusBindingProvider.TYPE_INPUT.equals(getType())) {
+                binding.internalUpdateItem(name, (InputRegister[]) storage, item);
+            }
+        } else {
+            binding.internalUpdateReadErrorItem(name, readError, item);
         }
-        if (ModbusBindingProvider.TYPE_HOLDING.equals(getType())
-                || ModbusBindingProvider.TYPE_INPUT.equals(getType())) {
-            binding.internalUpdateItem(name, (InputRegister[]) storage, item);
-        }
+    }
+
+    public boolean isUpdateUnchangedItems() {
+        return updateUnchangedItems;
+    }
+
+    public void setUpdateUnchangedItems(boolean updateUnchangedItems) {
+        this.updateUnchangedItems = updateUnchangedItems;
     }
 
     /**
@@ -443,8 +480,12 @@ public abstract class ModbusSlave {
      *
      * @param request describes what data are requested from the device
      * @return response data
+     * @throws ModbusConnectionException when connection cannot be established
+     * @throws ModbusException ModbusIOException on IO errors, ModbusSlaveException with protocol level exceptions
+     * @throws ModbusUnexpectedTransactionIdException when response transaction id does not match the request
      */
-    private ModbusResponse getModbusData(ModbusRequest request) {
+    private ModbusResponse getModbusData(ModbusRequest request)
+            throws ModbusConnectionException, ModbusException, ModbusUnexpectedTransactionIdException {
         ModbusSlaveEndpoint endpoint = getEndpoint();
         ModbusSlaveConnection connection = null;
         ModbusResponse response = null;
@@ -453,21 +494,21 @@ public abstract class ModbusSlave {
             if (connection == null) {
                 logger.warn("ModbusSlave ({}) not connected -- aborting read request {}. Endpoint {}", name, request,
                         endpoint);
-                return null;
+                throw new ModbusConnectionException(endpoint);
             }
             request.setUnitID(getId());
             transaction.setRequest(request);
 
             try {
                 transaction.execute();
-            } catch (Exception e) {
+            } catch (ModbusException e) {
                 logger.error(
                         "ModbusSlave ({}): Error getting modbus data for request {}. Error: {}. Endpoint {}. Connection: {}",
                         name, request, e.getMessage(), endpoint, connection);
                 invalidate(endpoint, connection);
                 // Invalidated connections should not be returned
                 connection = null;
-                return null;
+                throw e;
             }
 
             response = transaction.getResponse();
@@ -475,7 +516,7 @@ public abstract class ModbusSlave {
                 logger.warn(
                         "ModbusSlave ({}): Transaction id of the response does not match request {}.  Endpoint {}. Connection: {}. Ignoring response.",
                         name, request, endpoint, connection);
-                return null;
+                throw new ModbusUnexpectedTransactionIdException();
             }
         } finally {
             returnConnection(endpoint, connection);
@@ -547,5 +588,13 @@ public abstract class ModbusSlave {
             throw new IllegalStateException("transaction not initialized!");
         }
         transaction.setRetryDelayMillis(retryDelayMillis);
+    }
+
+    public boolean isPostUndefinedOnReadError() {
+        return postUndefinedOnReadError;
+    }
+
+    public void setPostUndefinedOnReadError(boolean postUndefinedOnReadError) {
+        this.postUndefinedOnReadError = postUndefinedOnReadError;
     }
 }

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusSlave.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusSlave.java
@@ -440,7 +440,7 @@ public abstract class ModbusSlave {
             for (String item : items) {
                 updateItem(binding, item);
             }
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             logger.error("ModbusSlave ({}) error getting response from slave", name, e);
         }
 

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusUnexpectedTransactionIdException.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusUnexpectedTransactionIdException.java
@@ -1,0 +1,10 @@
+package org.openhab.binding.modbus.internal;
+
+@SuppressWarnings("serial")
+public class ModbusUnexpectedTransactionIdException extends Exception {
+
+    public ModbusUnexpectedTransactionIdException() {
+
+    }
+
+}


### PR DESCRIPTION
Resolves #4552. 

This implementation emits Undefined state even with all read errors:
- connection establishment fails
- protocol errors (that is, modbus slave response is error response)
- IO errors
- transaction id mismatch (request's transaction id does not match response's transaction id)

Additionally, this PR will also implement transaction id check for writes, and in case of such mismatch, error is logged with WARN. Previously this case was not checked and not logged.

Pre-compiled jar available [here](https://github.com/ssalonen/openhab/releases/tag/modbus-error-detection-pr-2016-08-08)