### PR TITLE
Play songID from current playlist added

### DIFF
--- a/bundles/binding/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/MpdGenericBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/MpdGenericBindingProvider.java
@@ -147,6 +147,8 @@ public class MpdGenericBindingProvider extends AbstractGenericBindingProvider im
                 itemNames.add(itemName);
             } else if (mpdConfig.containsKey("ARTIST") && PlayerCommandTypeMapping.TRACKARTIST.equals(playerCommand)) {
                 itemNames.add(itemName);
+            } else if (mpdConfig.containsKey("NUMBER") && PlayerCommandTypeMapping.PLAYSONGID.equals(playerCommand)) {
+                itemNames.add(itemName);
             } else if (mpdConfig.containsKey(playerCommand.type.toString())) {
                 // we check to make sure the binding config contains
                 // playerId:playerCommand otherwise we get extra items
@@ -192,7 +194,7 @@ public class MpdGenericBindingProvider extends AbstractGenericBindingProvider im
      * config strings and use it to answer the requests to the MPD binding
      * provider.
      */
-    static class MpdBindingConfig extends HashMap<String, String>implements BindingConfig {
+    static class MpdBindingConfig extends HashMap<String, String> implements BindingConfig {
 
         /** generated serialVersion UID */
         private static final long serialVersionUID = 6164971643530954095L;

--- a/bundles/binding/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/PlayerCommandTypeMapping.java
+++ b/bundles/binding/org.openhab.binding.mpd/src/main/java/org/openhab/binding/mpd/internal/PlayerCommandTypeMapping.java
@@ -34,6 +34,12 @@ public enum PlayerCommandTypeMapping {
         }
     },
 
+    PLAYSONGID {
+        {
+            command = "playsongid";
+        }
+    },
+
     PLAY {
         {
             command = "play";


### PR DESCRIPTION
MPD enhancement. Added support for playing song with specified songID. It can be used as Selection to play specified stream

Item definition:

Number		Radio_GF_Salon_playitem		"Radio"		<none> 	(All) { mpd="NUMBER:p1:playsongid" }

Sitemap:

Selection item=Radio_GF_Salon_playitem mappings=[1="ZET Chilli",2="Radio Kolor",3="Radio 7",4="Złote Przeboje",5="EskaROCK",6="RMF Classic",7="RMF Maxxx",11="ESKA",9="RMF",10="MUZO.FM",8="PR 3",12="TOK FM" ]


 