### PR TITLE
DSC Alarm Command Updates for the IT100

### DIFF
--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmActiveBinding.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/DSCAlarmActiveBinding.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
  * @since 1.6.0
  */
 
-public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBindingProvider>implements ManagedService, DSCAlarmEventListener, DSCAlarmActionProvider {
+public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBindingProvider> implements ManagedService, DSCAlarmEventListener, DSCAlarmActionProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(DSCAlarmActiveBinding.class);
 
@@ -1265,7 +1265,7 @@ public class DSCAlarmActiveBinding extends AbstractActiveBinding<DSCAlarmBinding
                 return api.sendCommand(apiCode, data);
             }
         } catch (Exception e) {
-            logger.error("sendDSCAlarmCommand(): Failed to send DSC Alarm Command! - {}", e);
+            logger.error("sendDSCAlarmCommand(): Failed to Send DSC Alarm Command! - {}", e);
             return false;
         }
     }

--- a/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
+++ b/bundles/binding/org.openhab.binding.dscalarm/src/main/java/org/openhab/binding/dscalarm/internal/protocol/API.java
@@ -357,7 +357,7 @@ public class API {
                     break;
                 }
 
-                if (!interfaceType.equals(DSCAlarmInterfaceType.IT100)) {
+                if (interfaceType.equals(DSCAlarmInterfaceType.IT100)) {
                     data = apiData[0] + String.format("%-6s", dscAlarmUserCode).replace(' ', '0');
                 } else {
                     data = apiData[0] + dscAlarmUserCode;
@@ -392,10 +392,30 @@ public class API {
                 validCommand = true;
                 break;
             case KeyStroke: /* 070 */
-                if (apiData[0] == null || apiData[0].length() != 1 || !apiData[0].matches("[0-9]|A|#|\\*")) {
-                    logger.error("sendCommand(): \'keystroke\' must be a single character string from 0 to 9, *, #, or A, it was: {}", apiData[0]);
+                if (interfaceType.equals(DSCAlarmInterfaceType.ENVISALINK)) {
+                    if (apiData[0] == null || apiData[0].length() != 1 || !apiData[0].matches("[0-9]|A|\\*|#")) {
+                        logger.error("sendCommand(): \'keystroke\' must be a single character string from 0 to 9, *, #, or A, it was: {}", apiData[0]);
+                        break;
+                    }
+                } else if (interfaceType.equals(DSCAlarmInterfaceType.IT100)) {
+                    if (apiData[0] == null || apiData[0].length() != 1 || !apiData[0].matches("[0-9]|\\*|#|F|A|P|[a-e]|<|>|=|\\^|L")) {
+                        logger.error("sendCommand(): \'keystroke\' must be a single character string from 0 to 9, *, #, F, A, P, a to e, <, >, =, or ^, it was: {}", apiData[0]);
+                        break;
+                    } else if (apiData[0].equals("L")) { /* Long Key Press */
+                        try {
+                            Thread.sleep(1500);
+                            data = "^";
+                            validCommand = true;
+                            break;
+                        } catch (InterruptedException e) {
+                            logger.error("sendCommand(): \'keystroke\': Error with Long Key Press!");
+                            break;
+                        }
+                    }
+                } else {
                     break;
                 }
+
                 data = apiData[0];
                 validCommand = true;
                 break;


### PR DESCRIPTION
Updated commands 040 and 070 to better accommodate the IT100 interface.

1. Fixed logical bug in command 040 so the binding would a append zeros
to the user code of the IT100 instead of the Envisalink.
2. Added ability in command 070 to send all allowable characters for the
IT100.
3. Implemented a long key press option in command 070 for the IT100.

Signed-off by: Russell Stephens rsstephens@gmail.com (github: @RSStephens)