### PR TITLE
Update Nest Binding To only update if state has changed

### DIFF
--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
@@ -195,6 +195,7 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider>imple
         }
 
         DataModel newDataModel = dmres;
+        DataModel olDataModel2 = this.oldDataModel
         this.oldDataModel = newDataModel;
 
         // Iterate through bindings and update all inbound values.
@@ -203,17 +204,21 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider>imple
                 if (provider.isInBound(itemName)) {
                     final String property = provider.getProperty(itemName);
                     final State newState = getState(newDataModel, property);
+                    final State oldState = getState(OldDataModel2, property);
 
-                    logger.trace("Updating itemName '{}' with newState '{}'", itemName, newState);
 
-                    /*
-                     * we need to make sure that we won't send out this event to Nest again, when receiving it on the
-                     * openHAB bus
-                     */
-                    ignoreEventList.add(new Update(itemName, newState));
-                    logger.trace("Added event (item='{}', newState='{}') to the ignore event list (size={})", itemName,
+                    if (newState != oldState) {
+                        logger.trace("Updating itemName '{}' with newState '{}'", itemName, newState);
+
+                        /*
+                        * we need to make sure that we won't send out this event to Nest again, when receiving it on the
+                        * openHAB bus
+                        */
+                        ignoreEventList.add(new Update(itemName, newState));
+                        logger.trace("Added event (item='{}', newState='{}') to the ignore event list (size={})", itemName,
                             newState, ignoreEventList.size());
-                    this.eventPublisher.postUpdate(itemName, newState);
+                        this.eventPublisher.postUpdate(itemName, newState);
+                    }
                 }
             }
         }


### PR DESCRIPTION
The binding is clogging up the events log file with item updates. I propose a change so that the binding only updates an item when the value has changed.