### PR TITLE
Add option to send plain literals messages.

### DIFF
--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/TCPBinding.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/TCPBinding.java
@@ -267,7 +267,7 @@ public class TCPBinding extends AbstractSocketChannelBinding<TCPBindingProvider>
             String transformationType = parts[0];
             String transformationFunction = parts[1];
 
-           if (transformationType = "") {     // test for empty type first to avoid the WARN from getTransformationService
+           if (transformationType == "") {     // test for empty type first to avoid the WARN from getTransformationService
                 transformedResponse = transformationFunction;
             } else {
                 TransformationService transformationService = TransformationHelper

--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/TCPBinding.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/TCPBinding.java
@@ -267,14 +267,18 @@ public class TCPBinding extends AbstractSocketChannelBinding<TCPBindingProvider>
             String transformationType = parts[0];
             String transformationFunction = parts[1];
 
-            TransformationService transformationService = TransformationHelper
-                    .getTransformationService(TCPActivator.getContext(), transformationType);
-            if (transformationService != null) {
-                transformedResponse = transformationService.transform(transformationFunction, response);
+           if (transformationType = "") {     // test for empty type first to avoid the WARN from getTransformationService
+                transformedResponse = transformationFunction;
             } else {
-                transformedResponse = response;
-                logger.warn("couldn't transform response because transformationService of type '{}' is unavailable",
-                        transformationType);
+                TransformationService transformationService = TransformationHelper
+                        .getTransformationService(TCPActivator.getContext(), transformationType);
+                if (transformationService != null) {
+                    transformedResponse = transformationService.transform(transformationFunction, response);
+                } else {
+                    transformedResponse = response;
+                    logger.warn("couldn't transform response because transformationService of type '{}' is unavailable",
+                            transformationType);
+                }
             }
         } catch (Exception te) {
             logger.error("transformation throws exception [transformation=" + transformation + ", response=" + response

--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/TCPBinding.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/TCPBinding.java
@@ -236,29 +236,6 @@ public class TCPBinding extends AbstractSocketChannelBinding<TCPBindingProvider>
     protected void configureChannel(Channel channel) {
     }
 
-    /**
-     * Splits a transformation configuration string into its two parts - the
-     * transformation type and the function/pattern to apply.
-     *
-     * @param transformation the string to split
-     * @return a string array with exactly two entries for the type and the function
-     */
-    protected String[] splitTransformationConfig(String transformation) {
-        Matcher matcher = EXTRACT_FUNCTION_PATTERN.matcher(transformation);
-
-        if (!matcher.matches()) {
-            throw new IllegalArgumentException("given transformation function '" + transformation
-                    + "' does not follow the expected pattern '<function>(<pattern>)'");
-        }
-        matcher.reset();
-
-        matcher.find();
-        String type = matcher.group(1);
-        String pattern = matcher.group(2);
-
-        return new String[] { type, pattern };
-    }
-
     protected String transformResponse(String transformation, String response) {
         String transformedResponse;
         Matcher matcher = EXTRACT_FUNCTION_PATTERN.matcher(transformation);


### PR DESCRIPTION
The TCP binding does not allow to send plain literal strings straight from the item declaration <transformationrule> (the 4th argument in brackets), but forces to go through transformations.
A simple way to achieve that without changing the code much is to treat an 'empty' transformation to pass the argument directly as the response: instead of "MAP(my.device.map)" or "REGEX((.*))" for example, just type "(1234ABC)" to send the string 1234ABC. The parenthesis are needed to match the pattern tested before, otherwise some more code needs to changed. Also we can assume that no transformation rule will ever be named with an empty string, but it still matches the pattern.