### PR TITLE
[modbus] Connection timeout parameter for TCP slaves.

### DIFF
--- a/bundles/binding/org.openhab.binding.modbus.test/src/test/java/org/openhab/binding/modbus/internal/TestCaseSupport.java
+++ b/bundles/binding/org.openhab.binding.modbus.test/src/test/java/org/openhab/binding/modbus/internal/TestCaseSupport.java
@@ -148,7 +148,7 @@ public class TestCaseSupport {
         return InetAddress.getLocalHost();
     }
 
-    private static Dictionary<String, Object> addSlave(Dictionary<String, Object> config, ServerType serverType,
+    protected static Dictionary<String, Object> addSlave(Dictionary<String, Object> config, ServerType serverType,
             String connection, String slaveName, String type, String valuetype, int slaveId, int start, int length) {
         /**
          * Add a modbus slave to config

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/net/TCPMasterConnection.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/net/wimpi/modbus/net/TCPMasterConnection.java
@@ -18,6 +18,7 @@ package net.wimpi.modbus.net;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 
 import org.apache.commons.lang.builder.StandardToStringStyle;
@@ -49,6 +50,8 @@ public class TCPMasterConnection implements ModbusSlaveConnection {
     // private int m_Retries = Modbus.DEFAULT_RETRIES;
     private ModbusTCPTransport m_ModbusTransport;
 
+    private int m_ConnectTimeoutMillis;
+
     private static StandardToStringStyle toStringStyle = new StandardToStringStyle();
 
     static {
@@ -70,6 +73,11 @@ public class TCPMasterConnection implements ModbusSlaveConnection {
         setPort(port);
     }
 
+    public TCPMasterConnection(InetAddress adr, int port, int connectTimeoutMillis) {
+        this(adr, port);
+        setConnectTimeoutMillis(connectTimeoutMillis);
+    }
+
     /**
      * Opens this <tt>TCPMasterConnection</tt>.
      *
@@ -79,7 +87,8 @@ public class TCPMasterConnection implements ModbusSlaveConnection {
     public synchronized boolean connect() throws Exception {
         if (!isConnected()) {
             logger.debug("connect()");
-            m_Socket = new Socket(m_Address, m_Port);
+            m_Socket = new Socket();
+            m_Socket.connect(new InetSocketAddress(m_Address, m_Port), this.m_ConnectTimeoutMillis);
             setTimeout(m_Timeout);
             m_Socket.setReuseAddress(true);
             m_Socket.setSoLinger(true, 1);
@@ -221,6 +230,14 @@ public class TCPMasterConnection implements ModbusSlaveConnection {
     @Override
     public String toString() {
         return new ToStringBuilder(this, toStringStyle).append("socket", m_Socket).toString();
+    }
+
+    public int getConnectTimeoutMillis() {
+        return m_ConnectTimeoutMillis;
+    }
+
+    public void setConnectTimeoutMillis(int m_ConnectTimeoutMillis) {
+        this.m_ConnectTimeoutMillis = m_ConnectTimeoutMillis;
     }
 
 }// class TCPMasterConnection

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
@@ -526,6 +526,7 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider> 
                                 endpointPoolConfig.setInterConnectDelayMillis(Long.parseLong(settingIterator.next()));
 
                                 endpointPoolConfig.setConnectMaxTries(Integer.parseInt(settingIterator.next()));
+                                endpointPoolConfig.setConnectTimeoutMillis(Integer.parseInt(settingIterator.next()));
                             } catch (NoSuchElementException e) {
                                 // Some of the optional parameters are missing -- it's ok!
                             }
@@ -535,7 +536,7 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider> 
                                                 + "Expecting at most 6 parameters: hostname (mandatory) and "
                                                 + "optionally (in this order) port number, "
                                                 + "interTransactionDelayMillis, reconnectAfterMillis,"
-                                                + "interConnectDelayMillis, connectMaxTries.", key);
+                                                + "interConnectDelayMillis, connectMaxTries, connectTimeout.", key);
                                 throw new ConfigurationException(key, errMsg);
                             }
                         } else if (modbusSlave instanceof ModbusSerialSlave) {

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/pooling/EndpointPoolConfiguration.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/pooling/EndpointPoolConfiguration.java
@@ -16,6 +16,8 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 /**
  * Class representing pooling related configuration of a single endpoint
  *
+ * This class implements equals hashcode constract, and thus is suitable for use as keys in HashMaps, for example.
+ *
  */
 public class EndpointPoolConfiguration {
 
@@ -42,6 +44,12 @@ public class EndpointPoolConfiguration {
      * One can use 0ms to denote reconnection after every transaction (default).
      */
     private int reconnectAfterMillis;
+
+    /**
+     * How long before we give up establishing the connection. In milliseconds. Default of 0 means that system/OS
+     * default is respected.
+     */
+    private int connectTimeoutMillis;
 
     private static StandardToStringStyle toStringStyle = new StandardToStringStyle();
 
@@ -81,17 +89,26 @@ public class EndpointPoolConfiguration {
         this.passivateBorrowMinMillis = passivateBorrowMinMillis;
     }
 
+    public int getConnectTimeoutMillis() {
+        return connectTimeoutMillis;
+    }
+
+    public void setConnectTimeoutMillis(int connectTimeoutMillis) {
+        this.connectTimeoutMillis = connectTimeoutMillis;
+    }
+
     @Override
     public int hashCode() {
         return new HashCodeBuilder(2149, 3117).append(passivateBorrowMinMillis).append(interConnectDelayMillis)
-                .append(connectMaxTries).append(reconnectAfterMillis).toHashCode();
+                .append(connectMaxTries).append(reconnectAfterMillis).append(connectTimeoutMillis).toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this, toStringStyle).append("passivateBorrowMinMillis", passivateBorrowMinMillis)
                 .append("interConnectDelayMillis", interConnectDelayMillis).append("connectMaxTries", connectMaxTries)
-                .append("reconnectAfterMillis", reconnectAfterMillis).toString();
+                .append("reconnectAfterMillis", reconnectAfterMillis)
+                .append("connectTimeoutMillis", connectTimeoutMillis).toString();
     }
 
     @Override
@@ -109,7 +126,7 @@ public class EndpointPoolConfiguration {
         return new EqualsBuilder().append(passivateBorrowMinMillis, rhs.passivateBorrowMinMillis)
                 .append(interConnectDelayMillis, rhs.interConnectDelayMillis)
                 .append(connectMaxTries, rhs.connectMaxTries).append(reconnectAfterMillis, rhs.reconnectAfterMillis)
-                .isEquals();
+                .append(connectTimeoutMillis, rhs.connectTimeoutMillis).isEquals();
     }
 
 }

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/pooling/ModbusSlaveConnectionFactoryImpl.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/pooling/ModbusSlaveConnectionFactoryImpl.java
@@ -93,7 +93,12 @@ public class ModbusSlaveConnectionFactoryImpl
                 if (address == null) {
                     return null;
                 }
-                TCPMasterConnection connection = new TCPMasterConnection(address, key.getPort());
+                EndpointPoolConfiguration config = endpointPoolConfigs.get(key);
+                int connectTimeoutMillis = 0;
+                if (config != null) {
+                    connectTimeoutMillis = config.getConnectTimeoutMillis();
+                }
+                TCPMasterConnection connection = new TCPMasterConnection(address, key.getPort(), connectTimeoutMillis);
                 logger.trace("Created connection {} for endpoint {}", connection, key);
                 return connection;
             }

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -935,6 +935,7 @@ ntp:hostname=ptbtime1.ptb.de
 # - reconnectAfterMillis, optional, in milliseconds, default 0
 # - interConnectDelayMillis, optional, in milliseconds, default 0
 # - connectMaxTries, optional, default 3
+# - connectTimeout, optional, in milliseconds, default 0 (=infinite or OS default)
 #
 # As a general rule, usually only host needs to be specified. Parameters other than host 
 # and port should be overridden only in cases when extreme performance is required, or when there
@@ -950,9 +951,9 @@ ntp:hostname=ptbtime1.ptb.de
 #           |                 |             |   |  (reconnectAfterMillis, in milliseconds)
 #           |                 |             |   |  | (interConnectDelayMillis, in milliseconds)
 #           |                 |             |   |  | | (connectMaxTries)
-#           |                 |             |   |  | | |
-#           |                 |             |   |  | | |
-#modbus:tcp.slave1.connection=192.168.1.100:502:60:0:0:3
+#           |                 |             |   |  | | | (connectTimeout)
+#           |                 |             |   |  | | | |
+#modbus:tcp.slave1.connection=192.168.1.100:502:60:0:0:3:100
 
 # The data type, can be "coil" "discrete" "holding" "input". See wiki for more details.
 #modbus:tcp.slave1.type=

--- a/features/openhab-addons-external/src/main/resources/conf/modbus.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/modbus.cfg
@@ -11,6 +11,7 @@
 # - reconnectAfterMillis, optional, in milliseconds, default 0
 # - interConnectDelayMillis, optional, in milliseconds, default 0
 # - connectMaxTries, optional, default 3
+# - connectTimeout, optional, in milliseconds, default 0 (=infinite or OS default)
 #
 # As a general rule, usually only host needs to be specified. Parameters other than host 
 # and port should be overridden only in cases when extreme performance is required, or when there are
@@ -26,9 +27,9 @@
 #    |                 |             |   |  (reconnectAfterMillis, in milliseconds)
 #    |                 |             |   |  | (interConnectDelayMillis, in milliseconds)
 #    |                 |             |   |  | | (connectMaxTries)
-#    |                 |             |   |  | | |
-#    |                 |             |   |  | | |
-#tcp.slave1.connection=192.168.1.100:502:60:0:0:3
+#    |                 |             |   |  | | | (connectTimeout)
+#    |                 |             |   |  | | | |
+#tcp.slave1.connection=192.168.1.100:502:60:0:0:3:100
 
 # The data type, can be "coil" "discrete" "holding" "input". See wiki for more details.
 #tcp.slave1.type=


### PR DESCRIPTION
Resolves #4595

The default connection timeout is zero which is basically matches the previous behavior (OS default or infinite).

Pre-compiled JAR available at https://github.com/ssalonen/openhab/releases/tag/modbus-timeout-pr-2016-09-07

TODO (once merged): wiki page update