### PR TITLE
[satel] Added rule action to set user code

### DIFF
--- a/bundles/action/org.openhab.action.satel/src/main/java/org/openhab/action/satel/internal/Satel.java
+++ b/bundles/action/org.openhab.action.satel/src/main/java/org/openhab/action/satel/internal/Satel.java
@@ -156,6 +156,15 @@ public class Satel {
         }
     }
 
+    @ActionDoc(text = "Overrides configured user code. It will be used for all operations that require authorization.")
+    public static void satelSetUserCode(@ParamDoc(name = "userCode", text = "user code to set") String userCode) {
+        if (SatelActionService.satelCommModule == null) {
+            logger.debug("Satel communication module not available - execution aborted!");
+        } else {
+            SatelActionService.satelCommModule.setUserCode(userCode);
+        }
+    }
+
     private static class EventDescription {
         String eventText;
         int descKind;

--- a/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/SatelCommModule.java
+++ b/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/SatelCommModule.java
@@ -47,4 +47,11 @@ public interface SatelCommModule {
      */
     String getTextEncoding();
 
+    /**
+     * Overrides user code configured in settings.
+     * 
+     * @param userCode user code to set
+     */
+    void setUserCode(String userCode);
+
 }

--- a/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelBinding.java
+++ b/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelBinding.java
@@ -313,4 +313,12 @@ public class SatelBinding extends AbstractActiveBinding<SatelBindingProvider>
         return this.satelModule.getIntegraVersion();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setUserCode(String userCode) {
+        this.userCode = userCode;
+    }
+
 }


### PR DESCRIPTION
This PR adds ability to override user code configured in settings and required for some operations (controlling objects, etc).
There is one new action `satelSetUserCode(String newUserCode)` that changes current user code in the binding.