### PR TITLE
[telegram] sendTelegramPhoto caption should be UTF-8

### DIFF
--- a/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
+++ b/bundles/action/org.openhab.action.telegram/src/main/java/org/openhab/action/telegram/internal/Telegram.java
@@ -223,7 +223,7 @@ public class Telegram {
             parts[1] = new FilePart("photo",
                     new ByteArrayPartSource(String.format("image.%s", imageType), imageFromURL));
             if (caption != null) {
-                parts[2] = new StringPart("caption", caption);
+                parts[2] = new StringPart("caption", caption, "UTF-8");
             }
             postMethod.setRequestEntity(new MultipartRequestEntity(parts, postMethod.getParams()));
 


### PR DESCRIPTION
Fixes #4647

Please try [this test JAR](https://dl.dropboxusercontent.com/u/4286376/telegram-caption-utf-8/org.openhab.action.telegram-1.9.0-SNAPSHOT.jar) and report if it works to send Unicode characters in photo captions.

Signed-off-by: John Cocula <john@cocula.com>