### PR TITLE
TCP/UDP Binding enhancement 'MQTT style'

### DIFF
--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/TCPBinding.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/TCPBinding.java
@@ -236,53 +236,40 @@ public class TCPBinding extends AbstractSocketChannelBinding<TCPBindingProvider>
     protected void configureChannel(Channel channel) {
     }
 
-    /**
-     * Splits a transformation configuration string into its two parts - the
-     * transformation type and the function/pattern to apply.
-     *
-     * @param transformation the string to split
-     * @return a string array with exactly two entries for the type and the function
-     */
-    protected String[] splitTransformationConfig(String transformation) {
-        Matcher matcher = EXTRACT_FUNCTION_PATTERN.matcher(transformation);
-
-        if (!matcher.matches()) {
-            throw new IllegalArgumentException("given transformation function '" + transformation
-                    + "' does not follow the expected pattern '<function>(<pattern>)'");
-        }
-        matcher.reset();
-
-        matcher.find();
-        String type = matcher.group(1);
-        String pattern = matcher.group(2);
-
-        return new String[] { type, pattern };
-    }
 
     protected String transformResponse(String transformation, String response) {
         String transformedResponse;
-
-        try {
-            String[] parts = splitTransformationConfig(transformation);
-            String transformationType = parts[0];
-            String transformationFunction = parts[1];
-
-            TransformationService transformationService = TransformationHelper
-                    .getTransformationService(TCPActivator.getContext(), transformationType);
-            if (transformationService != null) {
-                transformedResponse = transformationService.transform(transformationFunction, response);
-            } else {
+        Matcher matcher = EXTRACT_FUNCTION_PATTERN.matcher(transformation);
+        String transformationServiceName;
+        String transformationServiceParam;
+        
+        if (StringUtils.isEmpty(transformation) || transformation.equalsIgnoreCase("default")) {
+        	transformedResponse = response;
+        } else if (matcher.matches()) {
+            matcher.reset();
+            matcher.find();
+            transformationServiceName = matcher.group(1);
+            transformationServiceParam = matcher.group(2);
+            try {
+                TransformationService transformationService = TransformationHelper
+                        .getTransformationService(TCPActivator.getContext(), transformationServiceName);
+                if (transformationService != null) {
+                    transformedResponse = transformationService.transform(transformationServiceParam, response);
+                } else {
+                    transformedResponse = response;
+                    logger.warn("couldn't transform response because transformationService of type '{}' is unavailable",
+                            transformationType);
+                }
+            } catch (Exception te) {
+                logger.error("transformation throws exception [transformation=" + transformation + ", response=" + response
+                        + "]", te);
+    
+                // in case of an error we return the response without any
+                // transformation
                 transformedResponse = response;
-                logger.warn("couldn't transform response because transformationService of type '{}' is unavailable",
-                        transformationType);
             }
-        } catch (Exception te) {
-            logger.error("transformation throws exception [transformation=" + transformation + ", response=" + response
-                    + "]", te);
-
-            // in case of an error we return the response without any
-            // transformation
-            transformedResponse = response;
+        } else {
+            transformedResponse = transformation;
         }
 
         logger.debug("transformed response is '{}'", transformedResponse);

--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/TCPBinding.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/TCPBinding.java
@@ -258,7 +258,7 @@ public class TCPBinding extends AbstractSocketChannelBinding<TCPBindingProvider>
                 } else {
                     transformedResponse = response;
                     logger.warn("couldn't transform response because transformationService of type '{}' is unavailable",
-                            transformationType);
+                            transformationServiceName);
                 }
             } catch (Exception te) {
                 logger.error("transformation throws exception [transformation=" + transformation + ", response=" + response

--- a/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/UDPBinding.java
+++ b/bundles/binding/org.openhab.binding.tcp/src/main/java/org/openhab/binding/tcp/protocol/internal/UDPBinding.java
@@ -243,53 +243,40 @@ public class UDPBinding extends AbstractDatagramChannelBinding<UDPBindingProvide
     protected void configureChannel(DatagramChannel channel) {
     }
 
-    /**
-     * Splits a transformation configuration string into its two parts - the
-     * transformation type and the function/pattern to apply.
-     *
-     * @param transformation the string to split
-     * @return a string array with exactly two entries for the type and the function
-     */
-    protected String[] splitTransformationConfig(String transformation) {
-        Matcher matcher = EXTRACT_FUNCTION_PATTERN.matcher(transformation);
-
-        if (!matcher.matches()) {
-            throw new IllegalArgumentException("given transformation function '" + transformation
-                    + "' does not follow the expected pattern '<function>(<pattern>)'");
-        }
-        matcher.reset();
-
-        matcher.find();
-        String type = matcher.group(1);
-        String pattern = matcher.group(2);
-
-        return new String[] { type, pattern };
-    }
 
     protected String transformResponse(String transformation, String response) {
+        Matcher matcher = EXTRACT_FUNCTION_PATTERN.matcher(transformation);
         String transformedResponse;
+        String transformationServiceName;
+        String transformationServiceParam;
+        
+        if (StringUtils.isEmpty(transformation) || transformation.equalsIgnoreCase("default")) {
+        	transformedResponse = response;
+        } else if (matcher.matches()) {
+            matcher.reset();
+            matcher.find();
+            transformationServiceName = matcher.group(1);
+            transformationServiceParam = matcher.group(2);
+            try {
+                 TransformationService transformationService = TransformationHelper
+                        .getTransformationService(TCPActivator.getContext(), transformationServiceName);
+                if (transformationService != null) {
+                    transformedResponse = transformationService.transform(transformationServiceParam, response);
+                } else {
+                    transformedResponse = response;
+                    logger.warn("couldn't transform response because transformationService of type '{}' is unavailable",
+                            transformationServiceName);
+                }
+            } catch (Exception te) {
+                logger.error("transformation throws exception [transformation=" + transformation + ", response=" + response
+                        + "]", te);
 
-        try {
-            String[] parts = splitTransformationConfig(transformation);
-            String transformationType = parts[0];
-            String transformationFunction = parts[1];
-
-            TransformationService transformationService = TransformationHelper
-                    .getTransformationService(TCPActivator.getContext(), transformationType);
-            if (transformationService != null) {
-                transformedResponse = transformationService.transform(transformationFunction, response);
-            } else {
+                // in case of an error we return the response without any
+                // transformation
                 transformedResponse = response;
-                logger.warn("couldn't transform response because transformationService of type '{}' is unavailable",
-                        transformationType);
             }
-        } catch (Exception te) {
-            logger.error("transformation throws exception [transformation=" + transformation + ", response=" + response
-                    + "]", te);
-
-            // in case of an error we return the response without any
-            // transformation
-            transformedResponse = response;
+        } else {
+        	transformedResponse = transformation;
         }
 
         logger.debug("transformed response is '{}'", transformedResponse);


### PR DESCRIPTION
The TCP binding currently does not allow straight string literals to be passed as message, it can only done through MAP files or other non direct means. The MQTT binding gives more options: "default", transformation or straight strings.  This PR takes from the MQTT Binding and applies the same rules while maintaining as much as possible the current code. The private method splitTransformationConfig is removed and its functionality incorporated directly into the transformResponse method.
