### PR TITLE
[Plugwise] Improve power state switching, fix ObjectAlreadyExistsException when (re)starting binding

### DIFF
--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/CirclePlus.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/CirclePlus.java
@@ -8,9 +8,6 @@
  */
 package org.openhab.binding.plugwise.internal;
 
-import static org.quartz.JobBuilder.newJob;
-import static org.quartz.TriggerBuilder.newTrigger;
-
 import org.joda.time.DateTime;
 import org.openhab.binding.plugwise.PlugwiseCommandType;
 import org.openhab.binding.plugwise.protocol.AcknowledgeMessage;
@@ -20,16 +17,10 @@ import org.openhab.binding.plugwise.protocol.RealTimeClockGetRequestMessage;
 import org.openhab.binding.plugwise.protocol.RealTimeClockGetResponseMessage;
 import org.openhab.binding.plugwise.protocol.RoleCallRequestMessage;
 import org.openhab.binding.plugwise.protocol.RoleCallResponseMessage;
-import org.quartz.CronScheduleBuilder;
-import org.quartz.CronTrigger;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
-import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
-import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,15 +42,13 @@ public class CirclePlus extends Circle {
 
     private static final Logger logger = LoggerFactory.getLogger(CirclePlus.class);
 
-    private static final String CIRCLE_PLUS_JOB_DATA_KEY = "CirclePlus";
+    public static final String CIRCLE_PLUS_JOB_DATA_KEY = "CirclePlus";
 
     protected DateTime realtimeClock;
 
     public CirclePlus(String mac, Stick stick, String friendly) {
         super(mac, stick, friendly);
         type = DeviceType.CirclePlus;
-
-        scheduleSetCirclePlusClockJob();
     }
 
     public boolean setClock() {
@@ -70,24 +59,6 @@ public class CirclePlus extends Circle {
         ClockSetRequestMessage message = new ClockSetRequestMessage(MAC, stamp);
         stick.sendMessage(message);
         return true;
-    }
-
-    private void scheduleSetCirclePlusClockJob() {
-        JobDataMap map = new JobDataMap();
-        map.put(CIRCLE_PLUS_JOB_DATA_KEY, this);
-
-        JobDetail job = newJob(SetClockJob.class).withIdentity(MAC + "-SetCirclePlusClock", "Plugwise")
-                .usingJobData(map).build();
-
-        CronTrigger trigger = newTrigger().withIdentity(MAC + "-SetCirclePlusClock", "Plugwise").startNow()
-                .withSchedule(CronScheduleBuilder.cronSchedule("0 0 0 * * ?")).build();
-
-        try {
-            Scheduler sched = StdSchedulerFactory.getDefaultScheduler();
-            sched.scheduleJob(job, trigger);
-        } catch (SchedulerException e) {
-            logger.error("Error scheduling Circle+ setClock Quartz Job", e);
-        }
     }
 
     /**


### PR DESCRIPTION
Switching power states of Circles can sometimes takes several seconds or more. This is caused by the `sendQueue` being filled with messages of the Quartz jobs that poll Circles for their state.

Also a user may notice that just after switching a power state, the switch goes back to its previous position, only until a second later it goes back to its new position. This is caused by the old power state that was just polled by a Quartz job. This may also result in a Circle not being switched at all.

In this PR a `prioritySendQueue` is introduced for switching power states. Also when there is a pending power state change, a just received (and soon obsolete) power state is ignored. Switching should now be fast and reliable, regardless of the workload resulting from the Quartz jobs. 



Also fixed the following exception when (re)starting the binding by only starting Quartz jobs when fully initialized.

```
19:30:15.542 [ERROR] [binding.plugwise.internal.CirclePlus] - Error scheduling Circle+ setClock Quartz Job
org.quartz.ObjectAlreadyExistsException: Unable to store Job : 'Plugwise.000D6F0000122334-SetCirclePlusClock', because one already exists with this identification.
	at org.quartz.simpl.RAMJobStore.storeJob(RAMJobStore.java:279)[105:org.eclipse.smarthome.core.scheduler:0.9.0.201610080632]
	at org.quartz.simpl.RAMJobStore.storeJobAndTrigger(RAMJobStore.java:251)[105:org.eclipse.smarthome.core.scheduler:0.9.0.201610080632]
	at org.quartz.core.QuartzScheduler.scheduleJob(QuartzScheduler.java:886)[105:org.eclipse.smarthome.core.scheduler:0.9.0.201610080632]
	at org.quartz.impl.StdScheduler.scheduleJob(StdScheduler.java:249)[105:org.eclipse.smarthome.core.scheduler:0.9.0.201610080632]
	at org.openhab.binding.plugwise.internal.CirclePlus.scheduleSetCirclePlusClockJob(CirclePlus.java:87)[202:org.openhab.binding.plugwise:1.9.0.201610070111]
	at org.openhab.binding.plugwise.internal.CirclePlus.<init>(CirclePlus.java:62)[202:org.openhab.binding.plugwise:1.9.0.201610070111]
	at org.openhab.binding.plugwise.internal.PlugwiseBinding.createPlugwiseDevice(PlugwiseBinding.java:170)[202:org.openhab.binding.plugwise:1.9.0.201610070111]
	at org.openhab.binding.plugwise.internal.PlugwiseBinding.setupNonStickDevices(PlugwiseBinding.java:153)[202:org.openhab.binding.plugwise:1.9.0.201610070111]
	at org.openhab.binding.plugwise.internal.PlugwiseBinding.updated(PlugwiseBinding.java:96)[202:org.openhab.binding.plugwise:1.9.0.201610070111]
	at org.apache.felix.cm.impl.helper.ManagedServiceTracker.updated(ManagedServiceTracker.java:189)[7:org.apache.felix.configadmin:1.8.8]
	at org.apache.felix.cm.impl.helper.ManagedServiceTracker.updateService(ManagedServiceTracker.java:152)[7:org.apache.felix.configadmin:1.8.8]
	at org.apache.felix.cm.impl.helper.ManagedServiceTracker.provideConfiguration(ManagedServiceTracker.java:85)[7:org.apache.felix.configadmin:1.8.8]
	at org.apache.felix.cm.impl.ConfigurationManager$ManagedServiceUpdate.provide(ConfigurationManager.java:1444)[7:org.apache.felix.configadmin:1.8.8]
	at org.apache.felix.cm.impl.ConfigurationManager$ManagedServiceUpdate.run(ConfigurationManager.java:1400)[7:org.apache.felix.configadmin:1.8.8]
	at org.apache.felix.cm.impl.UpdateThread.run0(UpdateThread.java:143)[7:org.apache.felix.configadmin:1.8.8]
	at org.apache.felix.cm.impl.UpdateThread.run(UpdateThread.java:110)[7:org.apache.felix.configadmin:1.8.8]
	at java.lang.Thread.run(Thread.java:745)[:1.8.0_65]
```