### PR TITLE
[mios] Add support for UI7 style thermostats.

### DIFF
--- a/bundles/binding/org.openhab.binding.mios/examples/scripts/miosTransform.xslt
+++ b/bundles/binding/org.openhab.binding.mios/examples/scripts/miosTransform.xslt
@@ -104,6 +104,7 @@ String   <xsl:value-of select="$DeviceNameFixed"/>DeviceStatus "<xsl:value-of se
 <xsl:when test="@service = 'urn:upnp-org:serviceId:HVAC_UserOperatingMode1'"     >HVAC_UserOperatingMode1</xsl:when>
 <xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Cool'"   >TemperatureSetpoint1_Cool</xsl:when>
 <xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Heat'"   >TemperatureSetpoint1_Heat</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1'"        >TemperatureSetpoint1</xsl:when>
 <xsl:when test="@service = 'urn:upnp-org:serviceId:AVTransport'"                 >AVTransport</xsl:when>
 <xsl:when test="@service = 'urn:upnp-org:serviceId:RenderingControl'"            >RenderingControl</xsl:when>
 <xsl:when test="@service = 'urn:upnp-org:serviceId:DeviceProperties'"            >DeviceProperties</xsl:when>
@@ -182,6 +183,10 @@ String   <xsl:value-of select="$DeviceNameFixed"/>DeviceStatus "<xsl:value-of se
 <xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSensor1'        and @variable = 'CurrentTemperature'"  >Number</xsl:when>
 <xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Cool' and @variable = 'CurrentSetpoint'"     >Number</xsl:when>
 <xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Heat' and @variable = 'CurrentSetpoint'"     >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1'      and @variable = 'CurrentSetpoint'"     >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1'      and @variable = 'SetpointTarget'"      >Number</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1'      and @variable = 'AutoMode'"            >Integer</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:HVAC_UserOperatingMode1'   and @variable = 'AutoMode'"            >Contact</xsl:when>
 <xsl:when test="@service = 'urn:upnp-org:serviceId:RenderingControl'          and @variable = 'Volume'"              >Dimmer</xsl:when>
 <xsl:when test="@service = 'urn:upnp-org:serviceId:RenderingControl'          and @variable = 'Mute'"                >Switch</xsl:when>
 <xsl:when test="@service = 'urn:micasaverde-com:serviceId:Camera1'            and @variable = 'AutoArchiveSeconds'"  >Integer</xsl:when>
@@ -199,6 +204,8 @@ String   <xsl:value-of select="$DeviceNameFixed"/>DeviceStatus "<xsl:value-of se
 <xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'          and @variable = 'CommFailureTime'"     >DateTime</xsl:when>
 <xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'          and @variable = 'sl_BatteryAlarm'"     >Integer</xsl:when>
 <xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'          and @variable = 'PollingEnabled'"      >Integer</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'          and @variable = 'PollRatings'"         >Number</xsl:when>
+<xsl:when test="@service = 'urn:micasaverde-com:serviceId:HaDevice1'          and @variable = 'WakeupRatings'"       >Number</xsl:when>
 <xsl:when test="@service = 'urn:micasaverde-com:serviceId:SecuritySensor1'    and @variable = 'LastTrip'"            >DateTime</xsl:when>
 <xsl:when test="@service = 'urn:micasaverde-com:serviceId:SecuritySensor1'    and @variable = 'LastTripAlert'"       >DateTime</xsl:when>
 <xsl:when test="@service = 'urn:micasaverde-com:serviceId:SecuritySensor1'    and @variable = 'LastUntrip'"          >DateTime</xsl:when>
@@ -367,6 +374,7 @@ String   <xsl:value-of select="$DeviceNameFixed"/>DeviceStatus "<xsl:value-of se
 <xsl:when test="@variable='Status'          and @service = 'urn:upnp-org:serviceId:SwitchPower1'"             ></xsl:when>
 <xsl:when test="                                @service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Heat'" >Heat</xsl:when>
 <xsl:when test="                                @service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Cool'" >Cool</xsl:when>
+<xsl:when test="                                @service = 'urn:upnp-org:serviceId:TemperatureSetpoint1'"      ></xsl:when>
 <xsl:when test="                                @service = 'urn:upnp-org:serviceId:HVAC_FanOperatingMode1'"    >Fan</xsl:when>
 <xsl:when test="                                @service = 'urn:upnp-org:serviceId:HVAC_UserOperatingMode1'"   >User</xsl:when>
 <xsl:otherwise><xsl:value-of select="@id"/></xsl:otherwise>
@@ -432,6 +440,7 @@ String   <xsl:value-of select="$DeviceNameFixed"/>DeviceStatus "<xsl:value-of se
 <xsl:when test="@variable = 'sl_LockChanged'"       > Lock Changed</xsl:when>
 <xsl:when test="@variable = 'sl_BatteryAlarm'"      > Battery Alarm</xsl:when>
 <xsl:when test="@variable = 'sl_UserCode'"          > User Code</xsl:when>
+<xsl:when test="@variable = 'sl_VeryLowBattery'"    > Very Low Battery</xsl:when>
 <xsl:when test="@variable = 'Volume'"               > Volume</xsl:when>
 <xsl:when test="@variable = 'Input'"                > Input</xsl:when>
 <xsl:when test="@variable = 'Channel'"              > Channel</xsl:when>
@@ -590,13 +599,24 @@ String   <xsl:value-of select="$DeviceNameFixed"/>DeviceStatus "<xsl:value-of se
 <xsl:when test="@variable = 'Version'"              > Version</xsl:when>
 <xsl:when test="@variable = 'StartTime'"            > Start Time</xsl:when>
 <xsl:when test="@variable = 'Children'"             > Children</xsl:when>
-<xsl:when test="@variable = 'CommFailureTime'"      > Comm Failure Time</xsl:when>
+<xsl:when test="@variable = 'CommFailureTime'"      > Comms Failure Time</xsl:when>
 <xsl:when test="@variable = 'ConsecutivePollFails'" > Consecutive Poll Fails</xsl:when>
 <xsl:when test="@variable = 'InternalAlerts'"       > Internal Alerts</xsl:when>
 <xsl:when test="@variable = 'UserProfileAssociation'" > User Profile Association</xsl:when>
 <xsl:when test="@variable = 'Message'"              > Message</xsl:when>
 <xsl:when test="@variable = 'HMode'"                > House Mode</xsl:when>
 <xsl:when test="@variable = 'Unit'"                 > Unit</xsl:when>
+<xsl:when test="@variable = 'ReportMode'"           > Report Mode</xsl:when>
+<xsl:when test="@variable = 'AutoMode'"             > Auto Mode</xsl:when>
+<xsl:when test="@variable = 'PollRatings'"          > Poll Ratings</xsl:when>
+<xsl:when test="@variable = 'WakeupRatings'"        > Wakeup Ratings</xsl:when>
+<xsl:when test="@variable = 'AllSetpoints'"         > All Setpoints</xsl:when>
+<xsl:when test="@variable = 'SetpointTarget'"       > Setpoint Target</xsl:when>
+<xsl:when test="@variable = 'SupportedType'"        > Supported Type</xsl:when>
+<xsl:when test="@variable = 'CommFailureAlarm'"     > Comms Failure Alarm</xsl:when>
+<xsl:when test="@variable = 'PinCodes'"             > PIN Codes</xsl:when>
+<xsl:when test="@variable = 'NumSchedules'"         > Number of Schedules</xsl:when>
+<xsl:when test="@variable = 'KeepPinCodes'"         > Keep PIN Codes</xsl:when>
 <xsl:when test="../../@id = '1'"                    ><xsl:value-of select="concat(' ', @variable)"/></xsl:when>
 <xsl:otherwise                                      > FIXME <xsl:value-of select="@variable"/></xsl:otherwise>
 </xsl:choose>
@@ -607,6 +627,8 @@ String   <xsl:value-of select="$DeviceNameFixed"/>DeviceStatus "<xsl:value-of se
 <xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSensor1' and @variable = 'CurrentTemperature'"           > [%.1f F]</xsl:when>
 <xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Cool' and @variable = 'CurrentSetpoint'"       > [%.1f F]</xsl:when>
 <xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1_Heat' and @variable = 'CurrentSetpoint'"       > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1' and @variable = 'CurrentSetpoint'"            > [%.1f F]</xsl:when>
+<xsl:when test="@service = 'urn:upnp-org:serviceId:TemperatureSetpoint1' and @variable = 'SetpointTarget'"             > [%.1f F]</xsl:when>
 <xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'FeelsLike'"                  > [%.1f F]</xsl:when>
 <xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'HeatIndex'"                  > [%.1f F]</xsl:when>
 <xsl:when test="@service = 'urn:upnp-micasaverde-com:serviceId:Weather1' and @variable = 'DewPoint'"                   > [%.1f F]</xsl:when>

--- a/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/DeviceDefaults.properties
+++ b/bundles/binding/org.openhab.binding.mios/src/main/java/org/openhab/binding/mios/internal/config/DeviceDefaults.properties
@@ -7,6 +7,7 @@ service/urn\:upnp-org\:serviceId\:SwitchPower1/Status=command:ON|OFF,in:MAP(mios
 service/urn\:upnp-org\:serviceId\:Dimming1/LoadLevelStatus=command:MAP(miosDimmerCommand.map)
 service/urn\:upnp-org\:serviceId\:TemperatureSetpoint1_Heat/CurrentSetpoint=command:MAP(miosTStatSetpointHeatCommand.map)
 service/urn\:upnp-org\:serviceId\:TemperatureSetpoint1_Cool/CurrentSetpoint=command:MAP(miosTStatSetpointCoolCommand.map)
+service/urn\:upnp-org\:serviceId\:TemperatureSetpoint1/CurrentSetpoint=command:MAP(miosTStatSetpointCommand.map)
 service/urn\:upnp-org\:serviceId\:HVAC_UserOperatingMode1/ModeStatus=command:MAP(miosTStatModeStatusCommand.map)
 service/urn\:upnp-org\:serviceId\:HVAC_FanOperatingMode1/Mode=command:MAP(miosTStatFanOperatingModeCommand.map)
 service/urn\:upnp-org\:serviceId\:RenderingControl/Volume=command:MAP(miosUPnPRenderingControlVolumeCommand.map)

--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -135,6 +135,7 @@
                                 <artifact><file>src/main/resources/transform/miosTStatModeStatusCommand.map</file><type>map</type><classifier>mios-tstatmodestatuscommand</classifier></artifact>
                                 <artifact><file>src/main/resources/transform/miosTStatSetpointCoolCommand.map</file><type>map</type><classifier>mios-tstatsetpointcoolcommand</classifier></artifact>
                                 <artifact><file>src/main/resources/transform/miosTStatSetpointHeatCommand.map</file><type>map</type><classifier>mios-tstatsetpointheatcommand</classifier></artifact>
+                                <artifact><file>src/main/resources/transform/miosTStatSetpointCommand.map</file><type>map</type><classifier>mios-tstatsetpointcommand</classifier></artifact>
                                 <artifact><file>src/main/resources/transform/miosUPnPRenderingControlMuteCommand.map</file><type>map</type><classifier>mios-upnprenderingcontrolmutecommand</classifier></artifact>
                                 <artifact><file>src/main/resources/transform/miosUPnPRenderingControlVolumeCommand.map</file><type>map</type><classifier>mios-upnprenderingcontrolvolumecommand</classifier></artifact>
                                 <artifact><file>src/main/resources/transform/miosUPnPTransportStatePlayModeCommand.map</file><type>map</type><classifier>mios-upnptransportstateplaymodecommand</classifier></artifact>

--- a/features/openhab-addons-external/src/main/resources/transform/miosTStatSetpointCommand.map
+++ b/features/openhab-addons-external/src/main/resources/transform/miosTStatSetpointCommand.map
@@ -1,0 +1,1 @@
+_defaultCommand=urn:upnp-org:serviceId:TemperatureSetpoint1/SetCurrentSetpoint(NewCurrentSetpoint=??)

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -363,6 +363,7 @@
     <configfile finalname="${openhab.conf}/transform/miosTStatModeStatusCommand.map" override="true">mvn:${project.groupId}/openhab-addons-external/${project.version}/map/mios-tstatmodestatuscommand</configfile>
     <configfile finalname="${openhab.conf}/transform/miosTStatSetpointCoolCommand.map" override="true">mvn:${project.groupId}/openhab-addons-external/${project.version}/map/mios-tstatsetpointcoolcommand</configfile>
     <configfile finalname="${openhab.conf}/transform/miosTStatSetpointHeatCommand.map" override="true">mvn:${project.groupId}/openhab-addons-external/${project.version}/map/mios-tstatsetpointheatcommand</configfile>
+    <configfile finalname="${openhab.conf}/transform/miosTStatSetpointCommand.map" override="true">mvn:${project.groupId}/openhab-addons-external/${project.version}/map/mios-tstatsetpointcommand</configfile>
     <configfile finalname="${openhab.conf}/transform/miosUPnPRenderingControlMuteCommand.map" override="true">mvn:${project.groupId}/openhab-addons-external/${project.version}/map/mios-upnprenderingcontrolmutecommand</configfile>
     <configfile finalname="${openhab.conf}/transform/miosUPnPRenderingControlVolumeCommand.map" override="true">mvn:${project.groupId}/openhab-addons-external/${project.version}/map/mios-upnprenderingcontrolvolumecommand</configfile>
     <configfile finalname="${openhab.conf}/transform/miosUPnPTransportStatePlayModeCommand.map" override="true">mvn:${project.groupId}/openhab-addons-external/${project.version}/map/mios-upnptransportstateplaymodecommand</configfile>


### PR DESCRIPTION
UI7 of MiOS changes the way Thermostats are implemented. This change
added minimalist support for UI7 Thermostats, based upon feedback
received from the community:

* https://community.openhab.org/t/mios-binding-thermostat/14967

Signed-off-by: Mark Clark <mr.guessed@gmail.com> (github: mrguessed)