### PR TITLE
[nest] October 2016 API Update

### DIFF
--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/AbstractDevice.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/AbstractDevice.java
@@ -39,7 +39,7 @@ public abstract class AbstractDevice extends AbstractMessagePart implements Data
     }
 
     /**
-     * @return the unique thermostat identifier.
+     * @return the unique device identifier.
      */
     @JsonProperty("device_id")
     public String getDevice_id() {

--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/Structure.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/Structure.java
@@ -39,7 +39,7 @@ public class Structure extends AbstractMessagePart implements DataModelElement {
     public static enum AwayState {
         HOME("home"),
         AWAY("away"),
-        AUTO_AWAY("auto-away"),
+        AUTO_AWAY("auto-away"), // deprecated by Oct 2016 API update
         UNKNOWN("unknown");
 
         private final String state;

--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/Thermostat.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/Thermostat.java
@@ -36,7 +36,8 @@ public class Thermostat extends AbstractDevice {
         COOL("cool"),
         HEAT_COOL("heat-cool"),
         ECO("eco"),
-        OFF("off");
+        OFF("off"),
+        BLANK("");
 
         private final String mode;
 

--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/Thermostat.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/Thermostat.java
@@ -101,40 +101,6 @@ public class Thermostat extends AbstractDevice {
         }
     }
 
-    /**
-     * Possible values for time_to_target_training
-     */
-    public static enum TimeToTargetTraining {
-        TRAINING("training"),
-        READY("ready");
-
-        private final String training;
-
-        private TimeToTargetTraining(String training) {
-            this.training = training;
-        }
-
-        @JsonValue
-        public String value() {
-            return training;
-        }
-
-        @JsonCreator
-        public static TimeToTargetTraining forValue(String v) {
-            for (TimeToTargetTraining tr : TimeToTargetTraining.values()) {
-                if (tr.equals(v)) {
-                    return tr;
-                }
-            }
-            throw new IllegalArgumentException("Invalid time_to_target_training: " + v);
-        }
-
-        @Override
-        public String toString() {
-            return this.training;
-        }
-    }
-
     private Boolean can_cool;
     private Boolean can_heat;
     private Boolean is_using_emergency_heat;
@@ -174,7 +140,7 @@ public class Thermostat extends AbstractDevice {
     private String where_name;
     private Integer fan_timer_duration;
     private String time_to_target;
-    private TimeToTargetTraining time_to_target_training;
+    private String time_to_target_training;
     private HvacMode previous_hvac_mode;
 
     public Thermostat(@JsonProperty("device_id") String device_id) {
@@ -605,7 +571,7 @@ public class Thermostat extends AbstractDevice {
      *         "training" to "ready".
      */
     @JsonProperty("time_to_target_training")
-    public TimeToTargetTraining getTime_to_target_training() {
+    public String getTime_to_target_training() {
         return this.time_to_target_training;
     }
 

--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/Thermostat.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/messages/Thermostat.java
@@ -172,7 +172,7 @@ public class Thermostat extends AbstractDevice {
     private Boolean sunlight_correction_active;
     private String where_name;
     private Integer fan_timer_duration;
-    private Integer time_to_target;
+    private String time_to_target;
     private TimeToTargetTraining time_to_target_training;
     private HvacMode previous_hvac_mode;
 
@@ -590,9 +590,10 @@ public class Thermostat extends AbstractDevice {
 
     /**
      * @return The time, in minutes, that it will take for the structure to reach the target temperature.
+     *         Possible values are "~0", "<5", "~15", "~90", ">120"
      */
     @JsonProperty("time_to_target")
-    public Integer getTime_to_target() {
+    public String getTime_to_target() {
         return this.time_to_target;
     }
 


### PR DESCRIPTION
Updates to the Nest binding to match [the October 2016 API Update](https://developers.nest.com/documentation/cloud/release-notes).

Please test [this JAR](https://dl.dropboxusercontent.com/u/4286376/nest-oct-2016-api-update/org.openhab.binding.nest-1.9.0-SNAPSHOT.jar) to verify that the new features work.  You will have to update your Product at developer.nest.com to use the v6 permissions, and set up a new PIN for your account and update your nest.cfg or openhab.cfg file.  Also, the thermostat against which you are testing must be at the 5.6 or later firmware version.

Please report back here or [on the forum](https://community.openhab.org/) with your results, and thanks!