### PR TITLE
[DSMR] Add openHAB 2 feature addon

### DIFF
--- a/bundles/binding/org.openhab.binding.dsmr/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.dsmr/ESH-INF/binding/binding.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="dsmr"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
+
+    <name>DSMR Binding</name>
+    <description>The DSMR Binding obtains data from a Dutch smart meter ("Slimme meter" in Dutch) via the P1-port.</description>
+
+    <config-description>
+        <parameter name="port" type="text" required="true">
+            <label>Serial port</label>
+            <description>The DSMR serial port, e.g. "COM1" for Windows or "/dev/ttyUSB0" for Linux.</description>
+            <default>/dev/ttyUSB0</default>
+        </parameter>
+    </config-description>
+</binding:binding>

--- a/bundles/binding/org.openhab.binding.dsmr/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.dsmr/ESH-INF/binding/binding.xml
@@ -6,6 +6,7 @@
 
     <name>DSMR Binding</name>
     <description>The DSMR Binding obtains data from a Dutch smart meter ("Slimme meter" in Dutch) via the P1-port.</description>
+    <author>Marcel Volaart</author>
 
     <config-description>
         <parameter name="port" type="text" required="true">

--- a/bundles/binding/org.openhab.binding.dsmr/build.properties
+++ b/bundles/binding/org.openhab.binding.dsmr/build.properties
@@ -2,5 +2,6 @@ source.. = src/main/java/,\
            src/main/resources/
 bin.includes = META-INF/,\
                .,\
-               OSGI-INF/
+               OSGI-INF/,\
+               ESH-INF/
 output.. = target/classes/

--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -40,6 +40,7 @@
                                 <artifact><file>src/main/resources/conf/culintertechno.cfg</file><type>cfg</type><classifier>culintertechno</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/denon.cfg</file><type>cfg</type><classifier>denon</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/dmx.cfg</file><type>cfg</type><classifier>dmx</classifier></artifact>
+                                <artifact><file>src/main/resources/conf/dsmr.cfg</file><type>cfg</type><classifier>dsmr</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/ebus.cfg</file><type>cfg</type><classifier>ebus</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/ecobee.cfg</file><type>cfg</type><classifier>ecobee</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/enphaseenergy.cfg</file><type>cfg</type><classifier>enphaseenergy</classifier></artifact>

--- a/features/openhab-addons-external/src/main/resources/conf/dsmr.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/dsmr.cfg
@@ -1,0 +1,11 @@
+############################## DSMR Binding ################################
+#
+# Port of the DSMR port (mandatory, e.g. /dev/ttyUSB0)
+#port=/dev/ttyUSB0
+# Configuration of additional meters (channel 0 is used for the main electricity meter)
+#gas.channel=1
+#water.channel=2
+#heating.channel=3
+#cooling.channel=4
+#generic.channel=5
+#slaveelectricity.channel=6

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -158,6 +158,14 @@
     <configfile finalname="${openhab.conf}/services/dmx.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/dmx</configfile>
   </feature>
 
+  <feature name="openhab-binding-dsmr" description="DSMR Binding" version="${project.version}">
+    <feature>openhab-runtime-base</feature>
+    <feature>openhab-runtime-compat1x</feature>
+    <feature>openhab-transport-serial</feature>
+    <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.dsmr/${project.version}</bundle>
+    <configfile finalname="${openhab.conf}/services/dsmr.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/dsmr</configfile>
+  </feature>
+
   <feature name="openhab-binding-ebus" description="eBUS Binding" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>


### PR DESCRIPTION
The DSMR Binding works just fine with OH2 so here is the OH2 feature addon. This should make using OH2 a bit more easy for the more than 1 million households in The Netherlands that already have a smart meter installed.