### PR TITLE
Patch for compatibility with OH2:

### DIFF
--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBinding.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBinding.java
@@ -53,7 +53,7 @@ import tuwien.auto.calimero.process.ProcessListener;
  * @since 0.3.0
  *
  */
-public class KNXBinding extends AbstractBinding<KNXBindingProvider>implements ProcessListener, KNXConnectionListener {
+public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements ProcessListener, KNXConnectionListener {
 
     private static final Logger logger = LoggerFactory.getLogger(KNXBinding.class);
 
@@ -108,7 +108,7 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider>implements Pr
     @Override
     protected void internalReceiveCommand(String itemName, Command command) {
         logger.trace("Received command (item='{}', command='{}')", itemName, command.toString());
-        if (!isEcho(itemName, command)) {
+        if (!KNXConnection.getCompatibilityOH2() && !isEcho(itemName, command)) {
             writeToKNX(itemName, command);
         }
     }

--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/connection/KNXConnection.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/connection/KNXConnection.java
@@ -66,6 +66,9 @@ public class KNXConnection implements ManagedService {
     /** the KNX bus address to use as local sourceaddress in KNX bus */
     private static String sLocalSourceAddr = "0.0.0";
 
+    /** Compatibility Mode for openHAB 2 */
+    private static boolean sCompatibilityOH2 = false;
+
     /** the KNX bus address to use as local sourceaddress in KNX bus */
     private static boolean sIgnoreLocalSourceEvents = false;
 
@@ -131,7 +134,7 @@ public class KNXConnection implements ManagedService {
     /**
      * Returns the KNXNetworkLink for talking to the KNX bus.
      * The link can be null, if it has not (yet) been established successfully.
-     * 
+     *
      * @return the KNX network link
      */
     public static synchronized ProcessCommunicator getCommunicator() {
@@ -167,7 +170,7 @@ public class KNXConnection implements ManagedService {
 
     /**
      * Tries to connect either by IP or serial bus, depending on supplied config data.
-     * 
+     *
      * @return true if connection was established, false otherwise
      */
     public static synchronized boolean connect() {
@@ -320,7 +323,7 @@ public class KNXConnection implements ManagedService {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.osgi.service.cm.ManagedService#updated(java.util.Dictionary)
      */
     @Override
@@ -332,6 +335,11 @@ public class KNXConnection implements ManagedService {
             String readingBusAddrString = (String) config.get("busaddr");
             if (StringUtils.isNotBlank(readingBusAddrString)) {
                 sLocalSourceAddr = readingBusAddrString;
+            }
+
+            String compatOH2String = (String) config.get("compatibilityOH2");
+            if (StringUtils.isNotBlank(compatOH2String)) {
+                sCompatibilityOH2 = compatOH2String.equalsIgnoreCase("true");
             }
 
             String readingIgnLocEv = (String) config.get("ignorelocalevents");
@@ -465,6 +473,10 @@ public class KNXConnection implements ManagedService {
 
     public static String getLocalSourceAddr() {
         return sLocalSourceAddr;
+    }
+
+    public static boolean getCompatibilityOH2() {
+        return sCompatibilityOH2;
     }
 
     public static boolean getIgnoreLocalSourceEvents() {


### PR DESCRIPTION
see: https://github.com/openhab/openhab2-addons/issues/503#issuecomment-254763216

The compatibility Layer of OH2 sends, one event for _Command_ AND one for _Update_.
OH1 sends, one event for _Command_ OR one for _Update_.

Therefore is a new configuration switch for openHAB 2 compatibility:

```
# Compatibility Mode for openHAB 2 (optional, defaults in openHAB 1 to false)
compatibilityOH2 = true
```

Needs to be updated too, but how to do it? They're not in the repository...

```
openhab/features/openhab-addons-external/src/main/resources/conf/knx.cfg
openhab-distro/distributions/openhab-offline/target/assembly/system/org/openhab/addons/openhab-addons-external/1.9.0-SNAPSHOT/openhab-addons-external-1.9.0-SNAPSHOT-knx.cfg
```
