### PR TITLE
Bump jdbc postgressql 9.4 version to 1211 and minimal version to 1208…

### DIFF
--- a/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
+++ b/bundles/persistence/org.openhab.persistence.jdbc/java/org/openhab/persistence/jdbc/internal/JdbcConfiguration.java
@@ -291,7 +291,7 @@ public class JdbcConfiguration {
             } else if (serviceName.equals("mysql")) {
                 warn += "\tMySQL:     version >= 5.1.36 from             http://mvnrepository.com/artifact/mysql/mysql-connector-java\n";
             } else if (serviceName.equals("postgresql")) {
-                warn += "\tPostgreSQL:version >= 9.4-1201-jdbc41 from    http://mvnrepository.com/artifact/org.postgresql/postgresql\n";
+                warn += "\tPostgreSQL:version >= 9.4.1208 from    http://mvnrepository.com/artifact/org.postgresql/postgresql\n";
             } else if (serviceName.equals("sqlite")) {
                 warn += "\tSQLite:    version >= 3.8.11.2 from           http://mvnrepository.com/artifact/org.xerial/sqlite-jdbc\n";
             }

--- a/pom.xml
+++ b/pom.xml
@@ -56,16 +56,16 @@
         <maven.compiler.target>1.7</maven.compiler.target>
 
         <repo.url>https://api.bintray.com/maven/openhab/mvn/openhab</repo.url>
-		 
+
 		<!-- JDBC Databasedriver Versions -->
 		<derby.version>10.12.1.1</derby.version>
 		<h2.version>1.4.191</h2.version>
 		<hsqldb.version>2.3.3</hsqldb.version>
 		<mariadb.version>1.3.5</mariadb.version>
 		<mysql.version>5.1.38</mysql.version>
-		<postgresql.version>9.4-1206-jdbc41</postgresql.version>
+		<postgresql.version>9.4.1211</postgresql.version>
 		<sqlite.version>3.8.11.2</sqlite.version>
-		
+
     </properties>
 
     <packaging>pom</packaging>


### PR DESCRIPTION
…. These

versions do not require org.osgi.service.jdbc.DataSourceFactory and thus OSGi
Enterprise is not required.

Closes #4682.

Signed-off-by: John Holland jotihojr@gmail.com (github: jotihojr)
