### PR TITLE
[nma] Add NotifyMyAndroid actions to OH2

### DIFF
--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -83,6 +83,7 @@
                                 <artifact><file>src/main/resources/conf/networkupstools.cfg</file><type>cfg</type><classifier>networkupstools</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/nibeheatpump.cfg</file><type>cfg</type><classifier>nibeheatpump</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/nikobus.cfg</file><type>cfg</type><classifier>nikobus</classifier></artifact>
+                                <artifact><file>src/main/resources/conf/nma.cfg</file><type>cfg</type><classifier>nma</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/novelanheatpump.cfg</file><type>cfg</type><classifier>novelanheatpump</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/ntp.cfg</file><type>cfg</type><classifier>ntp</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/onewire.cfg</file><type>cfg</type><classifier>onewire</classifier></artifact>

--- a/features/openhab-addons-external/src/main/resources/conf/nma.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/nma.cfg
@@ -1,0 +1,19 @@
+# The timeout for the communication with the NMA service (optional, defaults
+# to 10000 milliseconds)
+#timeout=
+
+# If you have a developerKey from NMA you can set it here, but this is completely optional
+#developerKey=
+
+# The default API key to send messages to. API keys can be created in your account's dashboard.
+#apiKey=
+
+# The application name which NMA will show (optional, defaults to 'openHAB').
+#appName=
+
+# The priority to use for messages if not specified otherwise. Can range from
+# -2 (lowest) to 2 (highest)
+#defaultPriority=
+
+# The URL to attach to NMA messages by default if not specified otherwise. Can be left empty.
+#defaultUrl=

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -46,6 +46,13 @@
     <configfile finalname="${openhab.conf}/services/mqtt.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/mqtt</configfile>
   </feature>
 
+  <feature name="openhab-action-nma" description="NotifyMyAndroid Action" version="${project.version}">
+    <feature>openhab-runtime-base</feature>
+    <feature>openhab-runtime-compat1x</feature>
+    <bundle start-level="80">mvn:org.openhab.action/org.openhab.action.nma/${project.version}</bundle>
+    <configfile finalname="${openhab.conf}/services/nma.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/nma</configfile>
+  </feature>
+
   <feature name="openhab-action-pebble" description="Pebble Action" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>


### PR DESCRIPTION
Actions known to work via manual install [here](https://community.openhab.org/t/notify-my-droid-in-oh-2/15012).