### PR TITLE
[jointSPACE] Add the 1.9 binding to the OH2 distro

### DIFF
--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -61,6 +61,7 @@
                                 <artifact><file>src/main/resources/conf/irtrans.cfg</file><type>cfg</type><classifier>irtrans</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/jdbc.cfg</file><type>cfg</type><classifier>jdbc</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/jpa.cfg</file><type>cfg</type><classifier>jpa</classifier></artifact>
+                                <artifact><file>src/main/resources/conf/jointspace.cfg</file><type>cfg</type><classifier>jointspace</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/knx.cfg</file><type>cfg</type><classifier>knx</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/koubachi.cfg</file><type>cfg</type><classifier>koubachi</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/lgtv.cfg</file><type>cfg</type><classifier>lgtv</classifier></artifact>

--- a/features/openhab-addons-external/src/main/resources/conf/jointspace.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/jointspace.cfg
@@ -1,0 +1,14 @@
+################################# JointSpace #############################################
+#
+
+# Timeout - or 'refresh interval', in milliseconds, of the worker thread. 
+# Used for polling. 
+#refreshinterval=5000
+
+# Ip of the jointspace enabled device
+#ip = 192.168.0.100
+
+# Port of the jointspace API. Defaults to 1925
+#jointspace:port = 1925
+
+

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -313,6 +313,13 @@
     <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.irtrans/${project.version}</bundle>
     <configfile finalname="${openhab.conf}/services/irtrans.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/irtrans</configfile>
   </feature>
+  
+  <feature name="openhab-binding-jointspace" description="jointSPACE Binding" version="${project.version}">
+    <feature>openhab-runtime-base</feature>
+    <feature>openhab-runtime-compat1x</feature>
+    <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.jointspace/${project.version}</bundle>
+    <configfile finalname="${openhab.conf}/services/jointspace.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jointspace</configfile>
+  </feature>
 
   <feature name="openhab-binding-knx" description="KNX Binding" version="${project.version}">
     <feature>openhab-runtime-base</feature>


### PR DESCRIPTION
Hi 

After confirming that the current jointSPACE binding with the current snapshot of OH2 is still compatible (see #1005), I created the necessary entries and file to make it usefull as a Karaf feature for OH2
[information from here](http://docs.openhab.org/developers/development/compatibilitylayer.html)

As I do not have experience with Karaf, I hope I did not forget something.