### PR TITLE
[http] Allow all item types to receive updates

### DIFF
--- a/bundles/binding/org.openhab.binding.http/src/main/java/org/openhab/binding/http/HttpBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.http/src/main/java/org/openhab/binding/http/HttpBindingProvider.java
@@ -12,8 +12,8 @@ import java.util.List;
 import java.util.Properties;
 
 import org.openhab.core.binding.BindingProvider;
-import org.openhab.core.items.Item;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
 
 /**
  * This interface is implemented by classes that can provide mapping information
@@ -28,20 +28,12 @@ import org.openhab.core.types.Command;
 public interface HttpBindingProvider extends BindingProvider {
 
     /**
-     * Returns the Type of the Item identified by {@code itemName}
-     * 
-     * @param itemName the name of the item to find the type for
-     * @return the type of the Item identified by {@code itemName}
-     */
-    Class<? extends Item> getItemType(String itemName);
-
-    /**
      * Returns the httpMethod to use according to <code>itemName</code> and
      * <code>command</code>. Is used by HTTP-Out-Binding.
-     * 
+     *
      * @param itemName the item for which to find a httpMethod
      * @param command the openHAB command for which to find a configuration
-     * 
+     *
      * @return the matching httpMethod or <code>null</code> if no matching
      *         httpMethod could be found.
      */
@@ -50,10 +42,10 @@ public interface HttpBindingProvider extends BindingProvider {
     /**
      * Returns the url to use according to <code>itemName</code> and
      * <code>command</code>. Is used by HTTP-Out-Binding.
-     * 
+     *
      * @param itemName the item for which to find a url
      * @param command the openHAB command for which to find a configuration
-     * 
+     *
      * @return the matching url or <code>null</code> if no matching
      *         url could be found.
      */
@@ -62,10 +54,10 @@ public interface HttpBindingProvider extends BindingProvider {
     /**
      * Returns HTTP headers to use according to <code>itemName</code> and
      * <code>command</code>. Is used by HTTP-Out-Binding.
-     * 
+     *
      * @param itemName the item for which to find a url
      * @param command the openHAB command for which to find a configuration
-     * 
+     *
      * @return the matching headers or <code>null</code> if no matching
      *         headers could be found.
      */
@@ -74,10 +66,10 @@ public interface HttpBindingProvider extends BindingProvider {
     /**
      * Returns the url to use according to <code>itemName</code> and
      * <code>command</code>. Is used by HTTP-In-Binding.
-     * 
+     *
      * @param itemName the item for which to find a url
      * @param command the openHAB command for which to find a configuration
-     * 
+     *
      * @return the matching url or <code>null</code> if no matching
      *         url could be found.
      */
@@ -86,7 +78,7 @@ public interface HttpBindingProvider extends BindingProvider {
     /**
      * Returns HTTP headers to use according to <code>itemName</code>. It is
      * used by HTTP-In-Binding
-     * 
+     *
      * @param itemName the item for which to find headers
      * @return the matching HTTP headers
      */
@@ -95,10 +87,10 @@ public interface HttpBindingProvider extends BindingProvider {
     /**
      * Returns the refresh interval to use according to <code>itemName</code>.
      * Is used by HTTP-In-Binding.
-     * 
+     *
      * @param itemName the item for which to find a refresh interval
      * @param command the openHAB command for which to find a configuration
-     * 
+     *
      * @return the matching refresh interval or <code>null</code> if no matching
      *         refresh interval could be found.
      */
@@ -107,18 +99,28 @@ public interface HttpBindingProvider extends BindingProvider {
     /**
      * Returns the transformation rule to use according to <code>itemName</code>.
      * Is used by HTTP-In-Binding.
-     * 
+     *
      * @param itemName the item for which to find a transformation rule
      * @param command the openHAB command for which to find a configuration
-     * 
+     *
      * @return the matching transformation rule or <code>null</code> if no matching
      *         transformation rule could be found.
      */
     String getTransformation(String itemName);
 
     /**
+     * Returns a {@link State} that is appropriate to the item to which
+     *
+     * @param itemName the item for which to produce a {@link State)
+     * @param value the string from which to produce a {@link State)
+     *
+     * @return the State, or null if no State can be derived from the value
+     */
+    State getState(String itemName, String value);
+
+    /**
      * Returns all items which are mapped to a HTTP-In-Binding
-     * 
+     *
      * @return item which are mapped to a HTTP-In-Binding
      */
     List<String> getInBindingItemNames();

--- a/bundles/binding/org.openhab.binding.http/src/main/java/org/openhab/binding/http/HttpBindingProvider.java
+++ b/bundles/binding/org.openhab.binding.http/src/main/java/org/openhab/binding/http/HttpBindingProvider.java
@@ -109,7 +109,9 @@ public interface HttpBindingProvider extends BindingProvider {
     String getTransformation(String itemName);
 
     /**
-     * Returns a {@link State} that is appropriate to the item to which
+     * Returns a {@link State} that is one of the named item's accepted data
+     * types, parsed from <code>value</code>. If <code>value</code> cannot be parsed
+     * into an accepted data type, <code>null</code> is returned.
      *
      * @param itemName the item for which to produce a {@link State)
      * @param value the string from which to produce a {@link State)


### PR DESCRIPTION
Prior to this PR, the HTTP binding would only update items of the following types:

* Number
* Contact
* Switch
* Rollershutter
* DateTime
* String

With this PR, the HTTP binding will update items of any type (Dimmer, Location, etc.), providing the incoming or optionally transformed string can be converted into one of the item's accepted data types.

A test JAR is [here](https://dl.dropboxusercontent.com/u/4286376/http-states/org.openhab.binding.http-1.9.0-SNAPSHOT.jar).

Fixes #4759

Signed-off-by: John Cocula <john@cocula.com>