### PR TITLE
[caldav] add filter-category-any

### DIFF
--- a/bundles/binding/org.openhab.binding.caldav-personal/src/main/java/org/openhab/binding/caldav_personal/internal/CalDavBinding.java
+++ b/bundles/binding/org.openhab.binding.caldav-personal/src/main/java/org/openhab/binding/caldav_personal/internal/CalDavBinding.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * @author Robert Delbrück
  * @since 1.8.0
  */
-public class CalDavBinding extends AbstractBinding<CalDavBindingProvider>implements ManagedService, EventNotifier {
+public class CalDavBinding extends AbstractBinding<CalDavBindingProvider> implements ManagedService, EventNotifier {
 
     private static final String PARAM_HOME_IDENTIFIERS = "homeIdentifiers";
     private static final String PARAM_USED_CALENDARS = "usedCalendars";
@@ -233,8 +233,10 @@ public class CalDavBinding extends AbstractBinding<CalDavBindingProvider>impleme
         CalDavQuery query = new CalDavQuery(config.getCalendar(), DateTime.now(), Sort.ASCENDING);
         query.setFilterName(config.getFilterName());
         query.setFilterCategory(config.getFilterCategory());
+        query.setFilterCategoryMatchesAny(config.getCategoriesFiltersAny());
         return query;
     }
+
     private synchronized void updateItem(String itemName, CalDavConfig config, List<CalDavEvent> events) {
         if (config.getType() == Type.PRESENCE) {
             List<CalDavEvent> subList = getActiveEvents(events);

--- a/bundles/binding/org.openhab.binding.caldav-personal/src/main/java/org/openhab/binding/caldav_personal/internal/CalDavConfig.java
+++ b/bundles/binding/org.openhab.binding.caldav-personal/src/main/java/org/openhab/binding/caldav_personal/internal/CalDavConfig.java
@@ -46,15 +46,32 @@ public class CalDavConfig implements BindingConfig {
     private final Value value;
     private final String filterName;
     private final List<String> filterCategory = new ArrayList<String>();
-    
-    public CalDavConfig(List<String> calendar, Type type, int eventNr,
-            Value value, String filterName, List<String> filterCategory) {
+    private final boolean categoriesFiltersAny;
+
+    public CalDavConfig(List<String> calendar, Type type, int eventNr, Value value, String filterName,
+            List<String> filterCategory) {
         this.calendar = calendar;
         this.type = type;
         this.eventNr = eventNr;
         this.value = value;
         this.filterName = filterName;
         this.filterCategory.addAll(filterCategory);
+        this.categoriesFiltersAny = false;
+    }
+
+    public CalDavConfig(List<String> calendar, Type type, int eventNr, Value value, String filterName,
+            List<String> filterCategory, boolean categoriesFiltersAny) {
+        this.calendar = calendar;
+        this.type = type;
+        this.eventNr = eventNr;
+        this.value = value;
+        this.filterName = filterName;
+        this.filterCategory.addAll(filterCategory);
+        this.categoriesFiltersAny = categoriesFiltersAny;
+    }
+
+    public boolean getCategoriesFiltersAny() {
+        return categoriesFiltersAny;
     }
 
     public List<String> getCalendar() {
@@ -76,28 +93,25 @@ public class CalDavConfig implements BindingConfig {
     public String getFilterName() {
         return filterName;
     }
-    
+
     public List<String> getFilterCategory() {
         return filterCategory;
     }
 
     @Override
     public String toString() {
-        return "CalDavPresenceConfig [calendar=" + calendar + ", type=" + type
-                + ", eventNr=" + eventNr + ", value=" + value + ", filterName=" + filterName + "]";
+        return "CalDavPresenceConfig [calendar=" + calendar + ", type=" + type + ", eventNr=" + eventNr + ", value="
+                + value + ", filterName=" + filterName + "]";
     }
 
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result
-                + ((calendar == null) ? 0 : calendar.hashCode());
+        result = prime * result + ((calendar == null) ? 0 : calendar.hashCode());
         result = prime * result + eventNr;
-        result = prime * result
-                + ((filterCategory == null) ? 0 : filterCategory.hashCode());
-        result = prime * result
-                + ((filterName == null) ? 0 : filterName.hashCode());
+        result = prime * result + ((filterCategory == null) ? 0 : filterCategory.hashCode());
+        result = prime * result + ((filterName == null) ? 0 : filterName.hashCode());
         result = prime * result + ((type == null) ? 0 : type.hashCode());
         result = prime * result + ((value == null) ? 0 : value.hashCode());
         return result;
@@ -105,48 +119,56 @@ public class CalDavConfig implements BindingConfig {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         CalDavConfig other = (CalDavConfig) obj;
         if (calendar == null) {
-            if (other.calendar != null)
+            if (other.calendar != null) {
                 return false;
-        } else if (!calendar.equals(other.calendar))
+            }
+        } else if (!calendar.equals(other.calendar)) {
             return false;
-        if (eventNr != other.eventNr)
+        }
+        if (eventNr != other.eventNr) {
             return false;
+        }
         if (filterCategory == null) {
-            if (other.filterCategory != null)
+            if (other.filterCategory != null) {
                 return false;
-        } else if (!filterCategory.equals(other.filterCategory))
+            }
+        } else if (!filterCategory.equals(other.filterCategory)) {
             return false;
+        }
         if (filterName == null) {
-            if (other.filterName != null)
+            if (other.filterName != null) {
                 return false;
-        } else if (!filterName.equals(other.filterName))
+            }
+        } else if (!filterName.equals(other.filterName)) {
             return false;
-        if (type != other.type)
+        }
+        if (type != other.type) {
             return false;
-        if (value != other.value)
+        }
+        if (value != other.value) {
             return false;
+        }
         return true;
     }
 
     public int getUniqueEventListKey() {
         final int prime = 31;
         int result = 1;
-        result = prime * result
-                + ((calendar == null) ? 0 : calendar.hashCode());
-        result = prime * result
-                + ((filterCategory == null) ? 0 : filterCategory.hashCode());
-        result = prime * result
-                + ((filterName == null) ? 0 : filterName.hashCode());
+        result = prime * result + ((calendar == null) ? 0 : calendar.hashCode());
+        result = prime * result + ((filterCategory == null) ? 0 : filterCategory.hashCode());
+        result = prime * result + ((filterName == null) ? 0 : filterName.hashCode());
         return result;
     }
-    
-    
+
 }

--- a/bundles/binding/org.openhab.binding.caldav-personal/src/main/java/org/openhab/binding/caldav_personal/internal/CalDavConfig.java
+++ b/bundles/binding/org.openhab.binding.caldav-personal/src/main/java/org/openhab/binding/caldav_personal/internal/CalDavConfig.java
@@ -9,10 +9,8 @@
 package org.openhab.binding.caldav_personal.internal;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.lang.ArrayUtils;
 import org.openhab.core.binding.BindingConfig;
 
 /**
@@ -101,7 +99,7 @@ public class CalDavConfig implements BindingConfig {
     @Override
     public String toString() {
         return "CalDavPresenceConfig [calendar=" + calendar + ", type=" + type + ", eventNr=" + eventNr + ", value="
-                + value + ", filterName=" + filterName + "]";
+                + value + ", filterName=" + filterName + ", categoriesFiltersAny=" + categoriesFiltersAny + "]";
     }
 
     @Override
@@ -114,6 +112,7 @@ public class CalDavConfig implements BindingConfig {
         result = prime * result + ((filterName == null) ? 0 : filterName.hashCode());
         result = prime * result + ((type == null) ? 0 : type.hashCode());
         result = prime * result + ((value == null) ? 0 : value.hashCode());
+        result = prime * result + Boolean.hashCode(categoriesFiltersAny);
         return result;
     }
 
@@ -159,6 +158,9 @@ public class CalDavConfig implements BindingConfig {
         if (value != other.value) {
             return false;
         }
+        if (categoriesFiltersAny != other.categoriesFiltersAny) {
+            return false;
+        }
         return true;
     }
 
@@ -168,6 +170,7 @@ public class CalDavConfig implements BindingConfig {
         result = prime * result + ((calendar == null) ? 0 : calendar.hashCode());
         result = prime * result + ((filterCategory == null) ? 0 : filterCategory.hashCode());
         result = prime * result + ((filterName == null) ? 0 : filterName.hashCode());
+        result = prime * result + Boolean.hashCode(categoriesFiltersAny);
         return result;
     }
 

--- a/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/CalDavQuery.java
+++ b/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/CalDavQuery.java
@@ -27,6 +27,7 @@ public class CalDavQuery {
     private Sort sort;
     private String filterName;
     private List<String> filterCategory;
+    private boolean filterCategoryMatchesAny = false;
 
     public CalDavQuery() {
         super();
@@ -90,6 +91,14 @@ public class CalDavQuery {
 
     public void setSort(Sort sort) {
         this.sort = sort;
+    }
+
+    public void setFilterCategoryMatchesAny(boolean filterCategoryMatchesAny) {
+        this.filterCategoryMatchesAny = filterCategoryMatchesAny;
+    }
+
+    public boolean getFilterCategoryMatchesAny() {
+        return filterCategoryMatchesAny;
     }
 
     public String getFilterName() {

--- a/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/internal/CalDavLoaderImpl.java
+++ b/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/internal/CalDavLoaderImpl.java
@@ -518,45 +518,38 @@ public class CalDavLoaderImpl extends AbstractActiveService implements ManagedSe
                             } else {
                                 log.trace("processing event category");
                                 boolean eventCategoriesMatchFilterCategories = false;
-                                switch (Boolean.toString(query.getFilterCategoryMatchesAny())) {
-                                    case "false":
-                                        log.trace("filter-category encountered");
-                                        eventCategoriesMatchFilterCategories = calDavEvent.getCategoryList()
-                                                .containsAll(query.getFilterCategory());
-                                        break;
-
-                                    case "true":
-                                        log.trace("filter-category-any encountered");
-                                        int filterCategoriesIndex = 0;
-                                        List<String> filterCategories = query.getFilterCategory();
-                                        List<String> eventCategories = calDavEvent.getCategoryList();
-                                        log.trace("comparing filter '{}' to event categories '{}' from event {}",
-                                                filterCategories, eventCategories, calDavEvent.getId());
-                                        // browse filter categories, which are not null
+                                if (query.getFilterCategoryMatchesAny()) {
+                                    log.trace("filter-category-any encountered");
+                                    int filterCategoriesIndex = 0;
+                                    List<String> filterCategories = query.getFilterCategory();
+                                    List<String> eventCategories = calDavEvent.getCategoryList();
+                                    log.trace("comparing filter '{}' to event categories '{}' from event {}",
+                                            filterCategories, eventCategories, calDavEvent.getId());
+                                    // browse filter categories, which are not null
+                                    while (eventCategoriesMatchFilterCategories == false
+                                            && filterCategoriesIndex < filterCategories.size()) {
+                                        int eventCategoriesIndex = 0;
+                                        // browse event categories, which can be null
                                         while (eventCategoriesMatchFilterCategories == false
-                                                && filterCategoriesIndex < filterCategories.size()) {
-                                            int eventCategoriesIndex = 0;
-                                            // browse event categories, which can be null
-                                            while (eventCategoriesMatchFilterCategories == false
-                                                    && eventCategoriesIndex < eventCategories.size()) {
-                                                if (eventCategories.get(eventCategoriesIndex).equalsIgnoreCase(
-                                                        filterCategories.get(filterCategoriesIndex))) {
-                                                    log.debug("filter category {} matches event category {}",
-                                                            filterCategories.get(filterCategoriesIndex),
-                                                            eventCategories.get(eventCategoriesIndex));
-                                                    eventCategoriesMatchFilterCategories = true;
-                                                }
-                                                eventCategoriesIndex++;
+                                                && eventCategoriesIndex < eventCategories.size()) {
+                                            if (eventCategories.get(eventCategoriesIndex)
+                                                    .equalsIgnoreCase(filterCategories.get(filterCategoriesIndex))) {
+                                                log.debug("filter category {} matches event category {}",
+                                                        filterCategories.get(filterCategoriesIndex),
+                                                        eventCategories.get(eventCategoriesIndex));
+                                                eventCategoriesMatchFilterCategories = true;
                                             }
-
-                                            filterCategoriesIndex++;
+                                            eventCategoriesIndex++;
                                         }
-                                        break;
 
-                                    default:
-
-                                        break;
+                                        filterCategoriesIndex++;
+                                    }
+                                } else {
+                                    log.trace("filter-category encountered");
+                                    eventCategoriesMatchFilterCategories = calDavEvent.getCategoryList()
+                                            .containsAll(query.getFilterCategory());
                                 }
+
                                 if (!eventCategoriesMatchFilterCategories) {
                                     continue;
                                 }

--- a/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/internal/CalDavLoaderImpl.java
+++ b/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/internal/CalDavLoaderImpl.java
@@ -27,9 +27,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 
-import net.fortuna.ical4j.model.Calendar;
-import net.fortuna.ical4j.util.CompatibilityHints;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.joda.time.DateTimeZone;
 import org.openhab.core.service.AbstractActiveService;
@@ -61,6 +58,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.sardine.Sardine;
+
+import net.fortuna.ical4j.model.Calendar;
+import net.fortuna.ical4j.util.CompatibilityHints;
 
 /**
  * Loads all events from the configured calDAV servers. This is done with an
@@ -120,7 +120,7 @@ public class CalDavLoaderImpl extends AbstractActiveService implements ManagedSe
     }
 
     private void removeAllJobs() throws SchedulerException {
-        if(scheduler!=null) {
+        if (scheduler != null) {
             scheduler.deleteJobs(new ArrayList<JobKey>(scheduler.getJobKeys(jobGroupEquals(JOB_NAME_EVENT_RELOADER))));
             scheduler.deleteJobs(new ArrayList<JobKey>(scheduler.getJobKeys(jobGroupEquals(JOB_NAME_EVENT_START))));
             scheduler.deleteJobs(new ArrayList<JobKey>(scheduler.getJobKeys(jobGroupEquals(JOB_NAME_EVENT_END))));
@@ -186,15 +186,11 @@ public class CalDavLoaderImpl extends AbstractActiveService implements ManagedSe
                 } else if (paramKey.equals(PROP_PRELOAD_TIME)) {
                     calDavConfig.setPreloadMinutes(Integer.parseInt(value));
                 } else if (paramKey.equals(PROP_HISTORIC_LOAD_TIME)) {
-                    calDavConfig
-                            .setHistoricLoadMinutes(Integer.parseInt(value));
+                    calDavConfig.setHistoricLoadMinutes(Integer.parseInt(value));
                 } else if (paramKey.equals(PROP_LAST_MODIFIED_TIMESTAMP_VALID)) {
-                    calDavConfig
-                            .setLastModifiedFileTimeStampValid(BooleanUtils.toBoolean(value));
-                } else if (paramKey
-                        .equals(PROP_DISABLE_CERTIFICATE_VERIFICATION)) {
-                    calDavConfig.setDisableCertificateVerification(BooleanUtils
-                            .toBoolean(value));
+                    calDavConfig.setLastModifiedFileTimeStampValid(BooleanUtils.toBoolean(value));
+                } else if (paramKey.equals(PROP_DISABLE_CERTIFICATE_VERIFICATION)) {
+                    calDavConfig.setDisableCertificateVerification(BooleanUtils.toBoolean(value));
                 } else if (paramKey.equals(PROP_CHARSET)) {
                     try {
                         Charset.forName(value);
@@ -515,13 +511,58 @@ public class CalDavLoaderImpl extends AbstractActiveService implements ManagedSe
                             }
                         }
                         if (query.getFilterCategory() != null) {
+                            log.trace("processing filter category");
                             if (calDavEvent.getCategoryList() == null) {
+                                log.trace("not found event category for event {}", calDavEvent.getId());
                                 continue;
                             } else {
-                                if (!calDavEvent.getCategoryList().containsAll(query.getFilterCategory())) {
+                                log.trace("processing event category");
+                                boolean eventCategoriesMatchFilterCategories = false;
+                                switch (Boolean.toString(query.getFilterCategoryMatchesAny())) {
+                                    case "false":
+                                        log.trace("filter-category encountered");
+                                        eventCategoriesMatchFilterCategories = calDavEvent.getCategoryList()
+                                                .containsAll(query.getFilterCategory());
+                                        break;
+
+                                    case "true":
+                                        log.trace("filter-category-any encountered");
+                                        int filterCategoriesIndex = 0;
+                                        List<String> filterCategories = query.getFilterCategory();
+                                        List<String> eventCategories = calDavEvent.getCategoryList();
+                                        log.trace("comparing filter '{}' to event categories '{}' from event {}",
+                                                filterCategories, eventCategories, calDavEvent.getId());
+                                        // browse filter categories, which are not null
+                                        while (eventCategoriesMatchFilterCategories == false
+                                                && filterCategoriesIndex < filterCategories.size()) {
+                                            int eventCategoriesIndex = 0;
+                                            // browse event categories, which can be null
+                                            while (eventCategoriesMatchFilterCategories == false
+                                                    && eventCategoriesIndex < eventCategories.size()) {
+                                                if (eventCategories.get(eventCategoriesIndex).equalsIgnoreCase(
+                                                        filterCategories.get(filterCategoriesIndex))) {
+                                                    log.debug("filter category {} matches event category {}",
+                                                            filterCategories.get(filterCategoriesIndex),
+                                                            eventCategories.get(eventCategoriesIndex));
+                                                    eventCategoriesMatchFilterCategories = true;
+                                                }
+                                                eventCategoriesIndex++;
+                                            }
+
+                                            filterCategoriesIndex++;
+                                        }
+                                        break;
+
+                                    default:
+
+                                        break;
+                                }
+                                if (!eventCategoriesMatchFilterCategories) {
                                     continue;
                                 }
                             }
+                        } else {
+                            log.trace("not found any filter category");
                         }
                         eventList.add(calDavEvent);
                     }


### PR DESCRIPTION

rebased on 2016/12/03 and squashed my commits into 1.

added a "filter-category-any" configuration that will allow a item
configuration to have filters that match any of an event filter. Allows
an event to command a GROUP, and have an "awareness" on all individual
items of the group that an event concerning them will happen

example : 
String cuisine_NextEventName1 "cuisine proch. evt. 1 [%s]" <calendar> {
caldavPersonal="calendar:chauffagecmd type:UPCOMING eventNr:1 value:NAME
filter-category-any:'cuisine,salon,rezdechaussee'"}
String cuisine_NextEventName2 "cuisine proch. evt. 2 [%s]" <calendar> {
caldavPersonal="calendar:chauffagecmd type:UPCOMING eventNr:2 value:NAME
filter-category-any:'cuisine,salon,rezdechaussee'"}
String cuisine_NextEventName3 "cuisine proch. evt. 3 [%s]" <calendar> {
caldavPersonal="calendar:chauffagecmd type:UPCOMING eventNr:3 value:NAME
filter-category-any:'cuisine,salon,rezdechaussee'"}


will match all 3 events below :
event1 with category "cuisine"
event2 with category "salon"
event3 with categories "salon,cuisine,rezdechaussee"