### PR TITLE
[dmx] fixes #4774

### DIFF
--- a/bundles/binding/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/core/DmxController.java
+++ b/bundles/binding/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/core/DmxController.java
@@ -35,7 +35,8 @@ public class DmxController implements DmxService, ManagedService {
     private static Logger logger = LoggerFactory.getLogger(DmxController.class);
 
     private static int TRANSMIT_FREQUENCY_MS = 35;
-    private DmxRepeatMode repeatMode = DmxTransmitter.DmxRepeatMode.ALWAYS; // default is send every update
+    private DmxTransmitter.DmxRepeatMode repeatMode = DmxTransmitter.DmxRepeatMode.ALWAYS; // default is send every
+                                                                                           // update
 
     /** Thread in which the DMX transmitter is running **/
     private Timer transmitterTimer;
@@ -301,14 +302,14 @@ public class DmxController implements DmxService, ManagedService {
             // refresh timeout (i.e. interval between transmits if nothing changed)
             String configuredRepeatMode = ((String) config.get("repeatMode"));
             if (StringUtils.isNotBlank(configuredRepeatMode)) {
-                repeatMode = DmxTransmitter.DmxRepeatMode(configuredRepeatMode);
-                if (repeatMode==null) {
+                repeatMode = DmxTransmitter.DmxRepeatMode.fromString(configuredRepeatMode);
+                if (repeatMode == null) {
                     repeatMode = DmxTransmitter.DmxRepeatMode.ALWAYS;
                     logger.error("repeatMode {} not recognized, set to {}", configuredRepeatMode, repeatMode);
                 } else {
                     logger.debug("repeatMode set to {}", repeatMode.toString());
                 }
-                
+
                 if (transmitter != null) {
                     transmitter.setRepeatMode(repeatMode);
                 }

--- a/bundles/binding/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/core/DmxController.java
+++ b/bundles/binding/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/core/DmxController.java
@@ -35,7 +35,7 @@ public class DmxController implements DmxService, ManagedService {
     private static Logger logger = LoggerFactory.getLogger(DmxController.class);
 
     private static int TRANSMIT_FREQUENCY_MS = 35;
-    private int repeatMode = DmxTransmitter.REPEAT_MODE_ALWAYS; // default is send every update
+    private DmxRepeatMode repeatMode = DmxTransmitter.DmxRepeatMode.ALWAYS; // default is send every update
 
     /** Thread in which the DMX transmitter is running **/
     private Timer transmitterTimer;
@@ -299,21 +299,16 @@ public class DmxController implements DmxService, ManagedService {
                 logger.debug("Setting connection from config: {}", connectionString);
             }
             // refresh timeout (i.e. interval between transmits if nothing changed)
-            String configuredRepeatMode = ((String) config.get("repeatMode")).toLowerCase();
+            String configuredRepeatMode = ((String) config.get("repeatMode"));
             if (StringUtils.isNotBlank(configuredRepeatMode)) {
-                if (configuredRepeatMode.matches("always")) {
-                    repeatMode = DmxTransmitter.REPEAT_MODE_ALWAYS;
-                    logger.debug("repeatMode set to always");
-                } else if (configuredRepeatMode.matches("never")) {
-                    repeatMode = DmxTransmitter.REPEAT_MODE_NEVER;
-                    logger.debug("repeatMode set to never");
-                } else if (configuredRepeatMode.matches("reduced")) {
-                    repeatMode = DmxTransmitter.REPEAT_MODE_REDUCED;
-                    logger.debug("repeatMode set to reduced");
+                repeatMode = DmxTransmitter.DmxRepeatMode(configuredRepeatMode);
+                if (repeatMode==null) {
+                    repeatMode = DmxTransmitter.DmxRepeatMode.ALWAYS;
+                    logger.error("repeatMode {} not recognized, set to {}", configuredRepeatMode, repeatMode);
                 } else {
-                    repeatMode = DmxTransmitter.REPEAT_MODE_ALWAYS;
-                    logger.warn("repeatMode not recognized, set to default 'always'");
+                    logger.debug("repeatMode set to {}", repeatMode.toString());
                 }
+                
                 if (transmitter != null) {
                     transmitter.setRepeatMode(repeatMode);
                 }

--- a/bundles/binding/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/core/DmxTransmitter.java
+++ b/bundles/binding/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/core/DmxTransmitter.java
@@ -31,10 +31,33 @@ public final class DmxTransmitter extends TimerTask {
     private static final int REPEAT_INTERVAL = 750;
     private static final int REPEAT_COUNT = 3;
 
-    public static final int REPEAT_MODE_ALWAYS = 0;
-    public static final int REPEAT_MODE_NEVER = 1;
-    public static final int REPEAT_MODE_REDUCED = 2;
+    public enum DmxRepeatMode {
+        ALWAYS('always'),
+        NEVER('never'),
+        REDUCED('reduced')
+        
+        private String repeatMode;
 
+        DmxRepeatMode(String repeatMode) {
+          this.repeatMode = repeatMode;
+        }
+        
+        public String toString() {
+            return this.repeatMode;
+        }
+        
+        public static DmxRepeatMode fromString(String repeatMode) {
+            if (repeatMode != null) {
+              for (DmxRepeatMode mode : DmxRepeatMode.values()) {
+                if (repeatMode.equalsIgnoreCase(mode.repeatMode)) {
+                  return mode;
+                }
+              }
+            }
+            return null;
+          }
+    }
+    
     private static Logger logger = LoggerFactory.getLogger(DmxTransmitter.class);
 
     private DmxUniverse universe = new DmxUniverse();
@@ -42,7 +65,7 @@ public final class DmxTransmitter extends TimerTask {
     private DmxService service;
 
     private boolean running;
-    private int repeatMode = 0;
+    private DmxRepeatMode repeatMode = DmxRepeatMode.ALWAYS;
 
     private boolean suspended;
 
@@ -78,11 +101,11 @@ public final class DmxTransmitter extends TimerTask {
                     universe.notifyStatusListeners();
                     lastTransmit = now;
                     packetRepeatCount = 0;
-                } else if (repeatMode == REPEAT_MODE_ALWAYS) {
+                } else if (repeatMode == DmxRepeatMode.ALWAYS) {
                     logger.trace("repeat mode always, sending DMX only");
                     conn.sendDmx(b);
                     lastTransmit = now;
-                } else if ((repeatMode == REPEAT_MODE_REDUCED)
+                } else if ((repeatMode == DmxRepeatMode.REDUCED)
                         && ((packetRepeatCount < REPEAT_COUNT) || ((now - lastTransmit) > REPEAT_INTERVAL))) {
                     logger.trace("output needs refresh, sending DMX only");
                     conn.sendDmx(b);
@@ -124,7 +147,7 @@ public final class DmxTransmitter extends TimerTask {
      * @param refreshInterval
      *            interval in ms (if output did not change)
      */
-    public void setRepeatMode(int repeatMode) {
+    public void setRepeatMode(DmxRepeatMode repeatMode) {
         this.repeatMode = repeatMode;
     }
 

--- a/bundles/binding/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/core/DmxTransmitter.java
+++ b/bundles/binding/org.openhab.binding.dmx/src/main/java/org/openhab/binding/dmx/internal/core/DmxTransmitter.java
@@ -32,32 +32,33 @@ public final class DmxTransmitter extends TimerTask {
     private static final int REPEAT_COUNT = 3;
 
     public enum DmxRepeatMode {
-        ALWAYS('always'),
-        NEVER('never'),
-        REDUCED('reduced')
-        
+        ALWAYS("always"),
+        NEVER("never"),
+        REDUCED("reduced");
+
         private String repeatMode;
 
         DmxRepeatMode(String repeatMode) {
-          this.repeatMode = repeatMode;
+            this.repeatMode = repeatMode;
         }
-        
+
+        @Override
         public String toString() {
             return this.repeatMode;
         }
-        
+
         public static DmxRepeatMode fromString(String repeatMode) {
             if (repeatMode != null) {
-              for (DmxRepeatMode mode : DmxRepeatMode.values()) {
-                if (repeatMode.equalsIgnoreCase(mode.repeatMode)) {
-                  return mode;
+                for (DmxRepeatMode mode : DmxRepeatMode.values()) {
+                    if (repeatMode.equalsIgnoreCase(mode.repeatMode)) {
+                        return mode;
+                    }
                 }
-              }
             }
             return null;
-          }
+        }
     }
-    
+
     private static Logger logger = LoggerFactory.getLogger(DmxTransmitter.class);
 
     private DmxUniverse universe = new DmxUniverse();

--- a/distribution/openhabhome/configurations/openhab_default.cfg
+++ b/distribution/openhabhome/configurations/openhab_default.cfg
@@ -1,4 +1,4 @@
-# This is the default configuration file, which comes with every openHAB distribution.
+﻿# This is the default configuration file, which comes with every openHAB distribution.
 # You should do a copy of it with the name 'openhab.cfg' and configure your personal
 # settings in there. This way you can be sure that they are not overwritten, if you
 # update openHAB one day.
@@ -1053,6 +1053,13 @@ ntp:hostname=ptbtime1.ptb.de
 # 'localhost:9010' or 'localhost:9020' depending on the choosen connection type)
 #dmx:connection=
 
+# Standard DMX-512A (E1.11) uses continous transmission (option "always", default value). 
+# Some DMX protocols (sACN/E1.31, ArtNET) allow suppressing packet transmission for
+# a short period of time (800-1000ms) to reduce network load (option "reduced").
+# Previous versions of the DMX binding did not repeat unchanged packets at all. While
+# this is not  in compliance with any standard the option "never" is included for
+# backward compatibilty.
+#dmx:repeatMode=always
 ############################### Philips Hue Binding ###################################
 #
 # IP address of Hue Bridge (optional, default is auto-discovery)


### PR DESCRIPTION
Adds configurable DMX transmit refresh. The "refresh" configuration option defaults to -1 (never refresh), which is compatible with the current implementation. A value of 0 would refresh every 35ms, another value would transmit data if it has been changed or the last transmission is more than (value) ms in the past.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>