### PR TITLE
Waterkotte Ecotouch heatpump binding for OH2

### DIFF
--- a/bundles/binding/org.openhab.binding.ecotouch/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.ecotouch/ESH-INF/binding/binding.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="ecotouch"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
+
+    <name>Waterkotte EcoTouch Binding</name>
+    <description>This is the binding for the Waterkotte EcoTouch heatpump.</description>
+    <author>Sebastian Held</author>
+
+    <config-description>
+        <parameter name="refresh" type="integer">
+            <label>Refresh interval (ms)</label>
+            <description>Data refresh interval in ms.</description>
+            <default>60000</default>
+        </parameter>
+        <parameter name="ip" type="text">
+            <label>IP address</label>
+            <description>The IP address of the Waterkotte EcoTouch display unit.</description>
+            <default></default>
+        </parameter>
+        <parameter name="username" type="text">
+            <label>Username</label>
+            <description>Username of the display unit.</description>
+            <default>admin</default>
+        </parameter>
+        <parameter name="password" type="text">
+            <label>Password</label>
+            <description>Password of the display unit.</description>
+            <default>wtkadmin</default>
+        </parameter>
+    </config-description>
+
+</binding:binding>

--- a/bundles/binding/org.openhab.binding.ecotouch/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.ecotouch/ESH-INF/binding/binding.xml
@@ -7,6 +7,7 @@
     <name>Waterkotte EcoTouch Binding</name>
     <description>This is the binding for the Waterkotte EcoTouch heatpump.</description>
     <author>Sebastian Held</author>
+    <service-id>org.openhab.ecotouch</service-id>
 
     <config-description>
         <parameter name="refresh" type="integer">

--- a/bundles/binding/org.openhab.binding.ecotouch/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.ecotouch/ESH-INF/binding/binding.xml
@@ -28,6 +28,7 @@
             <label>Password</label>
             <description>Password of the display unit.</description>
             <default>wtkadmin</default>
+            <context>password</context>
         </parameter>
     </config-description>
 

--- a/bundles/binding/org.openhab.binding.ecotouch/build.properties
+++ b/bundles/binding/org.openhab.binding.ecotouch/build.properties
@@ -2,5 +2,6 @@ source.. = src/main/java/,\
            src/main/resources/
 bin.includes = META-INF/,\
                .,\
-               OSGI-INF/
+               OSGI-INF/,\
+               ESH-INF/
 output.. = target/classes/

--- a/bundles/binding/org.openhab.binding.ecotouch/src/main/java/org/openhab/binding/ecotouch/EcoTouchTags.java
+++ b/bundles/binding/org.openhab.binding.ecotouch/src/main/java/org/openhab/binding/ecotouch/EcoTouchTags.java
@@ -380,6 +380,24 @@ public enum EcoTouchTags {
         }
     },
 
+    // German: Hysterese Heizung
+    TYPE_HYSTERESIS_HEATING {
+        {
+            command = "hysteresis_heating";
+            itemClass = NumberItem.class;
+            tagName = "A61";
+        }
+    },
+
+    // German: Außentemperatur gemittelt über 1h (scheinbar identisch zu A2)
+    TYPE_TEMPERATURE2_OUTSIDE_1H {
+        {
+            command = "temperature2_outside_1h";
+            itemClass = NumberItem.class;
+            tagName = "A90";
+        }
+    },
+
     // German: Heizkurve - nviNormAussen
     TYPE_NVINORMAUSSEN {
         {
@@ -425,10 +443,10 @@ public enum EcoTouchTags {
         }
     },
 
-    // German: undokumentiert: Anzeige Heizkreis-Temp Ist (??)
-    TYPE_DSP_HEAT_CURRENT {
+    // German: undokumentiert: Heizkreis Soll-Temp bei 0° Aussen
+    TYPE_TEMP_SET_0DEG {
         {
-            command = "heatTempCurrent";
+            command = "tempSet0Deg";
             itemClass = NumberItem.class;
             tagName = "A97";
         }
@@ -449,6 +467,42 @@ public enum EcoTouchTags {
             command = "nviSollKuehlen";
             itemClass = NumberItem.class;
             tagName = "A109";
+        }
+    },
+
+    // German: Temperaturveränderung Heizkreis bei PV-Ertrag
+    TYPE_TEMPCHANGE_HEATING_PV {
+        {
+            command = "tempchange_heating_pv";
+            itemClass = NumberItem.class;
+            tagName = "A682";
+        }
+    },
+
+    // German: Temperaturveränderung Kühlkreis bei PV-Ertrag
+    TYPE_TEMPCHANGE_COOLING_PV {
+        {
+            command = "tempchange_cooling_pv";
+            itemClass = NumberItem.class;
+            tagName = "A683";
+        }
+    },
+
+    // German: Temperaturveränderung Warmwasser bei PV-Ertrag
+    TYPE_TEMPCHANGE_WARMWATER_PV {
+        {
+            command = "tempchange_warmwater_pv";
+            itemClass = NumberItem.class;
+            tagName = "A684";
+        }
+    },
+
+    // German: Temperaturveränderung Pool bei PV-Ertrag
+    TYPE_TEMPCHANGE_POOL_PV {
+        {
+            command = "tempchange_pool_pv";
+            itemClass = NumberItem.class;
+            tagName = "A685";
         }
     },
 
@@ -624,6 +678,16 @@ public enum EcoTouchTags {
         }
     },
 
+    // German: undokumentiert: vermutlich Betriebsmodus PV 0=Aus, 1=Auto, 2=Ein
+    TYPE_ENABLE_PV {
+        {
+            command = "enable_pv";
+            itemClass = NumberItem.class;
+            tagName = "I41";
+            type = Type.Word;
+        }
+    },
+
     // German: Status der Wärmepumpenkomponenten
     TYPE_STATE {
         {
@@ -783,6 +847,16 @@ public enum EcoTouchTags {
             command = "interruptions";
             itemClass = NumberItem.class;
             tagName = "I53";
+            type = Type.Word;
+        }
+    },
+
+    // German: Serviceebene (0: normal, 1: service)
+    TYPE_STATE_SERVICE {
+        {
+            command = "state_service";
+            itemClass = NumberItem.class;
+            tagName = "I135";
             type = Type.Word;
         }
     },

--- a/bundles/binding/org.openhab.binding.ecotouch/src/main/java/org/openhab/binding/ecotouch/EcoTouchTags.java
+++ b/bundles/binding/org.openhab.binding.ecotouch/src/main/java/org/openhab/binding/ecotouch/EcoTouchTags.java
@@ -353,7 +353,34 @@ public enum EcoTouchTags {
         }
     },
 
-    // German: nviNormAussen
+    // German: % Heizungsumwälzpumpe
+    TYPE_PERCENT_HEAT_CIRC_PUMP {
+        {
+            command = "percent_heat_circ_pump";
+            itemClass = NumberItem.class;
+            tagName = "A51";
+        }
+    },
+
+    // German: % Quellenpumpe
+    TYPE_PERCENT_SOURCE_PUMP {
+        {
+            command = "percent_source_pump";
+            itemClass = NumberItem.class;
+            tagName = "A52";
+        }
+    },
+
+    // German: % Leistung Verdichter
+    TYPE_PERCENT_COMPRESSOR {
+        {
+            command = "percent_compressor";
+            itemClass = NumberItem.class;
+            tagName = "A58";
+        }
+    },
+
+    // German: Heizkurve - nviNormAussen
     TYPE_NVINORMAUSSEN {
         {
             command = "nviNormAussen";
@@ -362,7 +389,7 @@ public enum EcoTouchTags {
         }
     },
 
-    // German: nviHeizkreisNorm
+    // German: Heizkurve - nviHeizkreisNorm
     TYPE_NVIHEIZKREISNORM {
         {
             command = "nviHeizkreisNorm";
@@ -371,7 +398,7 @@ public enum EcoTouchTags {
         }
     },
 
-    // German: nviTHeizgrenze
+    // German: Heizkurve - nviTHeizgrenze
     TYPE_NVITHEIZGRENZE {
         {
             command = "nviTHeizgrenze";
@@ -380,12 +407,130 @@ public enum EcoTouchTags {
         }
     },
 
-    // German: nviTHeizgrenzeSoll
+    // German: Heizkurve - nviTHeizgrenzeSoll
     TYPE_NVITHEIZGRENZESOLL {
         {
             command = "nviTHeizgrenzeSoll";
             itemClass = NumberItem.class;
             tagName = "A94";
+        }
+    },
+
+    // German: undokumentiert: Heizkurve max. VL-Temp (??)
+    TYPE_MAX_VL_TEMP {
+        {
+            command = "maxVLTemp";
+            itemClass = NumberItem.class;
+            tagName = "A95";
+        }
+    },
+
+    // German: undokumentiert: Anzeige Heizkreis-Temp Ist (??)
+    TYPE_DSP_HEAT_CURRENT {
+        {
+            command = "heatTempCurrent";
+            itemClass = NumberItem.class;
+            tagName = "A97";
+        }
+    },
+
+    // German: undokumentiert: Kühlen Einschalt-Temp. Aussentemp (??)
+    TYPE_COOLENABLETEMP {
+        {
+            command = "coolEnableTemp";
+            itemClass = NumberItem.class;
+            tagName = "A108";
+        }
+    },
+
+    // German: Heizkurve - nviSollKuehlen
+    TYPE_NVITSOLLKUEHLEN {
+        {
+            command = "nviSollKuehlen";
+            itemClass = NumberItem.class;
+            tagName = "A109";
+        }
+    },
+
+    // German: undokumentiert: Firmware-Version Regler
+    // value 10401 => 01.04.01
+    TYPE_VERSION_CONTROLLER {
+        {
+            command = "version_controller";
+            itemClass = NumberItem.class;
+            tagName = "I1";
+            type = Type.Word;
+        }
+    },
+
+    // German: undokumentiert: Firmware-Build Regler
+    TYPE_VERSION_CONTROLLER_BUILD {
+        {
+            command = "version_controller_build";
+            itemClass = NumberItem.class;
+            tagName = "I2";
+            type = Type.Word;
+        }
+    },
+
+    // German: undokumentiert: BIOS-Version
+    // value 620 => 06.20
+    TYPE_VERSION_BIOS {
+        {
+            command = "version_bios";
+            itemClass = NumberItem.class;
+            tagName = "I3";
+            type = Type.Word;
+        }
+    },
+
+    // German: undokumentiert: Datum: Tag
+    TYPE_DATE_DAY {
+        {
+            command = "date_day";
+            itemClass = NumberItem.class;
+            tagName = "I5";
+            type = Type.Word;
+        }
+    },
+
+    // German: undokumentiert: Datum: Monat
+    TYPE_DATE_MONTH {
+        {
+            command = "date_month";
+            itemClass = NumberItem.class;
+            tagName = "I6";
+            type = Type.Word;
+        }
+    },
+
+    // German: undokumentiert: Datum: Jahr
+    TYPE_DATE_YEAR {
+        {
+            command = "date_year";
+            itemClass = NumberItem.class;
+            tagName = "I7";
+            type = Type.Word;
+        }
+    },
+
+    // German: undokumentiert: Uhrzeit: Stunde
+    TYPE_TIME_HOUR {
+        {
+            command = "time_hour";
+            itemClass = NumberItem.class;
+            tagName = "I8";
+            type = Type.Word;
+        }
+    },
+
+    // German: undokumentiert: Uhrzeit: Minute
+    TYPE_TIME_MINUTE {
+        {
+            command = "time_minute";
+            itemClass = NumberItem.class;
+            tagName = "I9";
+            type = Type.Word;
         }
     },
 
@@ -652,6 +797,108 @@ public enum EcoTouchTags {
         }
     },
 
+    // German: Handschaltung Heizungspumpe (H-0-A)
+    // H:Handschaltung Ein 0:Aus A:Automatik
+    // Kodierung: 0:? 1:? 2:Automatik
+    TYPE_MANUAL_HEATINGPUMP {
+        {
+            command = "manual_heatingpump";
+            itemClass = NumberItem.class;
+            tagName = "I1270";
+            type = Type.Word;
+        }
+    },
+
+    // German: Handschaltung Quellenpumpe (H-0-A)
+    TYPE_MANUAL_SOURCEPUMP {
+        {
+            command = "manual_sourcepump";
+            itemClass = NumberItem.class;
+            tagName = "I1281";
+            type = Type.Word;
+        }
+    },
+
+    // German: Handschaltung Solarpumpe 1 (H-0-A)
+    TYPE_MANUAL_SOLARPUMP1 {
+        {
+            command = "manual_solarpump1";
+            itemClass = NumberItem.class;
+            tagName = "I1287";
+            type = Type.Word;
+        }
+    },
+
+    // German: Handschaltung Solarpumpe 2 (H-0-A)
+    TYPE_MANUAL_SOLARPUMP2 {
+        {
+            command = "manual_solarpump2";
+            itemClass = NumberItem.class;
+            tagName = "I1289";
+            type = Type.Word;
+        }
+    },
+
+    // German: Handschaltung Speicherladepumpe (H-0-A)
+    TYPE_MANUAL_TANKPUMP {
+        {
+            command = "manual_tankpump";
+            itemClass = NumberItem.class;
+            tagName = "I1291";
+            type = Type.Word;
+        }
+    },
+
+    // German: Handschaltung Brauchwasserventil (H-0-A)
+    TYPE_MANUAL_VALVE {
+        {
+            command = "manual_valve";
+            itemClass = NumberItem.class;
+            tagName = "I1293";
+            type = Type.Word;
+        }
+    },
+
+    // German: Handschaltung Poolventil (H-0-A)
+    TYPE_MANUAL_POOLVALVE {
+        {
+            command = "manual_poolvalve";
+            itemClass = NumberItem.class;
+            tagName = "I1295";
+            type = Type.Word;
+        }
+    },
+
+    // German: Handschaltung Kühlventil (H-0-A)
+    TYPE_MANUAL_COOLVALVE {
+        {
+            command = "manual_coolvalve";
+            itemClass = NumberItem.class;
+            tagName = "I1297";
+            type = Type.Word;
+        }
+    },
+
+    // German: Handschaltung Vierwegeventil (H-0-A)
+    TYPE_MANUAL_4WAYVALVE {
+        {
+            command = "manual_4wayvalve";
+            itemClass = NumberItem.class;
+            tagName = "I1299";
+            type = Type.Word;
+        }
+    },
+
+    // German: Handschaltung Multiausgang Ext. (H-0-A)
+    TYPE_MANUAL_MULTIEXT {
+        {
+            command = "manual_multiext";
+            itemClass = NumberItem.class;
+            tagName = "I1319";
+            type = Type.Word;
+        }
+    },
+
     ;
 
     /**
@@ -719,7 +966,7 @@ public enum EcoTouchTags {
     }
 
     /**
-     * 
+     *
      * @param bindingConfig
      *            command e.g. TYPE_TEMPERATURE_OUTSIDE,..
      * @param itemClass
@@ -739,7 +986,7 @@ public enum EcoTouchTags {
 
     /**
      * Searches the available heat pump commands and returns the matching one.
-     * 
+     *
      * @param heatpumpCommand
      *            command string e.g. "temperature_outside"
      * @return matching EcoTouchTags instance, if available
@@ -760,7 +1007,7 @@ public enum EcoTouchTags {
     /**
      * Searches the available heat pump commands and returns the first matching
      * one.
-     * 
+     *
      * @param tag
      *            raw heatpump tag e.g. "A1"
      * @return first matching EcoTouchTags instance, if available

--- a/bundles/binding/org.openhab.binding.ecotouch/src/main/java/org/openhab/binding/ecotouch/internal/EcoTouchBinding.java
+++ b/bundles/binding/org.openhab.binding.ecotouch/src/main/java/org/openhab/binding/ecotouch/internal/EcoTouchBinding.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * @author Sebastian Held <sebastian.held@gmx.de>
  * @since 1.5.0
  */
-public class EcoTouchBinding extends AbstractActiveBinding<EcoTouchBindingProvider>implements ManagedService {
+public class EcoTouchBinding extends AbstractActiveBinding<EcoTouchBindingProvider> implements ManagedService {
 
     private static final Logger logger = LoggerFactory.getLogger(EcoTouchBinding.class);
 
@@ -104,9 +104,8 @@ public class EcoTouchBinding extends AbstractActiveBinding<EcoTouchBindingProvid
             // inside connector.getValues(tags))
             for (String tag : tags) {
                 try {
-                    int rawvalue = connector.getValue(tag); // raw value from
-                                                            // heat pump (needs
-                                                            // interpretation)
+                    // raw value from heat pump (needs interpretation)
+                    int rawvalue = connector.getValue(tag);
                     rawvalues.put(tag, rawvalue);
                 } catch (Exception e) {
                     // the connector already logged the exception cause

--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -43,6 +43,7 @@
                                 <artifact><file>src/main/resources/conf/dsmr.cfg</file><type>cfg</type><classifier>dsmr</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/ebus.cfg</file><type>cfg</type><classifier>ebus</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/ecobee.cfg</file><type>cfg</type><classifier>ecobee</classifier></artifact>
+                                <artifact><file>src/main/resources/conf/ecotouch.cfg</file><type>cfg</type><classifier>ecotouch</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/enphaseenergy.cfg</file><type>cfg</type><classifier>enphaseenergy</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/enocean.cfg</file><type>cfg</type><classifier>enocean</classifier></artifact>
                                 <artifact><file>src/main/resources/conf/epsonprojector.cfg</file><type>cfg</type><classifier>epsonprojector</classifier></artifact>

--- a/features/openhab-addons-external/src/main/resources/conf/ecotouch.cfg
+++ b/features/openhab-addons-external/src/main/resources/conf/ecotouch.cfg
@@ -1,0 +1,9 @@
+# Data refresh interval in ms (optional, defaults to 60000)
+#refresh=60000
+
+# The IP address of the Waterkotte EcoTouch display unit
+#ip=192.168.1.140
+
+# These are the defaults
+#username=admin
+#password=wtkadmin

--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -187,6 +187,13 @@
     <configfile finalname="${openhab.conf}/services/ecobee.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/ecobee</configfile>
   </feature>
 
+  <feature name="openhab-binding-ecotouch" description="Waterkotte Ecotouch Binding" version="${project.version}">
+    <feature>openhab-runtime-base</feature>
+    <feature>openhab-runtime-compat1x</feature>
+    <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.ecotouch/${project.version}</bundle>
+    <configfile finalname="${openhab.conf}/services/ecotouch.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/ecotouch</configfile>
+  </feature>
+
   <feature name="openhab-binding-energenie" description="Energenie Binding" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>


### PR DESCRIPTION
This pull request adds some more recognized tags to the binding and provides the metadata for OH2.
I can squash the commits into one, if requested.

Open problems:
OH2 shows the binding under PaperUI/Configuration/Bindings, but changes to the configuration are ignored (AbstractActiveBinding<>.updated(Dictionary<String, ?> config) is called with config == null, if no ecotouch.cfg file is in place).
Only configuration via the provided ecotouch.cfg file works.
