### PR TITLE
Add service ids to ESH-INF/binding/binding.xml files

### DIFF
--- a/bundles/binding/org.openhab.binding.dsmr/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.dsmr/ESH-INF/binding/binding.xml
@@ -8,6 +8,8 @@
     <description>The DSMR Binding obtains data from a Dutch smart meter ("Slimme meter" in Dutch) via the P1-port.</description>
     <author>Marcel Volaart</author>
 
+    <service-id>org.openhab.dsmr</service-id>
+
     <config-description>
         <parameter name="port" type="text" required="true">
             <label>Serial port</label>

--- a/bundles/binding/org.openhab.binding.ecobee/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.ecobee/ESH-INF/binding/binding.xml
@@ -8,6 +8,8 @@
     <description>Monitor and control Ecobee thermostats and their remote sensors using the cloud-based API.</description>
     <author>John Cocula</author>
 
+    <service-id>org.openhab.ecobee</service-id>
+
     <config-description>
         <parameter name="appkey" type="text" required="true">
             <label>API Key</label>

--- a/bundles/binding/org.openhab.binding.garadget/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.garadget/ESH-INF/binding/binding.xml
@@ -8,6 +8,8 @@
     <description>Monitor and control Garadget garage door futurizers using the Particle cloud-based API.</description>
     <author>John Cocula</author>
 
+    <service-id>org.openhab.garadget</service-id>
+
     <config-description>
         <parameter name="username" type="text" required="true">
             <label>Username</label>

--- a/bundles/binding/org.openhab.binding.gpio/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.gpio/ESH-INF/binding/binding.xml
@@ -5,23 +5,25 @@
         xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
 
     <name>GPIO Binding</name>
-    <description>This is the binding for gpio.</description>
+    <description>This is the binding for GPIO.</description>
     <author>Dancho Penev</author>
-    
+
+    <service-id>org.openhab.gpio</service-id>
+
     <config-description>
         <parameter name="sysfs" type="text">
-            <label>sysfs mount path</label>
-            <description>Optional directory path where "sysfs" pseudo file system is mounted, when isn't specified it will be determined automatically if "procfs" is mounted.</description>
+            <label>sysfs Mount Path</label>
+            <description>Optional directory path where "sysfs" pseudo file system is mounted. When not specified, it will be determined automatically if "procfs" is mounted.</description>
             <default>/sys</default>
         </parameter>
         <parameter name="debounce" type="integer">
-            <label>Debounce interval</label>
-            <description>Optional time interval in miliseconds when pin interrupts are ignored to prevent bounce effect, mainly on buttons. Global option for all pins, can be overwritten per pin in item configuration.</description>
+            <label>Debounce Interval</label>
+            <description>Optional time interval in milliseconds when pin interrupts are ignored to prevent bounce effect, mainly on buttons. Global option for all pins, can be overridden per pin in item configuration.</description>
             <default>0</default>
         </parameter>
         <parameter name="force" type="boolean">
-            <label>Forcibly take pin</label>
-            <description>Boolean controlling whether already exported pin should be forcibly taken under control of openHAB. Usefull after unclean shutdown. May cause serious issue if other software/system is also controlling GPIO and there is a configuration mistake for pin name/number.</description>
+            <label>Forcibly Take Pin</label>
+            <description>Boolean controlling whether already exported pin should be forcibly taken under control of openHAB. Useful after unclean shutdown. May cause serious issue if other software/system is also controlling GPIO and there is a configuration mistake for pin name/number.</description>
             <default>false</default>
         </parameter>
     </config-description>

--- a/bundles/binding/org.openhab.binding.gpio/OSGI-INF/gpiobinding.xml
+++ b/bundles/binding/org.openhab.binding.gpio/OSGI-INF/gpiobinding.xml
@@ -12,6 +12,7 @@
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.binding.gpio.gpiobinding">
    <implementation class="org.openhab.binding.gpio.internal.GPIOBinding"/>
    <property name="event.topics" type="String" value="openhab/*"/>
+   <property name="service.pid" type="String" value="org.openhab.gpio"/>
    <service>
       <provide interface="org.osgi.service.event.EventHandler"/>
    </service>

--- a/bundles/binding/org.openhab.binding.onewire/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.onewire/ESH-INF/binding/binding.xml
@@ -8,6 +8,8 @@
     <description>The OneWire bus system is a lightweight and cheap bus system mostly used for sensors like, temperature, humidity, counters and presence.</description>
     <author>Dennis Riegelbauer</author>
 
+    <service-id>org.openhab.onewire</service-id>
+
     <config-description>
         <parameter name="ip" type="text" required="true">
             <context>network-address</context>

--- a/bundles/binding/org.openhab.binding.plugwise/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.plugwise/ESH-INF/binding/binding.xml
@@ -7,6 +7,8 @@
     <name>Plugwise Binding</name>
     <description>Monitor and control Plugwise ZigBee devices using the Stick. Supported devices are the Circle, Circle+, Scan, Sense, Stealth and Switch.</description>
 
+    <service-id>org.openhab.plugwise</service-id>
+
     <config-description>
         <parameter name="stick.port" type="text" required="true">
             <label>Stick serial port</label>

--- a/bundles/binding/org.openhab.binding.powermax/ESH-INF/binding/binding.xml
+++ b/bundles/binding/org.openhab.binding.powermax/ESH-INF/binding/binding.xml
@@ -6,6 +6,8 @@
 	<description>The Visonic PowerMax binding interfaces with Visonic PowerMax and PowerMaster alarm panel series.</description>
 	<author>Laurent Garnier</author>
 
+    <service-id>org.openhab.powermax</service-id>
+
 	<config-description>
 		<parameter name="serialPort" type="text" required="false">
 			<label>Serial port</label>


### PR DESCRIPTION
Following the example in #4804, add `<service-id>org.openhab.ID</service-id>` to all 1.x bindings that already provide an `ESH-INF/binding/binding.xml` file for configuration through the Paper UI.  This should result in the binding services finding the configuration at the service PIDs where they are expected to be.  

The GPIO binding was a special case because it did not explicitly set its `service.pid`, which I understand means that the component's name is used instead.  So I explicitly set the `service.pid` for the service component to match how other bindings name their service PIDs.