### PR TITLE
Fix IllegalArgumentException with ColorItem MapDB persistence

### DIFF
--- a/bundles/persistence/org.openhab.persistence.mapdb/src/main/java/org/openhab/persistence/mapdb/internal/MapDBPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.mapdb/src/main/java/org/openhab/persistence/mapdb/internal/MapDBPersistenceService.java
@@ -144,10 +144,10 @@ public class MapDBPersistenceService implements QueryablePersistenceService {
         logger.debug("store called for {}", alias);
 
         State state = item.getState();
-        if (item instanceof DimmerItem || item instanceof RollershutterItem) {
-            state = item.getStateAs(PercentType.class);
-        } else if (item instanceof ColorItem) {
+        if (item instanceof ColorItem) {
             state = item.getStateAs(HSBType.class);
+        } else if (item instanceof DimmerItem || item instanceof RollershutterItem) {
+            state = item.getStateAs(PercentType.class);
         }
         MapDBItem mItem = new MapDBItem();
         mItem.setName(alias);
@@ -215,7 +215,7 @@ public class MapDBPersistenceService implements QueryablePersistenceService {
     /**
      * A quartz scheduler job to commit the mapdb transaction frequently. There
      * can be only one instance of a specific job type running at the same time.
-     * 
+     *
      * @author Jens Viebig
      * @since 1.7.0
      */


### PR DESCRIPTION
Because `ColorItem` extends `DimmerItem` the current `MapDBPersistenceService` implementation tries to store the item state as a percentage.

`item.getStateAs(PercentType.class)` then causes the following exception:

```
java.lang.IllegalArgumentException: Value must be between 0 and 100
```

Changing the if-then-else order results in the correct behavior.