### PR TITLE
Improved the handling of incorrect device id's

### DIFF
--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/data/HueSettings.java
@@ -273,6 +273,10 @@ public class HueSettings {
          */
         @SuppressWarnings("unchecked")
         protected SettingsTree node(String nodeName) {
+            if (dataMap.get(nodeName) == null){
+                return null;
+            }
+
             return new SettingsTree((Map<String, Object>) dataMap.get(nodeName));
         }
 

--- a/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBulb.java
+++ b/bundles/binding/org.openhab.binding.hue/src/main/java/org/openhab/binding/hue/internal/hardware/HueBulb.java
@@ -101,6 +101,7 @@ public class HueBulb {
             }
         } else {
             logger.warn("Not a valid id on the bridge: " + deviceId);
+            throw new IllegalStateException("Not a valid id on the bridge: " + deviceId);
         }
     }
 


### PR DESCRIPTION
I accidently used 3:brightness and this does not lead to the logging of any error, even while running in debug mode, after I traced down the problem I now changed the behavior the message "Not a valid id on the bridge: {bridge}" is logged and no further attempts to execute commands or update the status from the bridge are made.

The reason the old code did not work was that a null object was always wrapped in some internal object (see the code in HueSetting), further in the execution a null pointer was triggered, because the internal state of bulb was inconsistent because nothing could be retrieved from the bridge. That NPE was (unfortunately) swallowed by openHAB's core classes.

The reason an exception is now thrown from the HueBuld is that otherwise a HueBulb object will be constructed and/or used while it has an invalid state (it refers to a non-existing light).