### PR TITLE
[KNX] Add log entry if DPT incompatible

### DIFF
--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBinding.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBinding.java
@@ -53,7 +53,7 @@ import tuwien.auto.calimero.process.ProcessListener;
  * @since 0.3.0
  *
  */
-public class KNXBinding extends AbstractBinding<KNXBindingProvider>implements ProcessListener, KNXConnectionListener {
+public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements ProcessListener, KNXConnectionListener {
 
     private static final Logger logger = LoggerFactory.getLogger(KNXBinding.class);
 
@@ -480,6 +480,14 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider>implements Pr
             for (Datapoint datapoint : provider.getDatapoints(itemName, typeClass)) {
                 datapoints.add(datapoint);
             }
+        }
+        if (datapoints.isEmpty()) {
+            logger.warn("no compatible datapoint found for item {} ({}), check item configuration", itemName,
+                    typeClass.getName());
+
+        } else {
+            logger.trace("found {} compatible datapoints for item {} ({})", datapoints.size(), itemName,
+                    typeClass.getName());
         }
         return datapoints;
     }


### PR DESCRIPTION
fixes #4229: DecimalType and DPT 5.001 are incompatible, expected is PercentType. Misuse was not logged but failed silently.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>