### PR TITLE
Changed the order of accepted states in StringItem

### DIFF
--- a/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/items/StringItem.java
+++ b/bundles/core/org.openhab.core.library/src/main/java/org/openhab/core/library/items/StringItem.java
@@ -33,9 +33,9 @@ public class StringItem extends GenericItem {
 	private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
 
 	static {
-		acceptedDataTypes.add(StringType.class);
-		acceptedDataTypes.add((DateTimeType.class));
 		acceptedDataTypes.add(UnDefType.class);
+		acceptedDataTypes.add(DateTimeType.class);
+		acceptedDataTypes.add(StringType.class);
 
 		acceptedCommandTypes.add(StringType.class);
 	}


### PR DESCRIPTION
When TypeParser is used with the list of accepted states of StringItem, it will process the items in accepted order. Since StringType accepts any String, the other types (DateTimeType, UnDefType) would never be processed. The String "Undefined" would be convertet in StringType("Undefined") rather than UnDefType.UNDEF.