### PR TITLE
[Plugwise] Fix exceptions at binding startup, improve device cache

### DIFF
--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/CirclePlus.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/CirclePlus.java
@@ -106,7 +106,7 @@ public class CirclePlus extends Circle {
                             // devices
                             device = new Circle(((RoleCallResponseMessage) message).getNodeMAC(), stick,
                                     ((RoleCallResponseMessage) message).getNodeMAC());
-                            stick.plugwiseDeviceCache.add(device);
+                            stick.addDevice(device);
                             logger.debug("Added a Circle with MAC {} to the cache", device.getMAC());
                         }
 

--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseBinding.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseBinding.java
@@ -156,7 +156,7 @@ public class PlugwiseBinding extends AbstractActiveBinding<PlugwiseBindingProvid
                 PlugwiseDevice device = createPlugwiseDevice(deviceType, MAC, deviceName);
 
                 if (device != null) {
-                    stick.plugwiseDeviceCache.add(device);
+                    stick.addDevice(device);
                 }
             }
 
@@ -479,7 +479,7 @@ public class PlugwiseBinding extends AbstractActiveBinding<PlugwiseBindingProvid
                             if (!cp.getMAC().equals(element.getId())) {
                                 // a circleplus has been added/detected and it is not what is in the binding config
                                 PlugwiseDevice device = new Circle(element.getId(), stick, element.getId());
-                                stick.plugwiseDeviceCache.add(device);
+                                stick.addDevice(device);
                                 logger.debug("Plugwise added Circle with MAC address: {}", element.getId());
                             }
                         } else {

--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseDeviceCache.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseDeviceCache.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Caches all {@link PlugwiseDevice} instances and allows for querying them by mac, name and device class.
  *
  * @author Wouter Born
+ * @since 1.9.0
  */
 public class PlugwiseDeviceCache {
 

--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseDeviceCache.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseDeviceCache.java
@@ -1,0 +1,57 @@
+package org.openhab.binding.plugwise.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Caches all {@link PlugwiseDevice} instances and allows for querying them by mac, name and device class.
+ *
+ * @author Wouter Born
+ */
+public class PlugwiseDeviceCache {
+
+    private Map<String, PlugwiseDevice> macDeviceMapping = new ConcurrentHashMap<String, PlugwiseDevice>();
+    private Map<String, PlugwiseDevice> nameDeviceMapping = new ConcurrentHashMap<String, PlugwiseDevice>();
+
+    public void add(PlugwiseDevice device) {
+        macDeviceMapping.put(device.getMAC(), device);
+        nameDeviceMapping.put(device.getName(), device);
+    }
+
+    public void clear() {
+        macDeviceMapping.clear();
+        nameDeviceMapping.clear();
+    }
+
+    public PlugwiseDevice get(String id) {
+        PlugwiseDevice device = getByMAC(id);
+        if (device == null) {
+            return getByName(id);
+        } else {
+            return device;
+        }
+    }
+
+    public PlugwiseDevice getByMAC(String mac) {
+        return macDeviceMapping.get(mac);
+    }
+
+    public PlugwiseDevice getByName(String name) {
+        return nameDeviceMapping.get(name);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> List<T> getByClass(Class<T> deviceClass) {
+
+        List<T> result = new ArrayList<T>();
+        for (PlugwiseDevice device : macDeviceMapping.values()) {
+            if (deviceClass.isAssignableFrom(device.getClass())) {
+                result.add((T) device);
+            }
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
This PR fixes some exceptions that are occasionally thrown when the binding is started. Some examples of these stacktraces are:

```
17:25:58.113 [ERROR] [org.apache.felix.configadmin        ] - [org.osgi.service.cm.ManagedService, org.osgi.service.event.EventHandler, id=294, bundle=200/mvn:org.openhab.binding/org.openhab.binding.plugwise/1.9.0-SNAPSHOT]: Unexpected problem updating configuration org.openhab.plugwise
java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901)[:1.8.0_65]
	at java.util.ArrayList$Itr.next(ArrayList.java:851)[:1.8.0_65]
	at org.openhab.binding.plugwise.internal.Stick.getDeviceByMAC(Stick.java:148)[200:org.openhab.binding.plugwise:1.9.0.201611250210]
	at org.openhab.binding.plugwise.internal.PlugwiseBinding.setupNonStickDevices(PlugwiseBinding.java:149)[200:org.openhab.binding.plugwise:1.9.0.201611250210]
	at org.openhab.binding.plugwise.internal.PlugwiseBinding.updated(PlugwiseBinding.java:99)[200:org.openhab.binding.plugwise:1.9.0.201611250210]
	at org.apache.felix.cm.impl.helper.ManagedServiceTracker.updated(ManagedServiceTracker.java:189)[7:org.apache.felix.configadmin:1.8.8]
	at org.apache.felix.cm.impl.helper.ManagedServiceTracker.updateService(ManagedServiceTracker.java:152)[7:org.apache.felix.configadmin:1.8.8]
	at org.apache.felix.cm.impl.helper.ManagedServiceTracker.provideConfiguration(ManagedServiceTracker.java:85)[7:org.apache.felix.configadmin:1.8.8]
	at org.apache.felix.cm.impl.ConfigurationManager$ManagedServiceUpdate.provide(ConfigurationManager.java:1444)[7:org.apache.felix.configadmin:1.8.8]
	at org.apache.felix.cm.impl.ConfigurationManager$ManagedServiceUpdate.run(ConfigurationManager.java:1400)[7:org.apache.felix.configadmin:1.8.8]
	at org.apache.felix.cm.impl.UpdateThread.run0(UpdateThread.java:143)[7:org.apache.felix.configadmin:1.8.8]
	at org.apache.felix.cm.impl.UpdateThread.run(UpdateThread.java:110)[7:org.apache.felix.configadmin:1.8.8]
	at java.lang.Thread.run(Thread.java:745)[:1.8.0_65]


18:08:57.391 [ERROR] [nhab.binding.plugwise.internal.Stick] - SendJob: unexpected error
java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901)[:1.8.0_65]
	at java.util.ArrayList$Itr.next(ArrayList.java:851)[:1.8.0_65]
	at org.openhab.binding.plugwise.internal.Stick.getDeviceByMAC(Stick.java:148)[200:org.openhab.binding.plugwise:1.9.0.201611250210]
	at org.openhab.binding.plugwise.internal.Stick.processMessage(Stick.java:566)[200:org.openhab.binding.plugwise:1.9.0.201611250210]
	at org.openhab.binding.plugwise.internal.Stick$ProcessMessageThread.processMessage(Stick.java:763)[200:org.openhab.binding.plugwise:1.9.0.201611250210]
	at org.openhab.binding.plugwise.internal.Stick$ProcessMessageThread.run(Stick.java:745)[200:org.openhab.binding.plugwise:1.9.0.201611250210]
```

The Plugwise device cache is improved as follows:
* Concurrent hash maps are used to resolve the exceptions and improve performance
* Logic is extracted into a new `PlugwiseDeviceCache` object
* `PlugwiseDeviceCache` object is now private to the Stick so other objects interact with it in a consistent way (through the Stick)

