### PR TITLE
[caldav] fix #4820 recurring events not scheduled

### DIFF
--- a/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/CalDavEvent.java
+++ b/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/CalDavEvent.java
@@ -146,31 +146,63 @@ public class CalDavEvent {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result
-                + ((calendarId == null) ? 0 : calendarId.hashCode());
+        result = prime * result + ((calendarId == null) ? 0 : calendarId.hashCode());
         result = prime * result + ((id == null) ? 0 : id.hashCode());
         return result;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         CalDavEvent other = (CalDavEvent) obj;
         if (calendarId == null) {
-            if (other.calendarId != null)
+            if (other.calendarId != null) {
                 return false;
-        } else if (!calendarId.equals(other.calendarId))
+            }
+        } else if (!calendarId.equals(other.calendarId)) {
             return false;
+        }
         if (id == null) {
-            if (other.id != null)
+            if (other.id != null) {
                 return false;
-        } else if (!id.equals(other.id))
+            }
+        } else if (!id.equals(other.id)) {
             return false;
+        }
+        // supposing that the "lastChanged" timestamp has correctly been set in case of event modification for something
+        // like categories, place ... )
+        if (lastChanged == null) {
+            if (other.lastChanged != null) {
+                return false;
+            }
+        } else if (!lastChanged.equals(other.lastChanged)) {
+            return false;
+        }
+
+        // we NEED to compare event's start and stop date to be able to say they are equal :
+        if (start == null) {
+            if (other.start != null) {
+                return false;
+            }
+        } else if (!start.equals(other.start)) {
+            return false;
+        }
+        if (end == null) {
+            if (other.end != null) {
+                return false;
+            }
+        } else if (!end.equals(other.end)) {
+            return false;
+        }
+
         return true;
     }
 
@@ -179,5 +211,4 @@ public class CalDavEvent {
         return this.getShortName();
     }
 
-    
 }

--- a/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/internal/CalDavLoaderImpl.java
+++ b/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/internal/CalDavLoaderImpl.java
@@ -558,17 +558,13 @@ public class CalDavLoaderImpl extends AbstractActiveService implements ManagedSe
                             }
                         }
                         if (query.getFilterCategory() != null) {
-                            log.trace("processing filter category");
                             if (calDavEvent.getCategoryList() == null) {
-                                log.trace("not found event category for event {}", calDavEvent.getId());
                                 continue;
                             } else {
                                 if (!calDavEvent.getCategoryList().containsAll(query.getFilterCategory())) {
                                     continue;
                                 }
                             }
-                        } else {
-                            log.trace("not found any filter category");
                         }
                         eventList.add(calDavEvent);
                     }

--- a/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/internal/job/EventReloaderJob.java
+++ b/bundles/io/org.openhab.io.caldav/src/main/java/org/openhab/io/caldav/internal/job/EventReloaderJob.java
@@ -256,13 +256,12 @@ public class EventReloaderJob implements Job {
                     continue;
                 }
 
-                // oldEventIds.remove(filename); //BUGGY lazy "remove" ??(first occurence) :
                 // an ics file can contain multiple events
                 // ==> multiple eventcontainers could have the same filename (and different eventid),
                 // ==>we must not have one of them remaining in oldEventIds var (bad chosen name, cause it's a list of
                 // oldEventContainers's filename, so with doubles possible)
                 // or the remaining jobs with this filename will get unscheduled on the "removeDeletedEvents(config,
-                // oldEventIds)" call (line 134)
+                // oldEventIds)" call (line 136)
                 oldEventIds.removeAll(Arrays.asList(filename));
 
                 // must not be loaded


### PR DESCRIPTION
Fix #4820, tested live on my home heaters

rebased on upstream/master on 2016/12/03

The issue was that some known recuring events, under specific confitions would not have their schedule updated ; the reload code is calling the function "addEventToMap" for every new or modified event, but the event was already in the map, thus the call was ignored. Fixed that. At least this case does not occur at my home, all my heaters (zwave controlled) have worked perfectly this week (never before).

Added a lot of trace and debug lines to be able to understand what was
going on

revert .classpath modifications
cosmetics + small perf improvement
remove lambda expression
(jenkins alergic)
