### PR TITLE
reverted suffix on persistence add-ons

### DIFF
--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -642,7 +642,7 @@
 
   <!-- persistence -->
 
-  <feature name="openhab-persistence-influxdb1" description="InfluxDB (v 1.0) Persistence" version="${project.version}">
+  <feature name="openhab-persistence-influxdb" description="InfluxDB (v 1.0) Persistence" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.influxdb/${project.version}</bundle>
@@ -650,7 +650,7 @@
   </feature>
 
   <!-- JDBC Persistence for: Apache Derby, H2, HSQLDB, MariaDB, MySQL, PostgreSQL, SQLite -->
-  <feature name="openhab-persistence-jdbc-derby1" description="JDBC Persistence Apache Derby" version="${project.version}">
+  <feature name="openhab-persistence-jdbc-derby" description="JDBC Persistence Apache Derby" version="${project.version}">
     <configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jdbc</configfile>
     <feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
     <feature prerequisite="false" dependency="false">openhab-runtime-compat1x</feature>
@@ -658,7 +658,7 @@
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jdbc/${project.version}</bundle>
   </feature>
 
-  <feature name="openhab-persistence-jdbc-h21" description="JDBC Persistence H2" version="${project.version}">
+  <feature name="openhab-persistence-jdbc-h2" description="JDBC Persistence H2" version="${project.version}">
     <configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jdbc</configfile>
     <feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
     <feature prerequisite="false" dependency="false">openhab-runtime-compat1x</feature>
@@ -666,7 +666,7 @@
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jdbc/${project.version}</bundle>
   </feature>
 
-  <feature name="openhab-persistence-jdbc-hsqldb1" description="JDBC Persistence HSQLDB" version="${project.version}">
+  <feature name="openhab-persistence-jdbc-hsqldb" description="JDBC Persistence HSQLDB" version="${project.version}">
     <configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jdbc</configfile>
     <feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
     <feature prerequisite="false" dependency="false">openhab-runtime-compat1x</feature>
@@ -674,7 +674,7 @@
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jdbc/${project.version}</bundle>
   </feature>
 
-  <feature name="openhab-persistence-jdbc-mariadb1" description="JDBC Persistence MariaDB" version="${project.version}">
+  <feature name="openhab-persistence-jdbc-mariadb" description="JDBC Persistence MariaDB" version="${project.version}">
     <configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jdbc</configfile>
     <feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
     <feature prerequisite="false" dependency="false">openhab-runtime-compat1x</feature>
@@ -682,7 +682,7 @@
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jdbc/${project.version}</bundle>
   </feature>
 
-  <feature name="openhab-persistence-jdbc-mysql1" description="JDBC Persistence MySQL" version="${project.version}">
+  <feature name="openhab-persistence-jdbc-mysql" description="JDBC Persistence MySQL" version="${project.version}">
     <configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jdbc</configfile>
     <feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
     <feature prerequisite="false" dependency="false">openhab-runtime-compat1x</feature>
@@ -690,7 +690,7 @@
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jdbc/${project.version}</bundle>
   </feature>
 
-  <feature name="openhab-persistence-jdbc-postgresql1" description="JDBC Persistence PostgreSQL" version="${project.version}">
+  <feature name="openhab-persistence-jdbc-postgresql" description="JDBC Persistence PostgreSQL" version="${project.version}">
     <configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jdbc</configfile>
     <feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
     <feature prerequisite="false" dependency="false">openhab-runtime-compat1x</feature>
@@ -698,7 +698,7 @@
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jdbc/${project.version}</bundle>
   </feature>
 
-  <feature name="openhab-persistence-jdbc-sqlite1" description="JDBC Persistence SQLite" version="${project.version}">
+  <feature name="openhab-persistence-jdbc-sqlite" description="JDBC Persistence SQLite" version="${project.version}">
     <configfile finalname="${openhab.conf}/services/jdbc.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jdbc</configfile>
     <feature prerequisite="false" dependency="false">openhab-runtime-base</feature>
     <feature prerequisite="false" dependency="false">openhab-runtime-compat1x</feature>
@@ -706,21 +706,21 @@
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jdbc/${project.version}</bundle>
   </feature>
 
-  <feature name="openhab-persistence-jpa1" description="JPA Persistence" version="${project.version}">
+  <feature name="openhab-persistence-jpa" description="JPA Persistence" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jpa/${project.version}</bundle>
     <configfile finalname="${openhab.conf}/services/jpa.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/jpa</configfile>
   </feature>
 
-  <feature name="openhab-persistence-mapdb1" description="MapDB Persistence" version="${project.version}">
+  <feature name="openhab-persistence-mapdb" description="MapDB Persistence" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.mapdb/${project.version}</bundle>
     <configfile finalname="${openhab.conf}/services/mapdb.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/mapdb</configfile>
   </feature>
 
-  <feature name="openhab-persistence-mqtt1" description="MQTT Persistence" version="${project.version}">
+  <feature name="openhab-persistence-mqtt" description="MQTT Persistence" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>
     <bundle start-level="80">mvn:org.openhab.io/org.openhab.io.transport.mqtt/${project.version}</bundle>
@@ -729,14 +729,14 @@
     <configfile finalname="${openhab.conf}/services/mqtt-persistence.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/mqtt-persistence</configfile>
   </feature>
 
-  <feature name="openhab-persistence-mysql1" description="MySQL Persistence" version="${project.version}">
+  <feature name="openhab-persistence-mysql" description="MySQL Persistence" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.mysql/${project.version}</bundle>
     <configfile finalname="${openhab.conf}/services/mysql.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/mysql</configfile>
   </feature>
 
-  <feature name="openhab-persistence-rrd4j1" description="RRD4j Persistence" version="${project.version}">
+  <feature name="openhab-persistence-rrd4j" description="RRD4j Persistence" version="${project.version}">
     <feature>openhab-runtime-base</feature>
     <feature>openhab-runtime-compat1x</feature>
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.rrd4j/${project.version}</bundle>


### PR DESCRIPTION
as per our discussion, the suffix makes sense on bindings, but not necessarily on persistence add-ons, so I am reverting this.

Signed-off-by: Kai Kreuzer <kai@openhab.org>