### PR TITLE
[influxdb] Quote retention policy and measurement

### DIFF
--- a/bundles/persistence/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBPersistenceService.java
@@ -280,13 +280,18 @@ public class InfluxDBPersistenceService implements QueryablePersistenceService {
         List<HistoricItem> historicItems = new ArrayList<HistoricItem>();
 
         StringBuffer query = new StringBuffer();
-        query.append("select ");
-        query.append(VALUE_COLUMN_NAME);
-        query.append(" ");
-        query.append("from " + retentionPolicy + ".");
+        query
+            .append("select ")
+            .append(VALUE_COLUMN_NAME)
+            .append(' ')
+            .append("from \"")
+            .append(retentionPolicy)
+            .append("\".");
 
         if (filter.getItemName() != null) {
-            query.append(filter.getItemName());
+            query.append('"')
+                .append(filter.getItemName())
+                .append('"');
         } else {
             query.append("/.*/");
         }

--- a/bundles/persistence/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBPersistenceService.java
+++ b/bundles/persistence/org.openhab.persistence.influxdb/src/main/java/org/openhab/persistence/influxdb/internal/InfluxDBPersistenceService.java
@@ -280,18 +280,11 @@ public class InfluxDBPersistenceService implements QueryablePersistenceService {
         List<HistoricItem> historicItems = new ArrayList<HistoricItem>();
 
         StringBuffer query = new StringBuffer();
-        query
-            .append("select ")
-            .append(VALUE_COLUMN_NAME)
-            .append(' ')
-            .append("from \"")
-            .append(retentionPolicy)
-            .append("\".");
+        query.append("select ").append(VALUE_COLUMN_NAME).append(' ').append("from \"").append(retentionPolicy)
+                .append("\".");
 
         if (filter.getItemName() != null) {
-            query.append('"')
-                .append(filter.getItemName())
-                .append('"');
+            query.append('"').append(filter.getItemName()).append('"');
         } else {
             query.append("/.*/");
         }


### PR DESCRIPTION
Quotes are added around the retention policy and measurement
identifiers. The lexer of influxdb treats 'default' (which
is also the default retention policy) as a reserved word.

This will also allow querying items which have reserved
characters in their names.

Tested on openhab2. Fixes at least:
https://github.com/openhab/openhab/issues/4840