### PR TITLE
Replace string casting of config values

### DIFF
--- a/bundles/binding/org.openhab.binding.dsmr/src/main/java/org/openhab/binding/dsmr/internal/DSMRBinding.java
+++ b/bundles/binding/org.openhab.binding.dsmr/src/main/java/org/openhab/binding/dsmr/internal/DSMRBinding.java
@@ -11,6 +11,7 @@ package org.openhab.binding.dsmr.internal;
 import java.util.ArrayList;
 import java.util.Dictionary;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.dsmr.DSMRBindingProvider;
@@ -48,7 +49,7 @@ import org.slf4j.LoggerFactory;
  * @author M.Volaart
  * @since 1.7.0
  */
-public class DSMRBinding extends AbstractActiveBinding<DSMRBindingProvider>implements ManagedService {
+public class DSMRBinding extends AbstractActiveBinding<DSMRBindingProvider> implements ManagedService {
 
     /** Update interval as specified by DSMR */
     public static final int DSMR_UPDATE_INTERVAL = 10000;
@@ -186,7 +187,7 @@ public class DSMRBinding extends AbstractActiveBinding<DSMRBindingProvider>imple
         logger.debug("updated() is called!");
         if (config != null) {
             // Read port string
-            String portString = (String) config.get("port");
+            String portString = Objects.toString(config.get("port"), "");
             logger.debug("dsmr:port=" + portString);
             if (StringUtils.isNotBlank(portString)) {
                 port = portString;
@@ -200,7 +201,7 @@ public class DSMRBinding extends AbstractActiveBinding<DSMRBindingProvider>imple
             dsmrMeters.clear();
 
             for (DSMRMeterType meterType : DSMRMeterType.values()) {
-                String channelConfigValue = (String) config.get(meterType.channelConfigKey);
+                String channelConfigValue = Objects.toString(config.get(meterType.channelConfigKey), "");
                 logger.debug("dsmr:" + meterType.channelConfigKey + "=" + channelConfigValue);
 
                 if (StringUtils.isNotBlank(channelConfigValue)) {

--- a/bundles/binding/org.openhab.binding.dsmr/src/main/java/org/openhab/binding/dsmr/internal/DSMRBinding.java
+++ b/bundles/binding/org.openhab.binding.dsmr/src/main/java/org/openhab/binding/dsmr/internal/DSMRBinding.java
@@ -187,7 +187,7 @@ public class DSMRBinding extends AbstractActiveBinding<DSMRBindingProvider> impl
         logger.debug("updated() is called!");
         if (config != null) {
             // Read port string
-            String portString = Objects.toString(config.get("port"), "");
+            String portString = Objects.toString(config.get("port"), null);
             logger.debug("dsmr:port=" + portString);
             if (StringUtils.isNotBlank(portString)) {
                 port = portString;
@@ -201,7 +201,7 @@ public class DSMRBinding extends AbstractActiveBinding<DSMRBindingProvider> impl
             dsmrMeters.clear();
 
             for (DSMRMeterType meterType : DSMRMeterType.values()) {
-                String channelConfigValue = Objects.toString(config.get(meterType.channelConfigKey), "");
+                String channelConfigValue = Objects.toString(config.get(meterType.channelConfigKey), null);
                 logger.debug("dsmr:" + meterType.channelConfigKey + "=" + channelConfigValue);
 
                 if (StringUtils.isNotBlank(channelConfigValue)) {

--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
@@ -736,30 +736,30 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider>
 
             // to override the default granularity one has to add a
             // parameter to openhab.cfg like ecobee:granularity=2000
-            String granularityString = Objects.toString(config.get(CONFIG_GRANULARITY), "");
+            String granularityString = Objects.toString(config.get(CONFIG_GRANULARITY), null);
             granularity = isNotBlank(granularityString) ? Long.parseLong(granularityString) : DEFAULT_GRANULARITY;
 
             // to override the default refresh interval one has to add a
             // parameter to openhab.cfg like ecobee:refresh=240000
-            String refreshIntervalString = Objects.toString(config.get(CONFIG_REFRESH), "");
+            String refreshIntervalString = Objects.toString(config.get(CONFIG_REFRESH), null);
             refreshInterval = isNotBlank(refreshIntervalString) ? Long.parseLong(refreshIntervalString)
                     : DEFAULT_REFRESH;
 
             // to override the default quickPoll interval one has to add a
             // parameter to openhab.cfg like ecobee:quickpoll=4000
-            String quickPollIntervalString = Objects.toString(config.get(CONFIG_QUICKPOLL), "");
+            String quickPollIntervalString = Objects.toString(config.get(CONFIG_QUICKPOLL), null);
             quickPollInterval = isNotBlank(quickPollIntervalString) ? Long.parseLong(quickPollIntervalString)
                     : DEFAULT_QUICKPOLL;
 
             // to override the default HTTP timeout one has to add a
             // parameter to openhab.cfg like ecobee:timeout=20000
-            String timeoutString = Objects.toString(config.get(CONFIG_TIMEOUT), "");
+            String timeoutString = Objects.toString(config.get(CONFIG_TIMEOUT), null);
             if (isNotBlank(timeoutString)) {
                 AbstractRequest.setHttpRequestTimeout(Integer.parseInt(timeoutString));
             }
             // to override the default usage of Fahrenheit one has to add a
             // parameter to openhab.cfg, as in ecobee:tempscale=C
-            String tempScaleString = Objects.toString(config.get(CONFIG_TEMP_SCALE), "");
+            String tempScaleString = Objects.toString(config.get(CONFIG_TEMP_SCALE), null);
             if (isNotBlank(tempScaleString)) {
                 try {
                     Temperature.setLocalScale(Temperature.Scale.forValue(tempScaleString));
@@ -800,7 +800,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider>
                     credentialsCache.put(userid, credentials);
                 }
 
-                String value = Objects.toString(config.get(configKey), "");
+                String value = Objects.toString(config.get(configKey), null);
 
                 if (CONFIG_APP_KEY.equals(configKeyTail)) {
                     credentials.appKey = value;

--- a/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
+++ b/bundles/binding/org.openhab.binding.ecobee/src/main/java/org/openhab/binding/ecobee/internal/EcobeeBinding.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.prefs.Preferences;
@@ -735,30 +736,30 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider>
 
             // to override the default granularity one has to add a
             // parameter to openhab.cfg like ecobee:granularity=2000
-            String granularityString = (String) config.get(CONFIG_GRANULARITY);
+            String granularityString = Objects.toString(config.get(CONFIG_GRANULARITY), "");
             granularity = isNotBlank(granularityString) ? Long.parseLong(granularityString) : DEFAULT_GRANULARITY;
 
             // to override the default refresh interval one has to add a
             // parameter to openhab.cfg like ecobee:refresh=240000
-            String refreshIntervalString = (String) config.get(CONFIG_REFRESH);
+            String refreshIntervalString = Objects.toString(config.get(CONFIG_REFRESH), "");
             refreshInterval = isNotBlank(refreshIntervalString) ? Long.parseLong(refreshIntervalString)
                     : DEFAULT_REFRESH;
 
             // to override the default quickPoll interval one has to add a
             // parameter to openhab.cfg like ecobee:quickpoll=4000
-            String quickPollIntervalString = (String) config.get(CONFIG_QUICKPOLL);
+            String quickPollIntervalString = Objects.toString(config.get(CONFIG_QUICKPOLL), "");
             quickPollInterval = isNotBlank(quickPollIntervalString) ? Long.parseLong(quickPollIntervalString)
                     : DEFAULT_QUICKPOLL;
 
             // to override the default HTTP timeout one has to add a
             // parameter to openhab.cfg like ecobee:timeout=20000
-            String timeoutString = (String) config.get(CONFIG_TIMEOUT);
+            String timeoutString = Objects.toString(config.get(CONFIG_TIMEOUT), "");
             if (isNotBlank(timeoutString)) {
                 AbstractRequest.setHttpRequestTimeout(Integer.parseInt(timeoutString));
             }
             // to override the default usage of Fahrenheit one has to add a
             // parameter to openhab.cfg, as in ecobee:tempscale=C
-            String tempScaleString = (String) config.get(CONFIG_TEMP_SCALE);
+            String tempScaleString = Objects.toString(config.get(CONFIG_TEMP_SCALE), "");
             if (isNotBlank(tempScaleString)) {
                 try {
                     Temperature.setLocalScale(Temperature.Scale.forValue(tempScaleString));
@@ -799,7 +800,7 @@ public class EcobeeBinding extends AbstractActiveBinding<EcobeeBindingProvider>
                     credentialsCache.put(userid, credentials);
                 }
 
-                String value = (String) config.get(configKey);
+                String value = Objects.toString(config.get(configKey), "");
 
                 if (CONFIG_APP_KEY.equals(configKeyTail)) {
                     credentials.appKey = value;

--- a/bundles/binding/org.openhab.binding.ecotouch/src/main/java/org/openhab/binding/ecotouch/internal/EcoTouchBinding.java
+++ b/bundles/binding/org.openhab.binding.ecotouch/src/main/java/org/openhab/binding/ecotouch/internal/EcoTouchBinding.java
@@ -13,6 +13,7 @@ import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
@@ -204,24 +205,24 @@ public class EcoTouchBinding extends AbstractActiveBinding<EcoTouchBindingProvid
 
         if (config != null) {
 
-            String refreshIntervalString = (String) config.get("refresh");
+            String refreshIntervalString = Objects.toString(config.get("refresh"), "");
             if (StringUtils.isNotBlank(refreshIntervalString)) {
                 refreshInterval = Long.parseLong(refreshIntervalString);
             }
 
-            String ip = (String) config.get("ip"); //$NON-NLS-1$
+            String ip = Objects.toString(config.get("ip"), ""); //$NON-NLS-1$
             if (StringUtils.isBlank(ip)) {
                 throw new ConfigurationException("ip", "The ip address must not be empty.");
             }
             this.ip = ip;
 
-            String username = (String) config.get("username"); //$NON-NLS-1$
+            String username = Objects.toString(config.get("username"), ""); //$NON-NLS-1$
             if (StringUtils.isBlank(username)) {
                 throw new ConfigurationException("username", "The username must not be empty.");
             }
             this.username = username;
 
-            String password = (String) config.get("password"); //$NON-NLS-1$
+            String password = Objects.toString(config.get("password"), ""); //$NON-NLS-1$
             if (StringUtils.isBlank(password)) {
                 throw new ConfigurationException("password", "The password must not be empty.");
             }

--- a/bundles/binding/org.openhab.binding.ecotouch/src/main/java/org/openhab/binding/ecotouch/internal/EcoTouchBinding.java
+++ b/bundles/binding/org.openhab.binding.ecotouch/src/main/java/org/openhab/binding/ecotouch/internal/EcoTouchBinding.java
@@ -205,24 +205,24 @@ public class EcoTouchBinding extends AbstractActiveBinding<EcoTouchBindingProvid
 
         if (config != null) {
 
-            String refreshIntervalString = Objects.toString(config.get("refresh"), "");
+            String refreshIntervalString = Objects.toString(config.get("refresh"), null);
             if (StringUtils.isNotBlank(refreshIntervalString)) {
                 refreshInterval = Long.parseLong(refreshIntervalString);
             }
 
-            String ip = Objects.toString(config.get("ip"), ""); //$NON-NLS-1$
+            String ip = Objects.toString(config.get("ip"), null); //$NON-NLS-1$
             if (StringUtils.isBlank(ip)) {
                 throw new ConfigurationException("ip", "The ip address must not be empty.");
             }
             this.ip = ip;
 
-            String username = Objects.toString(config.get("username"), ""); //$NON-NLS-1$
+            String username = Objects.toString(config.get("username"), null); //$NON-NLS-1$
             if (StringUtils.isBlank(username)) {
                 throw new ConfigurationException("username", "The username must not be empty.");
             }
             this.username = username;
 
-            String password = Objects.toString(config.get("password"), ""); //$NON-NLS-1$
+            String password = Objects.toString(config.get("password"), null); //$NON-NLS-1$
             if (StringUtils.isBlank(password)) {
                 throw new ConfigurationException("password", "The password must not be empty.");
             }

--- a/bundles/binding/org.openhab.binding.fritzbox/src/main/java/org/openhab/binding/fritzbox/internal/FritzboxBinding.java
+++ b/bundles/binding/org.openhab.binding.fritzbox/src/main/java/org/openhab/binding/fritzbox/internal/FritzboxBinding.java
@@ -183,7 +183,7 @@ public class FritzboxBinding extends AbstractActiveBinding<FritzboxBindingProvid
     public void updated(Dictionary config) throws ConfigurationException {
 
         if (config != null) {
-            String ip = Objects.toString(config.get("ip"), "");
+            String ip = Objects.toString(config.get("ip"), null);
             if (StringUtils.isNotBlank(ip)) {
                 if (!ip.equals(FritzboxBinding.ip)) {
                     // only do something if the ip has changed
@@ -217,12 +217,12 @@ public class FritzboxBinding extends AbstractActiveBinding<FritzboxBindingProvid
                     }
                 }
             }
-            String password = Objects.toString(config.get("password"), "");
+            String password = Objects.toString(config.get("password"), null);
             if (StringUtils.isNotBlank(password)) {
                 FritzboxBinding.password = password;
             }
 
-            String username = Objects.toString(config.get("user"), "");
+            String username = Objects.toString(config.get("user"), null);
             if (StringUtils.isNotBlank(username)) {
                 FritzboxBinding.username = username;
             }

--- a/bundles/binding/org.openhab.binding.fritzbox/src/main/java/org/openhab/binding/fritzbox/internal/FritzboxBinding.java
+++ b/bundles/binding/org.openhab.binding.fritzbox/src/main/java/org/openhab/binding/fritzbox/internal/FritzboxBinding.java
@@ -20,6 +20,7 @@ import java.net.Socket;
 import java.util.Collection;
 import java.util.Dictionary;
 import java.util.HashMap;
+import java.util.Objects;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.net.telnet.TelnetClient;
@@ -61,7 +62,7 @@ import org.slf4j.LoggerFactory;
  * @author Jan N. Klug
  * @since 0.7.0
  */
-public class FritzboxBinding extends AbstractActiveBinding<FritzboxBindingProvider>implements ManagedService {
+public class FritzboxBinding extends AbstractActiveBinding<FritzboxBindingProvider> implements ManagedService {
 
     private static HashMap<String, String> commandMap = new HashMap<String, String>();
     private static HashMap<String, String> queryMap = new HashMap<String, String>();
@@ -182,7 +183,7 @@ public class FritzboxBinding extends AbstractActiveBinding<FritzboxBindingProvid
     public void updated(Dictionary config) throws ConfigurationException {
 
         if (config != null) {
-            String ip = (String) config.get("ip");
+            String ip = Objects.toString(config.get("ip"), "");
             if (StringUtils.isNotBlank(ip)) {
                 if (!ip.equals(FritzboxBinding.ip)) {
                     // only do something if the ip has changed
@@ -216,12 +217,12 @@ public class FritzboxBinding extends AbstractActiveBinding<FritzboxBindingProvid
                     }
                 }
             }
-            String password = (String) config.get("password");
+            String password = Objects.toString(config.get("password"), "");
             if (StringUtils.isNotBlank(password)) {
                 FritzboxBinding.password = password;
             }
 
-            String username = (String) config.get("user");
+            String username = Objects.toString(config.get("user"), "");
             if (StringUtils.isNotBlank(username)) {
                 FritzboxBinding.username = username;
             }

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/FritzboxTr064Binding.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/FritzboxTr064Binding.java
@@ -9,6 +9,7 @@
 package org.openhab.binding.fritzboxtr064.internal;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.fritzboxtr064.FritzboxTr064BindingProvider;
@@ -77,16 +78,16 @@ public class FritzboxTr064Binding extends AbstractActiveBinding<FritzboxTr064Bin
 
         // to override the default refresh interval one has to add a
         // parameter to openhab.cfg like <bindingName>:refresh=<intervalInMs>
-        String refreshIntervalString = (String) configuration.get("refresh");
+        String refreshIntervalString = Objects.toString(configuration.get("refresh"), "");
         if (StringUtils.isNotBlank(refreshIntervalString)) {
             refreshInterval = Long.parseLong(refreshIntervalString);
             logger.debug("Custom refresh interval set to " + refreshInterval);
         }
 
         // Check if fritzbox parameters were provided in config, otherwise does not make sense going on...
-        String fboxurl = (String) configuration.get("url");
-        String fboxuser = (String) configuration.get("user");
-        String fboxpw = (String) configuration.get("pass");
+        String fboxurl = Objects.toString(configuration.get("url"), "");
+        String fboxuser = Objects.toString(configuration.get("user"), "");
+        String fboxpw = Objects.toString(configuration.get("pass"), "");
         if (fboxurl == null) {
             logger.warn("Fritzbox URL was not provided in config. Shutting down binding.");
             // how to shutdown??

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/FritzboxTr064Binding.java
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/src/main/java/org/openhab/binding/fritzboxtr064/internal/FritzboxTr064Binding.java
@@ -78,16 +78,16 @@ public class FritzboxTr064Binding extends AbstractActiveBinding<FritzboxTr064Bin
 
         // to override the default refresh interval one has to add a
         // parameter to openhab.cfg like <bindingName>:refresh=<intervalInMs>
-        String refreshIntervalString = Objects.toString(configuration.get("refresh"), "");
+        String refreshIntervalString = Objects.toString(configuration.get("refresh"), null);
         if (StringUtils.isNotBlank(refreshIntervalString)) {
             refreshInterval = Long.parseLong(refreshIntervalString);
-            logger.debug("Custom refresh interval set to " + refreshInterval);
+            logger.debug("Custom refresh interval set to {}", refreshInterval);
         }
 
         // Check if fritzbox parameters were provided in config, otherwise does not make sense going on...
-        String fboxurl = Objects.toString(configuration.get("url"), "");
-        String fboxuser = Objects.toString(configuration.get("user"), "");
-        String fboxpw = Objects.toString(configuration.get("pass"), "");
+        String fboxurl = Objects.toString(configuration.get("url"), null);
+        String fboxuser = Objects.toString(configuration.get("user"), null);
+        String fboxpw = Objects.toString(configuration.get("pass"), null);
         if (fboxurl == null) {
             logger.warn("Fritzbox URL was not provided in config. Shutting down binding.");
             // how to shutdown??

--- a/bundles/binding/org.openhab.binding.garadget/src/main/java/org/openhab/binding/garadget/internal/GaradgetBinding.java
+++ b/bundles/binding/org.openhab.binding.garadget/src/main/java/org/openhab/binding/garadget/internal/GaradgetBinding.java
@@ -101,27 +101,27 @@ public class GaradgetBinding extends AbstractActiveBinding<GaradgetBindingProvid
 
         // to override the default granularity one has to add a
         // parameter to the .cfg like [garadget:]granularity=2000
-        String granularityString = Objects.toString(configuration.get(CONFIG_GRANULARITY), "");
+        String granularityString = Objects.toString(configuration.get(CONFIG_GRANULARITY), null);
         granularity = isNotBlank(granularityString) ? Long.parseLong(granularityString) : DEFAULT_GRANULARITY;
 
         // to override the default refresh interval one has to add a
         // parameter to .cfg like [garadget:]refresh=240000
-        String refreshIntervalString = Objects.toString(configuration.get(CONFIG_REFRESH), "");
+        String refreshIntervalString = Objects.toString(configuration.get(CONFIG_REFRESH), null);
         refreshInterval = isNotBlank(refreshIntervalString) ? Long.parseLong(refreshIntervalString) : DEFAULT_REFRESH;
 
         // to override the default quickPoll interval one has to add a
         // parameter to .cfg like [garadget:]quickpoll=4000
-        String quickPollIntervalString = Objects.toString(configuration.get(CONFIG_QUICKPOLL), "");
+        String quickPollIntervalString = Objects.toString(configuration.get(CONFIG_QUICKPOLL), null);
         quickPollInterval = isNotBlank(quickPollIntervalString) ? Long.parseLong(quickPollIntervalString)
                 : DEFAULT_QUICKPOLL;
 
         // to override the default HTTP timeout one has to add a
         // parameter to .cfg like [garadget:]timeout=20000
-        String timeoutString = Objects.toString(configuration.get(CONFIG_TIMEOUT), "");
+        String timeoutString = Objects.toString(configuration.get(CONFIG_TIMEOUT), null);
         int timeout = isNotBlank(timeoutString) ? Integer.parseInt(timeoutString) : DEFAULT_TIMEOUT;
 
-        String username = Objects.toString(configuration.get("username"), "");
-        String password = Objects.toString(configuration.get("password"), "");
+        String username = Objects.toString(configuration.get("username"), null);
+        String password = Objects.toString(configuration.get("password"), null);
 
         if (isNotBlank(username) && isNotBlank(password)) {
             connection = new Connection(username, password, timeout);

--- a/bundles/binding/org.openhab.binding.garadget/src/main/java/org/openhab/binding/garadget/internal/GaradgetBinding.java
+++ b/bundles/binding/org.openhab.binding.garadget/src/main/java/org/openhab/binding/garadget/internal/GaradgetBinding.java
@@ -12,6 +12,7 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -100,27 +101,27 @@ public class GaradgetBinding extends AbstractActiveBinding<GaradgetBindingProvid
 
         // to override the default granularity one has to add a
         // parameter to the .cfg like [garadget:]granularity=2000
-        String granularityString = (String) configuration.get(CONFIG_GRANULARITY);
+        String granularityString = Objects.toString(configuration.get(CONFIG_GRANULARITY), "");
         granularity = isNotBlank(granularityString) ? Long.parseLong(granularityString) : DEFAULT_GRANULARITY;
 
         // to override the default refresh interval one has to add a
         // parameter to .cfg like [garadget:]refresh=240000
-        String refreshIntervalString = (String) configuration.get(CONFIG_REFRESH);
+        String refreshIntervalString = Objects.toString(configuration.get(CONFIG_REFRESH), "");
         refreshInterval = isNotBlank(refreshIntervalString) ? Long.parseLong(refreshIntervalString) : DEFAULT_REFRESH;
 
         // to override the default quickPoll interval one has to add a
         // parameter to .cfg like [garadget:]quickpoll=4000
-        String quickPollIntervalString = (String) configuration.get(CONFIG_QUICKPOLL);
+        String quickPollIntervalString = Objects.toString(configuration.get(CONFIG_QUICKPOLL), "");
         quickPollInterval = isNotBlank(quickPollIntervalString) ? Long.parseLong(quickPollIntervalString)
                 : DEFAULT_QUICKPOLL;
 
         // to override the default HTTP timeout one has to add a
         // parameter to .cfg like [garadget:]timeout=20000
-        String timeoutString = (String) configuration.get(CONFIG_TIMEOUT);
+        String timeoutString = Objects.toString(configuration.get(CONFIG_TIMEOUT), "");
         int timeout = isNotBlank(timeoutString) ? Integer.parseInt(timeoutString) : DEFAULT_TIMEOUT;
 
-        String username = (String) configuration.get("username");
-        String password = (String) configuration.get("password");
+        String username = Objects.toString(configuration.get("username"), "");
+        String password = Objects.toString(configuration.get("password"), "");
 
         if (isNotBlank(username) && isNotBlank(password)) {
             connection = new Connection(username, password, timeout);

--- a/bundles/binding/org.openhab.binding.myq/src/main/java/org/openhab/binding/myq/internal/MyqBinding.java
+++ b/bundles/binding/org.openhab.binding.myq/src/main/java/org/openhab/binding/myq/internal/MyqBinding.java
@@ -126,27 +126,27 @@ public class MyqBinding extends AbstractBinding<MyqBindingProvider> {
      */
     public void modified(final Map<String, Object> configuration) {
 
-        String refreshIntervalString = Objects.toString(configuration.get("refresh"), "");
+        String refreshIntervalString = Objects.toString(configuration.get("refresh"), null);
         if (StringUtils.isNotBlank(refreshIntervalString)) {
             refreshInterval = Long.parseLong(refreshIntervalString);
         }
 
         // update the internal configuration accordingly
-        String usernameString = Objects.toString(configuration.get("username"), "");
-        String passwordString = Objects.toString(configuration.get("password"), "");
+        String usernameString = Objects.toString(configuration.get("username"), null);
+        String passwordString = Objects.toString(configuration.get("password"), null);
 
-        String appId = (String) configuration.get("appId");
+        String appId = Objects.toString(configuration.get("appId"), null);
         if (StringUtils.isBlank(appId)) {
             appId = MyqData.DEFAULT_APP_ID;
         }
 
         int timeout = MyqData.DEFAUALT_TIMEOUT;
-        String timeoutString = Objects.toString(configuration.get("timeout"), "");
+        String timeoutString = Objects.toString(configuration.get("timeout"), null);
         if (StringUtils.isNotBlank(timeoutString)) {
             timeout = Integer.parseInt(timeoutString);
         }
 
-        String craftmanString = Objects.toString(configuration.get("craftman"), "");
+        String craftmanString = Objects.toString(configuration.get("craftman"), null);
         if (StringUtils.isNotBlank(craftmanString)) {
             useCraftman = Boolean.parseBoolean(craftmanString);
         }

--- a/bundles/binding/org.openhab.binding.myq/src/main/java/org/openhab/binding/myq/internal/MyqBinding.java
+++ b/bundles/binding/org.openhab.binding.myq/src/main/java/org/openhab/binding/myq/internal/MyqBinding.java
@@ -10,6 +10,7 @@ package org.openhab.binding.myq.internal;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -125,14 +126,14 @@ public class MyqBinding extends AbstractBinding<MyqBindingProvider> {
      */
     public void modified(final Map<String, Object> configuration) {
 
-        String refreshIntervalString = (String) configuration.get("refresh");
+        String refreshIntervalString = Objects.toString(configuration.get("refresh"), "");
         if (StringUtils.isNotBlank(refreshIntervalString)) {
             refreshInterval = Long.parseLong(refreshIntervalString);
         }
 
         // update the internal configuration accordingly
-        String usernameString = (String) configuration.get("username");
-        String passwordString = (String) configuration.get("password");
+        String usernameString = Objects.toString(configuration.get("username"), "");
+        String passwordString = Objects.toString(configuration.get("password"), "");
 
         String appId = (String) configuration.get("appId");
         if (StringUtils.isBlank(appId)) {
@@ -140,12 +141,12 @@ public class MyqBinding extends AbstractBinding<MyqBindingProvider> {
         }
 
         int timeout = MyqData.DEFAUALT_TIMEOUT;
-        String timeoutString = (String) configuration.get("timeout");
+        String timeoutString = Objects.toString(configuration.get("timeout"), "");
         if (StringUtils.isNotBlank(timeoutString)) {
             timeout = Integer.parseInt(timeoutString);
         }
 
-        String craftmanString = (String) configuration.get("craftman");
+        String craftmanString = Objects.toString(configuration.get("craftman"), "");
         if (StringUtils.isNotBlank(craftmanString)) {
             useCraftman = Boolean.parseBoolean(craftmanString);
         }

--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
@@ -449,14 +449,14 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider> impl
 
             // to override the default refresh interval one has to add a
             // parameter to openhab.cfg like nest:refresh=120000
-            String refreshIntervalString = Objects.toString(config.get(CONFIG_REFRESH), "");
+            String refreshIntervalString = Objects.toString(config.get(CONFIG_REFRESH), null);
             if (isNotBlank(refreshIntervalString)) {
                 refreshInterval = Long.parseLong(refreshIntervalString);
             }
 
             // to override the default HTTP request timeout one has to add a
             // parameter to openhab.cfg like nest:timeout=20000
-            String timeoutString = Objects.toString(config.get(CONFIG_TIMEOUT), "");
+            String timeoutString = Objects.toString(config.get(CONFIG_TIMEOUT), null);
             if (isNotBlank(timeoutString)) {
                 AbstractRequest.setHttpRequestTimeout(Integer.parseInt(timeoutString));
             }
@@ -481,7 +481,7 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider> impl
                     credentialsCache.put(userid, credentials);
                 }
 
-                String value = Objects.toString(config.get(configKey), "");
+                String value = Objects.toString(config.get(configKey), null);
 
                 if (CONFIG_CLIENT_ID.equals(configKeyTail)) {
                     credentials.clientId = value;

--- a/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
+++ b/bundles/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/internal/NestBinding.java
@@ -20,6 +20,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.prefs.Preferences;
 
 import org.openhab.binding.nest.NestBindingProvider;
@@ -51,7 +52,7 @@ import org.slf4j.LoggerFactory;
  * @author John Cocula
  * @since 1.7.0
  */
-public class NestBinding extends AbstractActiveBinding<NestBindingProvider>implements ManagedService {
+public class NestBinding extends AbstractActiveBinding<NestBindingProvider> implements ManagedService {
 
     private static final String DEFAULT_USER_ID = "DEFAULT_USER";
 
@@ -448,14 +449,14 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider>imple
 
             // to override the default refresh interval one has to add a
             // parameter to openhab.cfg like nest:refresh=120000
-            String refreshIntervalString = (String) config.get(CONFIG_REFRESH);
+            String refreshIntervalString = Objects.toString(config.get(CONFIG_REFRESH), "");
             if (isNotBlank(refreshIntervalString)) {
                 refreshInterval = Long.parseLong(refreshIntervalString);
             }
 
             // to override the default HTTP request timeout one has to add a
             // parameter to openhab.cfg like nest:timeout=20000
-            String timeoutString = (String) config.get(CONFIG_TIMEOUT);
+            String timeoutString = Objects.toString(config.get(CONFIG_TIMEOUT), "");
             if (isNotBlank(timeoutString)) {
                 AbstractRequest.setHttpRequestTimeout(Integer.parseInt(timeoutString));
             }
@@ -480,7 +481,7 @@ public class NestBinding extends AbstractActiveBinding<NestBindingProvider>imple
                     credentialsCache.put(userid, credentials);
                 }
 
-                String value = (String) config.get(configKey);
+                String value = Objects.toString(config.get(configKey), "");
 
                 if (CONFIG_CLIENT_ID.equals(configKeyTail)) {
                     credentials.clientId = value;

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OneWireBinding.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OneWireBinding.java
@@ -96,7 +96,7 @@ public class OneWireBinding extends AbstractBinding<OneWireBindingProvider>
     public void updated(Dictionary<String, ?> pvConfig) throws ConfigurationException {
         if (pvConfig != null) {
             // Basic config
-            String lvPostOnlyChangedValues = Objects.toString(pvConfig.get("post_only_changed_values"), "");
+            String lvPostOnlyChangedValues = Objects.toString(pvConfig.get("post_only_changed_values"), null);
             if (StringUtils.isNotBlank(lvPostOnlyChangedValues)) {
                 ivPostOnlyChangedValues = Boolean.getBoolean(lvPostOnlyChangedValues);
             }
@@ -127,8 +127,7 @@ public class OneWireBinding extends AbstractBinding<OneWireBindingProvider>
             AbstractOneWireControlBindingConfig lvControlBindingConfig = (AbstractOneWireControlBindingConfig) lvBindigConfig;
             lvControlBindingConfig.executeControl(this, pvCommand);
         } else {
-            logger.debug("received command {} for item {} which is not writable or executable", pvCommand,
-                    pvItemName);
+            logger.debug("received command {} for item {} which is not writable or executable", pvCommand, pvItemName);
         }
     }
 

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OneWireBinding.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/OneWireBinding.java
@@ -11,6 +11,7 @@ package org.openhab.binding.onewire.internal;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.onewire.OneWireBindingProvider;
@@ -95,7 +96,7 @@ public class OneWireBinding extends AbstractBinding<OneWireBindingProvider>
     public void updated(Dictionary<String, ?> pvConfig) throws ConfigurationException {
         if (pvConfig != null) {
             // Basic config
-            String lvPostOnlyChangedValues = (String) pvConfig.get("post_only_changed_values");
+            String lvPostOnlyChangedValues = Objects.toString(pvConfig.get("post_only_changed_values"), "");
             if (StringUtils.isNotBlank(lvPostOnlyChangedValues)) {
                 ivPostOnlyChangedValues = Boolean.getBoolean(lvPostOnlyChangedValues);
             }

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/connection/OneWireConnection.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/connection/OneWireConnection.java
@@ -186,13 +186,13 @@ public class OneWireConnection {
         }
 
         logger.debug("OneWire configuration present. Setting up owserver connection.");
-        cvIp = Objects.toString(pvConfig.get("ip"), "");
+        cvIp = Objects.toString(pvConfig.get("ip"), null);
         if (StringUtils.isBlank(cvIp)) {
             logger.error("owserver IP address was configured as an empty string.");
             throw new ConfigurationException("onewire:ip", "owserver IP address was configured as an empty string.");
         }
 
-        String lvPortConfig = Objects.toString(pvConfig.get("port"), "");
+        String lvPortConfig = Objects.toString(pvConfig.get("port"), null);
         if (StringUtils.isNotBlank(lvPortConfig)) {
             cvPort = Integer.parseInt(lvPortConfig);
         }
@@ -203,7 +203,7 @@ public class OneWireConnection {
         }
         logger.debug("owserver ip:port = {}:{}", cvIp, cvPort);
 
-        String lvTempScaleString = Objects.toString(pvConfig.get("tempscale"), "");
+        String lvTempScaleString = Objects.toString(pvConfig.get("tempscale"), null);
         if (StringUtils.isNotBlank(lvTempScaleString)) {
             try {
                 cvTempScale = OwTemperatureScale.valueOf(lvTempScaleString);
@@ -215,19 +215,19 @@ public class OneWireConnection {
             }
         }
 
-        String lvRetryString = Objects.toString(pvConfig.get("retry"), "");
+        String lvRetryString = Objects.toString(pvConfig.get("retry"), null);
         if (StringUtils.isNotBlank(lvRetryString)) {
             cvRetry = Integer.parseInt(lvRetryString);
         }
         logger.debug("onewire:retry = {}", cvRetry);
 
-        String lvServerRetries = Objects.toString(pvConfig.get("server_retries"), "");
+        String lvServerRetries = Objects.toString(pvConfig.get("server_retries"), null);
         if (StringUtils.isNotBlank(lvServerRetries)) {
             cvServerRetries = Integer.parseInt(lvServerRetries);
         }
         logger.debug("onewire:server_retries = {}", cvServerRetries);
 
-        String lvRetryIntervalString = Objects.toString(pvConfig.get("server_retryInterval"), "");
+        String lvRetryIntervalString = Objects.toString(pvConfig.get("server_retryInterval"), null);
         if (StringUtils.isNotBlank(lvRetryIntervalString)) {
             cvServerRetryInterval = Integer.parseInt(lvRetryIntervalString);
             if (cvServerRetryInterval < 5 && cvServerRetryInterval > 0) {
@@ -342,14 +342,13 @@ public class OneWireConnection {
         int lvAttempt = 1;
         while (lvAttempt <= cvRetry) {
             try {
-                logger.debug("Trying to write '{}' to '{}', write attempt={}",
-                        pvValue, pvDevicePropertyPath, lvAttempt);
+                logger.debug("Trying to write '{}' to '{}', write attempt={}", pvValue, pvDevicePropertyPath,
+                        lvAttempt);
                 if (checkIfDeviceExists(pvDevicePropertyPath)) {
                     OneWireConnection.getConnection().write(pvDevicePropertyPath, pvValue);
                     return; // Success, exit
                 } else {
-                    logger.info("There is no device for path {}, write attempt={}",
-                            pvDevicePropertyPath, lvAttempt);
+                    logger.info("There is no device for path {}, write attempt={}", pvDevicePropertyPath, lvAttempt);
                 }
             } catch (OwfsException oe) {
                 logger.error("Writing {} to path {} attempt {} threw an exception", pvValue, pvDevicePropertyPath,

--- a/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/connection/OneWireConnection.java
+++ b/bundles/binding/org.openhab.binding.onewire/src/main/java/org/openhab/binding/onewire/internal/connection/OneWireConnection.java
@@ -11,6 +11,7 @@ package org.openhab.binding.onewire.internal.connection;
 import java.io.IOException;
 import java.util.Dictionary;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.onewire.internal.deviceproperties.AbstractOneWireDevicePropertyBindingConfig;
@@ -185,13 +186,13 @@ public class OneWireConnection {
         }
 
         logger.debug("OneWire configuration present. Setting up owserver connection.");
-        cvIp = (String) pvConfig.get("ip");
+        cvIp = Objects.toString(pvConfig.get("ip"), "");
         if (StringUtils.isBlank(cvIp)) {
             logger.error("owserver IP address was configured as an empty string.");
             throw new ConfigurationException("onewire:ip", "owserver IP address was configured as an empty string.");
         }
 
-        String lvPortConfig = (String) pvConfig.get("port");
+        String lvPortConfig = Objects.toString(pvConfig.get("port"), "");
         if (StringUtils.isNotBlank(lvPortConfig)) {
             cvPort = Integer.parseInt(lvPortConfig);
         }
@@ -202,7 +203,7 @@ public class OneWireConnection {
         }
         logger.debug("owserver ip:port = {}:{}", cvIp, cvPort);
 
-        String lvTempScaleString = (String) pvConfig.get("tempscale");
+        String lvTempScaleString = Objects.toString(pvConfig.get("tempscale"), "");
         if (StringUtils.isNotBlank(lvTempScaleString)) {
             try {
                 cvTempScale = OwTemperatureScale.valueOf(lvTempScaleString);
@@ -214,19 +215,19 @@ public class OneWireConnection {
             }
         }
 
-        String lvRetryString = (String) pvConfig.get("retry");
+        String lvRetryString = Objects.toString(pvConfig.get("retry"), "");
         if (StringUtils.isNotBlank(lvRetryString)) {
             cvRetry = Integer.parseInt(lvRetryString);
         }
         logger.debug("onewire:retry = {}", cvRetry);
 
-        String lvServerRetries = (String) pvConfig.get("server_retries");
+        String lvServerRetries = Objects.toString(pvConfig.get("server_retries"), "");
         if (StringUtils.isNotBlank(lvServerRetries)) {
             cvServerRetries = Integer.parseInt(lvServerRetries);
         }
         logger.debug("onewire:server_retries = {}", cvServerRetries);
 
-        String lvRetryIntervalString = (String) pvConfig.get("server_retryInterval");
+        String lvRetryIntervalString = Objects.toString(pvConfig.get("server_retryInterval"), "");
         if (StringUtils.isNotBlank(lvRetryIntervalString)) {
             cvServerRetryInterval = Integer.parseInt(lvRetryIntervalString);
             if (cvServerRetryInterval < 5 && cvServerRetryInterval > 0) {

--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseBinding.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseBinding.java
@@ -25,6 +25,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang.IllegalClassException;
+import org.apache.commons.lang.ObjectUtils;
 import org.joda.time.DateTime;
 import org.openhab.binding.plugwise.PlugwiseBindingProvider;
 import org.openhab.binding.plugwise.PlugwiseCommandType;
@@ -106,7 +107,7 @@ public class PlugwiseBinding extends AbstractActiveBinding<PlugwiseBindingProvid
 
     private Stick setupStick(Dictionary<String, ?> config) {
 
-        String port = (String) config.get("stick.port");
+        String port = ObjectUtils.toString(config.get("stick.port"), null);
 
         if (port == null) {
             return null;
@@ -115,13 +116,13 @@ public class PlugwiseBinding extends AbstractActiveBinding<PlugwiseBindingProvid
         Stick stick = new Stick(port, this);
         logger.debug("Plugwise added Stick connected to serial port {}", port);
 
-        String interval = (String) config.get("stick.interval");
+        String interval = ObjectUtils.toString(config.get("stick.interval"), null);
         if (interval != null) {
             stick.setInterval(Integer.valueOf(interval));
             logger.debug("Setting the interval to send ZigBee PDUs to {} ms", interval);
         }
 
-        String retries = (String) config.get("stick.retries");
+        String retries = ObjectUtils.toString(config.get("stick.retries"), null);
         if (retries != null) {
             stick.setRetries(Integer.valueOf(retries));
             logger.debug("Setting the maximum number of attempts to send a message to ", retries);
@@ -143,7 +144,7 @@ public class PlugwiseBinding extends AbstractActiveBinding<PlugwiseBindingProvid
                 continue;
             }
 
-            String MAC = (String) config.get(deviceName + ".mac");
+            String MAC = ObjectUtils.toString(config.get(deviceName + ".mac"), null);
             if (MAC == null || MAC.equals("")) {
                 logger.warn("Plugwise can not add device with name {} without a MAC address", deviceName);
             } else if (stick.getDeviceByMAC(MAC) != null) {
@@ -152,7 +153,7 @@ public class PlugwiseBinding extends AbstractActiveBinding<PlugwiseBindingProvid
                                 + "the same MAC address is already used by device with name: {}",
                         deviceName, MAC, stick.getDeviceByMAC(MAC).name);
             } else {
-                String deviceType = (String) config.get(deviceName + ".type");
+                String deviceType = ObjectUtils.toString(config.get(deviceName + ".type"), null);
                 PlugwiseDevice device = createPlugwiseDevice(deviceType, MAC, deviceName);
 
                 if (device != null) {

--- a/bundles/binding/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/PowerMaxBinding.java
+++ b/bundles/binding/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/PowerMaxBinding.java
@@ -444,12 +444,12 @@ public class PowerMaxBinding extends AbstractActiveBinding<PowerMaxBindingProvid
         PowerMaxReceiveType.POWERLINK.setHandlerClass(PowerMaxPowerlinkMessage.class);
 
         if (config != null) {
-            String serialPortString = Objects.toString(config.get("serialPort"), "");
+            String serialPortString = Objects.toString(config.get("serialPort"), null);
             if (StringUtils.isNotBlank(serialPortString)) {
                 serialPort = serialPortString;
             }
 
-            String ipString = Objects.toString(config.get("ip"), "");
+            String ipString = Objects.toString(config.get("ip"), null);
             if (StringUtils.isNotBlank(ipString)) {
                 ipAddress = ipString;
             }
@@ -470,7 +470,7 @@ public class PowerMaxBinding extends AbstractActiveBinding<PowerMaxBindingProvid
             }
 
             if (ipAddress != null) {
-                String tcpPortString = Objects.toString(config.get("tcpPort"), "");
+                String tcpPortString = Objects.toString(config.get("tcpPort"), null);
                 if (StringUtils.isNotBlank(tcpPortString)) {
                     try {
                         tcpPort = Integer.parseInt(tcpPortString);
@@ -487,7 +487,7 @@ public class PowerMaxBinding extends AbstractActiveBinding<PowerMaxBindingProvid
                 }
             }
 
-            String motionOffDelayString = Objects.toString(config.get("motionOffDelay"), "");
+            String motionOffDelayString = Objects.toString(config.get("motionOffDelay"), null);
             if (StringUtils.isNotBlank(motionOffDelayString)) {
                 try {
                     motionOffDelay = Integer.parseInt(motionOffDelayString) * 60000;
@@ -499,22 +499,22 @@ public class PowerMaxBinding extends AbstractActiveBinding<PowerMaxBindingProvid
                 }
             }
 
-            String allowArmingString = Objects.toString(config.get("allowArming"), "");
+            String allowArmingString = Objects.toString(config.get("allowArming"), null);
             if (StringUtils.isNotBlank(allowArmingString)) {
                 allowArming = Boolean.valueOf(allowArmingString);
             }
-            String allowDisarmingString = Objects.toString(config.get("allowDisarming"), "");
+            String allowDisarmingString = Objects.toString(config.get("allowDisarming"), null);
             if (StringUtils.isNotBlank(allowDisarmingString)) {
                 allowDisarming = Boolean.valueOf(allowDisarmingString);
             }
-            String forceStandardModeString = Objects.toString(config.get("forceStandardMode"), "");
+            String forceStandardModeString = Objects.toString(config.get("forceStandardMode"), null);
             if (StringUtils.isNotBlank(forceStandardModeString)) {
                 forceStandardMode = Boolean.valueOf(forceStandardModeString);
                 PowerMaxReceiveType.POWERLINK.setHandlerClass(
                         forceStandardMode ? PowerMaxBaseMessage.class : PowerMaxPowerlinkMessage.class);
             }
 
-            String panelTypeString = Objects.toString(config.get("panelType"), "");
+            String panelTypeString = Objects.toString(config.get("panelType"), null);
             if (StringUtils.isNotBlank(panelTypeString)) {
                 try {
                     panelType = PowerMaxPanelType.fromLabel(panelTypeString);
@@ -525,12 +525,12 @@ public class PowerMaxBinding extends AbstractActiveBinding<PowerMaxBindingProvid
             }
             PowerMaxPanelSettings.initPanelSettings(panelType);
 
-            String autoSyncTimeString = Objects.toString(config.get("autoSyncTime"), "");
+            String autoSyncTimeString = Objects.toString(config.get("autoSyncTime"), null);
             if (StringUtils.isNotBlank(autoSyncTimeString)) {
                 autoSyncTime = Boolean.valueOf(autoSyncTimeString);
             }
 
-            String pinCodeString = Objects.toString(config.get("pinCode"), "");
+            String pinCodeString = Objects.toString(config.get("pinCode"), null);
             if (StringUtils.isNotBlank(pinCodeString)) {
                 pinCode = pinCodeString;
             }

--- a/bundles/binding/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/PowerMaxBinding.java
+++ b/bundles/binding/org.openhab.binding.powermax/src/main/java/org/openhab/binding/powermax/internal/PowerMaxBinding.java
@@ -12,6 +12,7 @@ import java.util.Calendar;
 import java.util.Dictionary;
 import java.util.EventObject;
 import java.util.HashMap;
+import java.util.Objects;
 
 import org.apache.commons.lang.StringUtils;
 import org.openhab.binding.powermax.PowerMaxBindingConfig;
@@ -443,12 +444,14 @@ public class PowerMaxBinding extends AbstractActiveBinding<PowerMaxBindingProvid
         PowerMaxReceiveType.POWERLINK.setHandlerClass(PowerMaxPowerlinkMessage.class);
 
         if (config != null) {
-            if (StringUtils.isNotBlank((String) config.get("serialPort"))) {
-                serialPort = (String) config.get("serialPort");
+            String serialPortString = Objects.toString(config.get("serialPort"), "");
+            if (StringUtils.isNotBlank(serialPortString)) {
+                serialPort = serialPortString;
             }
 
-            if (StringUtils.isNotBlank((String) config.get("ip"))) {
-                ipAddress = (String) config.get("ip");
+            String ipString = Objects.toString(config.get("ip"), "");
+            if (StringUtils.isNotBlank(ipString)) {
+                ipAddress = ipString;
             }
 
             if (serialPort == null && ipAddress == null) {
@@ -467,43 +470,54 @@ public class PowerMaxBinding extends AbstractActiveBinding<PowerMaxBindingProvid
             }
 
             if (ipAddress != null) {
-                if (StringUtils.isNotBlank((String) config.get("tcpPort"))) {
+                String tcpPortString = Objects.toString(config.get("tcpPort"), "");
+                if (StringUtils.isNotBlank(tcpPortString)) {
                     try {
-                        tcpPort = Integer.parseInt((String) config.get("tcpPort"));
+                        tcpPort = Integer.parseInt(tcpPortString);
                     } catch (NumberFormatException numberFormatException) {
                         tcpPort = 0;
-                        logger.warn("PowerMax alarm binding: TCP port not configured correctly (number expected)");
+                        logger.warn(
+                                "PowerMax alarm binding: TCP port not configured correctly (number expected, received '{}')",
+                                tcpPortString);
                         this.setProperlyConfigured(false);
                         throw new ConfigurationException("tcpPort",
-                                "TCP port not configured correctly (number expected)");
+                                "TCP port not configured correctly (number expected, received '" + tcpPortString
+                                        + "')");
                     }
                 }
             }
 
-            if (StringUtils.isNotBlank((String) config.get("motionOffDelay"))) {
+            String motionOffDelayString = Objects.toString(config.get("motionOffDelay"), "");
+            if (StringUtils.isNotBlank(motionOffDelayString)) {
                 try {
-                    motionOffDelay = Integer.parseInt((String) config.get("motionOffDelay")) * 60000;
+                    motionOffDelay = Integer.parseInt(motionOffDelayString) * 60000;
                 } catch (NumberFormatException numberFormatException) {
                     motionOffDelay = DEFAULT_MOTION_OFF_DELAY;
-                    logger.warn("PowerMax alarm binding: motion off delay not configured correctly (number expected)");
+                    logger.warn(
+                            "PowerMax alarm binding: motion off delay not configured correctly (number expected, received '{}')",
+                            motionOffDelayString);
                 }
             }
 
-            if (StringUtils.isNotBlank((String) config.get("allowArming"))) {
-                allowArming = Boolean.valueOf((String) config.get("allowArming"));
+            String allowArmingString = Objects.toString(config.get("allowArming"), "");
+            if (StringUtils.isNotBlank(allowArmingString)) {
+                allowArming = Boolean.valueOf(allowArmingString);
             }
-            if (StringUtils.isNotBlank((String) config.get("allowDisarming"))) {
-                allowDisarming = Boolean.valueOf((String) config.get("allowDisarming"));
+            String allowDisarmingString = Objects.toString(config.get("allowDisarming"), "");
+            if (StringUtils.isNotBlank(allowDisarmingString)) {
+                allowDisarming = Boolean.valueOf(allowDisarmingString);
             }
-            if (StringUtils.isNotBlank((String) config.get("forceStandardMode"))) {
-                forceStandardMode = Boolean.valueOf((String) config.get("forceStandardMode"));
+            String forceStandardModeString = Objects.toString(config.get("forceStandardMode"), "");
+            if (StringUtils.isNotBlank(forceStandardModeString)) {
+                forceStandardMode = Boolean.valueOf(forceStandardModeString);
                 PowerMaxReceiveType.POWERLINK.setHandlerClass(
                         forceStandardMode ? PowerMaxBaseMessage.class : PowerMaxPowerlinkMessage.class);
             }
 
-            if (StringUtils.isNotBlank((String) config.get("panelType"))) {
+            String panelTypeString = Objects.toString(config.get("panelType"), "");
+            if (StringUtils.isNotBlank(panelTypeString)) {
                 try {
-                    panelType = PowerMaxPanelType.fromLabel((String) config.get("panelType"));
+                    panelType = PowerMaxPanelType.fromLabel(panelTypeString);
                 } catch (IllegalArgumentException exception) {
                     panelType = PowerMaxPanelType.POWERMAX_PRO;
                     logger.warn("PowerMax alarm binding: panel type not configured correctly");
@@ -511,12 +525,14 @@ public class PowerMaxBinding extends AbstractActiveBinding<PowerMaxBindingProvid
             }
             PowerMaxPanelSettings.initPanelSettings(panelType);
 
-            if (StringUtils.isNotBlank((String) config.get("autoSyncTime"))) {
-                autoSyncTime = Boolean.valueOf((String) config.get("autoSyncTime"));
+            String autoSyncTimeString = Objects.toString(config.get("autoSyncTime"), "");
+            if (StringUtils.isNotBlank(autoSyncTimeString)) {
+                autoSyncTime = Boolean.valueOf(autoSyncTimeString);
             }
 
-            if (StringUtils.isNotBlank((String) config.get("pinCode"))) {
-                pinCode = (String) config.get("pinCode");
+            String pinCodeString = Objects.toString(config.get("pinCode"), "");
+            if (StringUtils.isNotBlank(pinCodeString)) {
+                pinCode = pinCodeString;
             }
 
             this.setProperlyConfigured(true);


### PR DESCRIPTION
For every current binding that has an `ESH-INF/binding/binding.xml` file with configuration parameters, replace all constructs like
```java
String configValue = (String) config.get(“configKey”);
```
with
```java
String configValue = Objects.toString(config.get(“configKey"), null);
```
Because OH2 runtime, unlike OH1 runtime, the ConfigAdmin dictionary can have non-String config values.

Signed-off-by: John Cocula <john@cocula.com>