### PR TITLE
[gcal-persistence] Remove unneeded ch.qos.logback imports

### DIFF
--- a/bundles/persistence/org.openhab.persistence.gcal/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.gcal/META-INF/MANIFEST.MF
@@ -5,14 +5,7 @@ Bundle-SymbolicName: org.openhab.persistence.gcal
 Bundle-Version: 1.9.0.qualifier
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Import-Package: ch.qos.logback.classic,
- ch.qos.logback.classic.encoder,
- ch.qos.logback.classic.spi,
- ch.qos.logback.core,
- ch.qos.logback.core.encoder,
- ch.qos.logback.core.pattern,
- ch.qos.logback.core.spi,
- com.google.api.client.auth.oauth2,
+Import-Package: com.google.api.client.auth.oauth2,
  com.google.api.client.googleapis.services,
  com.google.api.client.http,
  com.google.api.client.http.javanet,


### PR DESCRIPTION
Bundle was importing ch.qos.logback packages which were never referenced, but also not present in OH2.  See https://github.com/openhab/openhab/pull/4891#issuecomment-267331202