### PR TITLE
Update for Plex binding

### DIFF
--- a/bundles/binding/org.openhab.binding.plex/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.plex/META-INF/MANIFEST.MF
@@ -10,12 +10,13 @@ Bundle-Activator: org.openhab.binding.plex.internal.PlexActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Plex binding of the open Home Automation Bus (openHAB)
 Import-Package: javax.xml.bind,
- javax.xml.bind.annotation, 
+ javax.xml.bind.annotation,
  javax.xml.bind.annotation.adapters,
  org.apache.commons.lang,
  org.codehaus.jackson,
- org.codehaus.jackson.map,
  org.codehaus.jackson.annotate,
+ org.codehaus.jackson.map,
+ org.codehaus.jackson.map.annotate,
  org.openhab.core.binding,
  org.openhab.core.events,
  org.openhab.core.items,

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexApiLevel.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexApiLevel.java
@@ -15,7 +15,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * A little abstraction to keep track of changes within the Plex API. These are not "official" API levels used by Plex.
+ * This enum is used to keep track of changes within the Plex API. These are not "official" API levels used by Plex.
  * They are however necessary for supporting different versions of the Plex Media Server within this binding.
  *
  * @author Jeroen Idserda

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexApiLevel.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexApiLevel.java
@@ -15,7 +15,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * This enum is used to keep track of changes within the Plex API. These are not "official" API levels used by Plex.
+ * This enum keeps track of changes within the Plex API. These are not "official" API levels used by Plex.
  * They are however necessary for supporting different versions of the Plex Media Server within this binding.
  *
  * @author Jeroen Idserda
@@ -30,6 +30,15 @@ public enum PlexApiLevel {
 
     private PlexApiLevel(String fromVersion) {
         this.fromVersion = fromVersion;
+    }
+
+    /**
+     * Gets the latest (most recent) api level
+     *
+     * @return Latest api level
+     */
+    public static PlexApiLevel getLatest() {
+        return values()[values().length - 1];
     }
 
     /**
@@ -56,11 +65,11 @@ public enum PlexApiLevel {
         }
 
         // Assume latest version for unprocessable version numbers
-        return PlexApiLevel.values()[PlexApiLevel.values().length - 1];
+        return getLatest();
     }
 
     private boolean isEqualOrBeforeVersion(String version) {
-        String[] v1 = this.fromVersion.split("\\.");
+        String[] v1 = fromVersion.split("\\.");
         String[] v2 = version.split("\\.");
 
         int length = Math.min(v1.length, v2.length);

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexApiLevel.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexApiLevel.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2010-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.plex.internal;
+
+import static org.apache.commons.lang.StringUtils.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A little abstraction to keep track of changes within the Plex API. These are not "official" API levels used by Plex.
+ * They are however necessary for supporting different versions of the Plex Media Server within this binding.
+ *
+ * @author Jeroen Idserda
+ * @since 1.9.0
+ */
+public enum PlexApiLevel {
+
+    v1("0.0"),
+    v2("1.3.2.3112");
+
+    private String fromVersion;
+
+    private PlexApiLevel(String fromVersion) {
+        this.fromVersion = fromVersion;
+    }
+
+    /**
+     * Get the API level for a certain version of the Plex Media Server.
+     *
+     * @param version Version of the Plex Media Server
+     * @return The appropriate API level for this version
+     */
+    public static PlexApiLevel getApiLevel(String version) {
+        if (isNotBlank(version)) {
+            String[] versionWithBuildnumber = version.split("-");
+            String versionOnly = versionWithBuildnumber[0];
+
+            if (isNotBlank(versionOnly) && isNumeric(versionOnly.replaceAll("\\.", ""))) {
+                List<PlexApiLevel> levels = Arrays.asList(values());
+                Collections.reverse(levels);
+
+                for (PlexApiLevel level : levels) {
+                    if (level.isEqualOrBeforeVersion(versionOnly)) {
+                        return level;
+                    }
+                }
+            }
+        }
+
+        // Assume latest version for unprocessable version numbers
+        return PlexApiLevel.values()[PlexApiLevel.values().length - 1];
+    }
+
+    private boolean isEqualOrBeforeVersion(String version) {
+        String[] v1 = this.fromVersion.split("\\.");
+        String[] v2 = version.split("\\.");
+
+        int length = Math.min(v1.length, v2.length);
+        for (int i = 0; i < length; i++) {
+            int result = new Integer(v1[i]).compareTo(Integer.parseInt(v2[i]));
+            if (result != 0) {
+                return result <= 0;
+            }
+        }
+
+        return Integer.compare(v1.length, v2.length) <= 0;
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexBinding.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexBinding.java
@@ -13,6 +13,7 @@ import static org.apache.commons.lang.StringUtils.*;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
@@ -182,8 +183,13 @@ public class PlexBinding extends AbstractActiveBinding<PlexBindingProvider> {
         logger.debug("Plex config, server at {}:{}", connectionProperties.getHost(), connectionProperties.getPort());
 
         if (isNotBlank(connectionProperties.getHost())) {
-            connect(connectionProperties);
-            setProperlyConfigured(true);
+            try {
+                connect(connectionProperties);
+                setProperlyConfigured(true);
+            } catch (UnknownHostException e) {
+                setProperlyConfigured(false);
+                logger.error("Cannot resolve Plex Media Server host: " + connectionProperties.getHost());
+            }
         } else {
             logger.warn("No host configured for Plex binding");
             setProperlyConfigured(false);
@@ -229,8 +235,10 @@ public class PlexBinding extends AbstractActiveBinding<PlexBindingProvider> {
 
     /**
      * Connect to the Plex server.
+     *
+     * @throws UnknownHostException If hostname is not resolvable.
      */
-    private void connect(PlexConnectionProperties connectionProperties) {
+    private void connect(PlexConnectionProperties connectionProperties) throws UnknownHostException {
         connector = new PlexConnector(connectionProperties, new PlexUpdateReceivedCallback() {
             @Override
             public void updateReceived(PlexSession session) {

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnectionProperties.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnectionProperties.java
@@ -37,7 +37,7 @@ public class PlexConnectionProperties {
 
     private String password;
 
-    private PlexApiLevel apiLevel;
+    private PlexApiLevel apiLevel = PlexApiLevel.getLatest();
 
     public String getHost() {
         return host;

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnectionProperties.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnectionProperties.java
@@ -37,6 +37,8 @@ public class PlexConnectionProperties {
 
     private String password;
 
+    private PlexApiLevel apiLevel;
+
     public String getHost() {
         return host;
     }
@@ -93,6 +95,14 @@ public class PlexConnectionProperties {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public PlexApiLevel getApiLevel() {
+        return apiLevel;
+    }
+
+    public void setApiLevel(PlexApiLevel apiLevel) {
+        this.apiLevel = apiLevel;
     }
 
     public boolean hasToken() {

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnector.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnector.java
@@ -491,7 +491,7 @@ public class PlexConnector extends Thread {
      */
     private class PlexWebSocketListener implements WebSocketTextListener {
 
-        private ObjectMapper mapper = new ObjectMapper();
+        private final ObjectMapper mapper = new ObjectMapper();
 
         @Override
         public void onOpen(WebSocket webSocket) {

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnector.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/PlexConnector.java
@@ -190,8 +190,7 @@ public class PlexConnector extends Thread {
      */
     private void open() throws IOException, InterruptedException, ExecutionException {
         close();
-        String uri = wsUri + (connection.hasToken() ? getTokenHeaderAsQueryParam() : "");
-        webSocket = client.prepareGet(uri).execute(handler).get();
+        webSocket = client.prepareGet(addDefaultQueryParameters(wsUri)).execute(handler).get();
     }
 
     /**
@@ -396,11 +395,7 @@ public class PlexConnector extends Thread {
         }
 
         if (!isBlank(cover)) {
-            cover = String.format("%s%s", connection.getUri().toString(), cover);
-
-            if (connection.hasToken()) {
-                cover = cover + getTokenHeaderAsQueryParam();
-            }
+            cover = addDefaultQueryParameters(String.format("%s%s", connection.getUri().toString(), cover));
         }
 
         return cover;
@@ -715,7 +710,11 @@ public class PlexConnector extends Thread {
         return headers;
     }
 
-    private String getTokenHeaderAsQueryParam() {
-        return "?" + TOKEN_HEADER + "=" + connection.getToken();
+    private String addDefaultQueryParameters(String uri) {
+        if (connection.hasToken()) {
+            uri += "?" + TOKEN_HEADER + "=" + connection.getToken();
+        }
+
+        return uri;
     }
 }

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/Device.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/Device.java
@@ -34,6 +34,9 @@ public class Device {
     private String productVersion;
 
     @XmlAttribute
+    private String provides;
+
+    @XmlAttribute
     private boolean httpsRequired;
 
     @XmlElement(name = "Connection")
@@ -53,6 +56,14 @@ public class Device {
 
     public void setProductVersion(String productVersion) {
         this.productVersion = productVersion;
+    }
+
+    public String getProvides() {
+        return provides;
+    }
+
+    public void setProvides(String provides) {
+        this.provides = provides;
     }
 
     public boolean isHttpsRequired() {

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/Device.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/Device.java
@@ -19,7 +19,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * Part of {@link MediaContainer}. This object contains information about a Plex device.
- * 
+ *
  * @author Jeroen Idserda
  * @since 1.8.0
  */
@@ -27,37 +27,48 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Device {
 
-	@XmlAttribute
-	private String name;
+    @XmlAttribute
+    private String name;
 
-	@XmlAttribute
-	private boolean httpsRequired;
+    @XmlAttribute
+    private String productVersion;
 
-	@XmlElement(name = "Connection")
-	private List<Connection> connections = new ArrayList<Connection>();
+    @XmlAttribute
+    private boolean httpsRequired;
 
-	public String getName() {
-		return name;
-	}
+    @XmlElement(name = "Connection")
+    private List<Connection> connections = new ArrayList<Connection>();
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public boolean isHttpsRequired() {
-		return httpsRequired;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	public void setHttpsRequired(boolean httpsRequired) {
-		this.httpsRequired = httpsRequired;
-	}
+    public String getProductVersion() {
+        return productVersion;
+    }
 
-	public List<Connection> getConnections() {
-		return connections;
-	}
+    public void setProductVersion(String productVersion) {
+        this.productVersion = productVersion;
+    }
 
-	public void setConnections(List<Connection> connections) {
-		this.connections = connections;
-	}
+    public boolean isHttpsRequired() {
+        return httpsRequired;
+    }
+
+    public void setHttpsRequired(boolean httpsRequired) {
+        this.httpsRequired = httpsRequired;
+    }
+
+    public List<Connection> getConnections() {
+        return connections;
+    }
+
+    public void setConnections(List<Connection> connections) {
+        this.connections = connections;
+    }
 
 }

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/SessionUpdate.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/SessionUpdate.java
@@ -9,7 +9,7 @@
 package org.openhab.binding.plex.internal.communication;
 
 /**
- * ..
+ * Interface for objects containing updated information for a Plex media playing session.
  *
  * @author Jeroen Idserda
  * @since 1.9.0

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/SessionUpdate.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/SessionUpdate.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.plex.internal.communication;
+
+/**
+ * ..
+ *
+ * @author Jeroen Idserda
+ * @since 1.9.0
+ */
+public interface SessionUpdate {
+
+    public String getKey();
+
+    public String getState();
+
+    public String getSessionKey();
+
+    public Integer getViewOffset();
+
+}

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/websocket/Child.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/websocket/Child.java
@@ -6,10 +6,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.openhab.binding.plex.internal.communication;
+package org.openhab.binding.plex.internal.communication.websocket;
 
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
+import org.openhab.binding.plex.internal.communication.SessionUpdate;
 
 /**
  * Part of the {@link Update} object
@@ -18,7 +19,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
  * @since 1.7.0
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Child {
+public class Child implements SessionUpdate {
 
     @JsonProperty(value = "_elementType")
     private String elementType;
@@ -39,6 +40,7 @@ public class Child {
         this.elementType = elementType;
     }
 
+    @Override
     public String getKey() {
         return key;
     }
@@ -47,6 +49,7 @@ public class Child {
         this.key = key;
     }
 
+    @Override
     public String getSessionKey() {
         return sessionKey;
     }
@@ -55,6 +58,7 @@ public class Child {
         this.sessionKey = sessionKey;
     }
 
+    @Override
     public String getState() {
         return state;
     }
@@ -63,6 +67,7 @@ public class Child {
         this.state = state;
     }
 
+    @Override
     public Integer getViewOffset() {
         return viewOffset;
     }

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/websocket/NotificationContainer.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/websocket/NotificationContainer.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2010-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.plex.internal.communication.websocket;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.annotate.JsonRootName;
+
+/**
+ * ..
+ *
+ * @author Jeroen Idserda
+ * @since 1.9.0
+ */
+@JsonRootName(value = "NotificationContainer")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NotificationContainer {
+
+    private String type;
+
+    private Integer size;
+
+    @JsonProperty(value = "PlaySessionStateNotification")
+    private List<PlaySessionStateNotification> stateNotifications = new ArrayList<>();
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Integer getSize() {
+        return size;
+    }
+
+    public void setSize(Integer size) {
+        this.size = size;
+    }
+
+    public List<PlaySessionStateNotification> getStateNotifications() {
+        return stateNotifications;
+    }
+
+    public void setStateNotifications(List<PlaySessionStateNotification> stateNotifications) {
+        this.stateNotifications = stateNotifications;
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/websocket/NotificationContainer.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/websocket/NotificationContainer.java
@@ -16,7 +16,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonRootName;
 
 /**
- * ..
+ * This object holds updates received from the Plex websocket connection for api level 2
  *
  * @author Jeroen Idserda
  * @since 1.9.0

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/websocket/PlaySessionStateNotification.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/websocket/PlaySessionStateNotification.java
@@ -12,7 +12,7 @@ import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.openhab.binding.plex.internal.communication.SessionUpdate;
 
 /**
- * ..
+ * Part of the {@link NotificationContainer} object
  *
  * @author Jeroen Idserda
  * @since 1.9.0

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/websocket/PlaySessionStateNotification.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/websocket/PlaySessionStateNotification.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2010-2016 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.plex.internal.communication.websocket;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.openhab.binding.plex.internal.communication.SessionUpdate;
+
+/**
+ * ..
+ *
+ * @author Jeroen Idserda
+ * @since 1.9.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PlaySessionStateNotification implements SessionUpdate {
+
+    private String key;
+
+    private String sessionKey;
+
+    private String state;
+
+    private Integer viewOffset;
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public String getSessionKey() {
+        return sessionKey;
+    }
+
+    public void setSessionKey(String sessionKey) {
+        this.sessionKey = sessionKey;
+    }
+
+    @Override
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    @Override
+    public Integer getViewOffset() {
+        return viewOffset;
+    }
+
+    public void setViewOffset(Integer viewOffset) {
+        this.viewOffset = viewOffset;
+    }
+
+}

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/websocket/Update.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/websocket/Update.java
@@ -14,7 +14,7 @@ import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
- * This object holds updates received from the Plex websocket connection
+ * This object holds updates received from the Plex websocket connection for api level 1
  *
  * @author Jeroen Idserda
  * @since 1.7.0

--- a/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/websocket/Update.java
+++ b/bundles/binding/org.openhab.binding.plex/src/main/java/org/openhab/binding/plex/internal/communication/websocket/Update.java
@@ -6,7 +6,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.openhab.binding.plex.internal.communication;
+package org.openhab.binding.plex.internal.communication.websocket;
 
 import java.util.List;
 


### PR DESCRIPTION
This fixes two issues in the current Plex binding:

- Latest Plex Media Server (>= 1.3.2.3112) sends a different message format over the websocket connection. The binding now supports both this and the earlier format.
- No websocket connections were possible when authentication was enabled in PMS. The token used for other http calls is now also sent as a query parameter when connecting to the websocket. 