### PR TITLE
[Plugwise] Fix device names can sometimes not be resolved

### DIFF
--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseBinding.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/PlugwiseBinding.java
@@ -98,6 +98,7 @@ public class PlugwiseBinding extends AbstractActiveBinding<PlugwiseBindingProvid
 
         if (stick != null) {
             setupNonStickDevices(config);
+            stick.startBackgroundThreads();
             setProperlyConfigured(true);
         } else {
             logger.warn("Plugwise needs at least one Stick in order to operate");

--- a/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/Stick.java
+++ b/bundles/binding/org.openhab.binding.plugwise/src/main/java/org/openhab/binding/plugwise/internal/Stick.java
@@ -236,11 +236,14 @@ public class Stick extends PlugwiseDevice implements SerialPortEventListener {
         }
 
         initialised = true;
-        sendThread.start();
-        processMessageThread.start();
 
         // initialise the Stick
         sendMessage(new InitialiseRequestMessage());
+    }
+
+    public void startBackgroundThreads() {
+        sendThread.start();
+        processMessageThread.start();
     }
 
     /**


### PR DESCRIPTION
Sometimes the following warnings/errors show up when the binding is started:
```
2016-12-12 09:01:11.124 [WARN ] [ng.plugwise.internal.PlugwiseBinding] - Plugwise can not add device with name: light and MAC address: 000D6F0000414243, the same MAC address is already used by device with name: 000D6F0000414243
2016-12-12 09:01:11.201 [WARN ] [ng.plugwise.internal.PlugwiseBinding] - Plugwise can not add a valid device without a proper MAC address. light can not be used
2016-12-12 09:01:11.244 [ERROR] [ng.plugwise.internal.PlugwiseBinding] - Error scheduling a Quartz Job for a non-defined Plugwise device (light)
```

As a result the respective named device can not be used until the binding is restarted.

This PR resolves the issue by only starting the Stick messaging threads when `PlugwiseBinding.setupNonStickDevices(..)`  has completed. This allows for al user named devices to be setup before the binding starts automatically detecting devices. When the binding adds automatically detected devices, it uses the MAC as device name.