### PR TITLE
Beta3

### DIFF
--- a/bundles/action/org.openhab.action.astro/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.astro/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Astro Action
 Bundle-SymbolicName: org.openhab.action.astro
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.astro.internal.AstroActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Astro action of the open Home Aut

--- a/bundles/action/org.openhab.action.astro/pom.xml
+++ b/bundles/action/org.openhab.action.astro/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.dscalarm/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.dscalarm/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB DSC Alarm Action
 Bundle-SymbolicName: org.openhab.action.dscalarm
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.dscalarm.internal.DSCAlarmActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the DSC Alarm action of the open Home Automation Bus (openHAB)

--- a/bundles/action/org.openhab.action.dscalarm/pom.xml
+++ b/bundles/action/org.openhab.action.dscalarm/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.ecobee/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.ecobee/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Ecobee Action
 Bundle-SymbolicName: org.openhab.action.ecobee
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.ecobee.internal.EcobeeActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Ecobee action of the open Home Aut

--- a/bundles/action/org.openhab.action.ecobee/pom.xml
+++ b/bundles/action/org.openhab.action.ecobee/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.harmonyhub/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.harmonyhub/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB HarmonyHub Action
 Bundle-SymbolicName: org.openhab.action.harmonyhub
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.harmonyhub.internal.HarmonyHubActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the HarmonyHub action of the open Home Aut

--- a/bundles/action/org.openhab.action.harmonyhub/pom.xml
+++ b/bundles/action/org.openhab.action.harmonyhub/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openhab.bundles</groupId>
         <artifactId>action</artifactId>
-        <version>1.9.0-SNAPSHOT</version>
+        <version>1.9.0.b3</version>
     </parent>
 
     <properties>

--- a/bundles/action/org.openhab.action.homematic/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.homematic/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Homematic Action
 Bundle-SymbolicName: org.openhab.action.homematic
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.homematic.internal.HomematicActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Homematic action of the open Home Aut

--- a/bundles/action/org.openhab.action.homematic/pom.xml
+++ b/bundles/action/org.openhab.action.homematic/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.mail/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.mail/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Mail Action
 Bundle-SymbolicName: org.openhab.action.mail
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.mail.internal.MailActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Mail action of the open Home Aut

--- a/bundles/action/org.openhab.action.mail/pom.xml
+++ b/bundles/action/org.openhab.action.mail/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.mios/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.mios/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB MiOS Action
 Bundle-SymbolicName: org.openhab.action.mios
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.mios.internal.MiosActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the MiOS action of the open Home Aut

--- a/bundles/action/org.openhab.action.mios/pom.xml
+++ b/bundles/action/org.openhab.action.mios/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.mqtt/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.mqtt/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Mqtt Action
 Bundle-SymbolicName: org.openhab.action.mqtt
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.mqtt.internal.MqttActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Mqtt action of the open Home Aut

--- a/bundles/action/org.openhab.action.mqtt/pom.xml
+++ b/bundles/action/org.openhab.action.mqtt/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.nma/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.nma/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB NotifyMyAndroid Action
 Bundle-SymbolicName: org.openhab.action.nma
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.nma.internal.NotifyMyAndroidActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the NotifyMyAndroid action of the open Home Aut

--- a/bundles/action/org.openhab.action.nma/pom.xml
+++ b/bundles/action/org.openhab.action.nma/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.openwebif/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.openwebif/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB OpenWebIf Action
 Bundle-SymbolicName: org.openhab.action.openwebif
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.openwebif.internal.OpenWebIfActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the OpenWebIf action of the open Home Aut

--- a/bundles/action/org.openhab.action.openwebif/pom.xml
+++ b/bundles/action/org.openhab.action.openwebif/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.pebble/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.pebble/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Pebble Action
 Bundle-SymbolicName: org.openhab.action.pebble
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.pebble.internal.PebbleActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Pebble action of the open Home Aut

--- a/bundles/action/org.openhab.action.pebble/pom.xml
+++ b/bundles/action/org.openhab.action.pebble/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openhab.bundles</groupId>
         <artifactId>action</artifactId>
-        <version>1.9.0-SNAPSHOT</version>
+        <version>1.9.0.b3</version>
     </parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.prowl/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.prowl/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Prowl Action
 Bundle-SymbolicName: org.openhab.action.prowl
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.prowl.internal.ProwlActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Prowl action of the open Home Aut

--- a/bundles/action/org.openhab.action.prowl/pom.xml
+++ b/bundles/action/org.openhab.action.prowl/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.pushover/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.pushover/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Pushover Action
 Bundle-SymbolicName: org.openhab.action.pushover
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.pushover.internal.PushoverActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Pushover action of the open Home Automation Bus (openHAB)

--- a/bundles/action/org.openhab.action.pushover/pom.xml
+++ b/bundles/action/org.openhab.action.pushover/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.squeezebox/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.squeezebox/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Squeezebox Action
 Bundle-SymbolicName: org.openhab.action.squeezebox
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.squeezebox.internal.SqueezeboxActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Squeezebox action of the open Home Aut

--- a/bundles/action/org.openhab.action.squeezebox/pom.xml
+++ b/bundles/action/org.openhab.action.squeezebox/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.telegram/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.telegram/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Telegram Action
 Bundle-SymbolicName: org.openhab.action.telegram
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.telegram.internal.TelegramActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Telegram action of the open Home Automation Bus (openHAB)

--- a/bundles/action/org.openhab.action.telegram/pom.xml
+++ b/bundles/action/org.openhab.action.telegram/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.tinkerforge/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.tinkerforge/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB TinkerForge Action
 Bundle-SymbolicName: org.openhab.action.tinkerforge
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.tinkerforge.internal.TinkerForgeActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the TinkerForge action of the open Home Aut

--- a/bundles/action/org.openhab.action.tinkerforge/pom.xml
+++ b/bundles/action/org.openhab.action.tinkerforge/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.twitter/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.twitter/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Twitter Action
 Bundle-SymbolicName: org.openhab.action.twitter
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.twitter.internal.TwitterActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Twitter action of the open Home Aut

--- a/bundles/action/org.openhab.action.twitter/pom.xml
+++ b/bundles/action/org.openhab.action.twitter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.weather/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.weather/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Weather Action
 Bundle-SymbolicName: org.openhab.action.weather
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.weather.internal.WeatherActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Weather action of the open Home Aut

--- a/bundles/action/org.openhab.action.weather/pom.xml
+++ b/bundles/action/org.openhab.action.weather/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.xbmc/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.xbmc/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB XBMC Action
 Bundle-SymbolicName: org.openhab.action.xbmc
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.xbmc.internal.XBMCActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the XBMC action of the open Home Aut

--- a/bundles/action/org.openhab.action.xbmc/pom.xml
+++ b/bundles/action/org.openhab.action.xbmc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.xmpp/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.xmpp/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB XMPP Action
 Bundle-SymbolicName: org.openhab.action.xmpp
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.xmpp.internal.XMPPActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the XMPP action of the open Home Aut

--- a/bundles/action/org.openhab.action.xmpp/pom.xml
+++ b/bundles/action/org.openhab.action.xmpp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/org.openhab.action.xpl/META-INF/MANIFEST.MF
+++ b/bundles/action/org.openhab.action.xpl/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB xPL Action
 Bundle-SymbolicName: org.openhab.action.xpl
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.action.xpl.internal.XplActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the xPL action of the open Home Aut

--- a/bundles/action/org.openhab.action.xpl/pom.xml
+++ b/bundles/action/org.openhab.action.xpl/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>action</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/action/pom.xml
+++ b/bundles/action/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab</groupId>
     <artifactId>bundles</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/binding/org.openhab.binding.akm868/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.akm868/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB AKM868 Binding
 Bundle-SymbolicName: org.openhab.binding.akm868
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the AKM868 binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.akm868/pom.xml
+++ b/bundles/binding/org.openhab.binding.akm868/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.alarmdecoder/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.alarmdecoder.internal
 Ignore-Package: org.openhab.binding.alarmdecoder.internal
 Bundle-Name: openHAB AlarmDecoder Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.alarmdecoder.internal.AlarmDecoderActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.alarmdecoder/pom.xml
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB AlarmDecoder Binding</name>

--- a/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBinding.java
+++ b/bundles/binding/org.openhab.binding.alarmdecoder/src/main/java/org/openhab/binding/alarmdecoder/internal/AlarmDecoderBinding.java
@@ -317,6 +317,7 @@ public class AlarmDecoderBinding extends AbstractActiveBinding<AlarmDecoderBindi
                 m_port.disableReceiveFraming();
                 m_port.disableReceiveThreshold();
                 m_reader = new BufferedReader(new InputStreamReader(m_port.getInputStream()));
+                m_writer = new BufferedWriter(new OutputStreamWriter(m_port.getOutputStream()));
                 logger.info("connected to serial port: {}", m_serialDeviceName);
                 startMsgReader();
             } else {

--- a/bundles/binding/org.openhab.binding.anel/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.anel/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Anel Binding
 Bundle-SymbolicName: org.openhab.binding.anel
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.anel.internal.AnelActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Anel binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.anel/pom.xml
+++ b/bundles/binding/org.openhab.binding.anel/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.asterisk/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.asterisk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Asterisk Binding
 Bundle-SymbolicName: org.openhab.binding.asterisk
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.asterisk.internal.AsteriskActivator
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.asterisk/pom.xml
+++ b/bundles/binding/org.openhab.binding.asterisk/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Asterisk Binding</name>

--- a/bundles/binding/org.openhab.binding.astro/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.astro/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.astro.internal
 Ignore-Package: org.openhab.binding.astro.internal
 Bundle-Name: openHAB Astro Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.astro.internal.bus.AstroActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.astro/pom.xml
+++ b/bundles/binding/org.openhab.binding.astro/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.bundles</groupId>
     <artifactId>binding</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <name>openHAB Astro Binding</name>

--- a/bundles/binding/org.openhab.binding.autelis/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.autelis/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Autelis Binding
 Bundle-SymbolicName: org.openhab.binding.autelis
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Autelis binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.autelis/pom.xml
+++ b/bundles/binding/org.openhab.binding.autelis/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.benqprojector/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.benqprojector/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB BenqProjector Binding
 Bundle-SymbolicName: org.openhab.binding.benqprojector
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.benqprojector.internal.BenqProjectorActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the BenqProjector binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.benqprojector/pom.xml
+++ b/bundles/binding/org.openhab.binding.benqprojector/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.bluetooth/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.bluetooth/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Bluetooth Binding
 Bundle-SymbolicName: org.openhab.binding.bluetooth
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.bluetooth.internal.BluetoothActivator
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.bluetooth/pom.xml
+++ b/bundles/binding/org.openhab.binding.bluetooth/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Bluetooth Binding</name>

--- a/bundles/binding/org.openhab.binding.bticino/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.bticino/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Ignore-Package: org.openhab.binding.bticino.internal
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB BTicino Binding
 Bundle-SymbolicName: org.openhab.binding.bticino
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.openhab.core.binding,

--- a/bundles/binding/org.openhab.binding.bticino/pom.xml
+++ b/bundles/binding/org.openhab.binding.bticino/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.bundles</groupId>
     <artifactId>binding</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <properties>

--- a/bundles/binding/org.openhab.binding.caldav-command/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.caldav-command/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB CalDav Command Binding
 Bundle-SymbolicName: org.openhab.binding.caldav-command
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.caldav_command.internal.CalDavActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the CalDAV-Command binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.caldav-command/pom.xml
+++ b/bundles/binding/org.openhab.binding.caldav-command/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.caldav-personal/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.caldav-personal/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB CalDav Binding
 Bundle-SymbolicName: org.openhab.binding.caldav-personal
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.caldav_personal.internal.CalDavActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the CalDav-Personal binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.caldav-personal/pom.xml
+++ b/bundles/binding/org.openhab.binding.caldav-personal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.comfoair/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.comfoair/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.comfoair.internal
 Ignore-Package: org.openhab.binding.comfoair.internal
 Bundle-Name: openHAB ComfoAir Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.comfoair.internal.ComfoAirActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.comfoair/pom.xml
+++ b/bundles/binding/org.openhab.binding.comfoair/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB ComfoAir Binding</name>

--- a/bundles/binding/org.openhab.binding.configadmin/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.configadmin/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.configadmin.internal
 Ignore-Package: org.openhab.binding.configadmin.internal
 Bundle-Name: openHAB ConfigAdmin Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.configadmin.internal.ConfigAdminActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.configadmin/pom.xml
+++ b/bundles/binding/org.openhab.binding.configadmin/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB ConfigAdmin Binding</name>

--- a/bundles/binding/org.openhab.binding.cups/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.cups/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.cups.internal
 Ignore-Package: org.openhab.binding.cups.internal
 Bundle-Name: openHAB Cups Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.cups.internal.CupsActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.cups/pom.xml
+++ b/bundles/binding/org.openhab.binding.cups/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Cups Binding</name>

--- a/bundles/binding/org.openhab.binding.daikin/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.daikin/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.daikin.internal
 Ignore-Package: org.openhab.binding.daikin.internal
 Bundle-Name: openHAB Daikin Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.daikin.internal.DaikinActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.daikin/pom.xml
+++ b/bundles/binding/org.openhab.binding.daikin/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Daikin Binding</name>

--- a/bundles/binding/org.openhab.binding.davis/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.davis/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Davis Binding
 Bundle-SymbolicName: org.openhab.binding.davis
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.davis.internal.DavisActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Davis binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.davis/pom.xml
+++ b/bundles/binding/org.openhab.binding.davis/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Davis Binding</name>

--- a/bundles/binding/org.openhab.binding.denon/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.denon/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Denon Binding
 Bundle-SymbolicName: org.openhab.binding.denon
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.denon.internal.DenonActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Denon binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.denon/pom.xml
+++ b/bundles/binding/org.openhab.binding.denon/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.digitalstrom/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.digitalstrom/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB DigitalSTROM Binding
 Bundle-SymbolicName: org.openhab.binding.digitalstrom
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.digitalstrom.internal.DigitalSTROMActivator
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.digitalstrom/pom.xml
+++ b/bundles/binding/org.openhab.binding.digitalstrom/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB DigitalSTROM Binding</name>

--- a/bundles/binding/org.openhab.binding.dmx.artnet/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.dmx.artnet/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: artnet interface for openHAB DMX Binding
 Bundle-SymbolicName: org.openhab.binding.dmx.artnet
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the artnet interface of the DMX binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.dmx.artnet/pom.xml
+++ b/bundles/binding/org.openhab.binding.dmx.artnet/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB artnet interface for DMX Binding</name>

--- a/bundles/binding/org.openhab.binding.dmx.lib485/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.dmx.lib485/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: lib485 interface for openHAB DMX Binding
 Bundle-SymbolicName: org.openhab.binding.dmx.lib485
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the lib485 interface of the DMX binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.dmx.lib485/pom.xml
+++ b/bundles/binding/org.openhab.binding.dmx.lib485/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB lib485 interface for DMX Binding</name>

--- a/bundles/binding/org.openhab.binding.dmx.ola/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.dmx.ola/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: OLA interface for openHAB DMX Binding
 Bundle-SymbolicName: org.openhab.binding.dmx.ola
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the OLA inteface of the DMX binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.dmx.ola/pom.xml
+++ b/bundles/binding/org.openhab.binding.dmx.ola/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB OLA inteface for DMX Binding</name>

--- a/bundles/binding/org.openhab.binding.dmx.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.dmx.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for DMX Binding
 Bundle-SymbolicName: org.openhab.binding.dmx.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Fragment-Host: org.openhab.binding.dmx;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: openHAB.org

--- a/bundles/binding/org.openhab.binding.dmx.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.dmx.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB DMX Binding Tests</name>

--- a/bundles/binding/org.openhab.binding.dmx/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.dmx/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB DMX Binding
 Bundle-SymbolicName: org.openhab.binding.dmx
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the DMX binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.dmx/pom.xml
+++ b/bundles/binding/org.openhab.binding.dmx/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB DMX Binding</name>

--- a/bundles/binding/org.openhab.binding.dscalarm/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.dscalarm/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: openHAB DSC Alarm Binding
 Bundle-SymbolicName: org.openhab.binding.dscalarm
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.dscalarm.internal.DSCAlarmActivator
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.dscalarm/pom.xml
+++ b/bundles/binding/org.openhab.binding.dscalarm/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB DSC Alarm Binding</name>

--- a/bundles/binding/org.openhab.binding.dsmr/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.dsmr/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Ignore-Package: org.openhab.binding.dsmr.internal
 Bundle-Name: openHAB DSMR Binding
 Bundle-SymbolicName: org.openhab.binding.dsmr
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.dsmr.internal.DSMRActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the DSMR binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.dsmr/pom.xml
+++ b/bundles/binding/org.openhab.binding.dsmr/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.ebus/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.ebus/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: This is the eBus binding of the open Home Aut
  omation Bus (openHAB)
 Bundle-SymbolicName: org.openhab.binding.ebus
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: gnu.io;resolution:=optional,
  org.apache.commons.io,

--- a/bundles/binding/org.openhab.binding.ebus/pom.xml
+++ b/bundles/binding/org.openhab.binding.ebus/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB eBus Binding</name>

--- a/bundles/binding/org.openhab.binding.ecobee/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.ecobee/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Ecobee Binding
 Bundle-SymbolicName: org.openhab.binding.ecobee
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.ecobee.internal.EcobeeActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Ecobee binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.ecobee/pom.xml
+++ b/bundles/binding/org.openhab.binding.ecobee/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.ecotouch/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.ecotouch/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB EcoTouch Binding
 Bundle-SymbolicName: org.openhab.binding.ecotouch
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.ecotouch.internal.EcoTouchActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the EcoTouch binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.ecotouch/pom.xml
+++ b/bundles/binding/org.openhab.binding.ecotouch/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.ehealth/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.ehealth/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Ignore-Package: org.openhab.binding.ehealth.internal
 Bundle-Name: openHAB Libelium eHealth Binding
 Bundle-SymbolicName: org.openhab.binding.ehealth
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.ehealth.internal.EHealthActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Libelium eHealth binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.ehealth/pom.xml
+++ b/bundles/binding/org.openhab.binding.ehealth/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Libelium eHealth Binding</name>

--- a/bundles/binding/org.openhab.binding.ekey/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.ekey/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB eKey Binding
 Bundle-SymbolicName: org.openhab.binding.ekey
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.ekey.internal.EKeyActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the eKey binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.ekey/pom.xml
+++ b/bundles/binding/org.openhab.binding.ekey/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.em.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.em.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the EM binding
 Bundle-SymbolicName: org.openhab.binding.em.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.binding.em
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.em.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.em.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.em/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.em/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB EM Binding
 Bundle-SymbolicName: org.openhab.binding.em
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.em.internal.EMActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the EM binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.em/pom.xml
+++ b/bundles/binding/org.openhab.binding.em/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB EM Binding</name>

--- a/bundles/binding/org.openhab.binding.energenie/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.energenie/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Energenie Binding
 Bundle-SymbolicName: org.openhab.binding.energenie
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.energenie.internal.EnergenieActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Energenie binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.energenie/pom.xml
+++ b/bundles/binding/org.openhab.binding.energenie/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.enigma2.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.enigma2.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Enigma2 binding
 Bundle-SymbolicName: org.openhab.binding.enigma2.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.binding.enigma2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.enigma2.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.enigma2.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.enigma2/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.enigma2/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Enigma2 Binding
 Bundle-SymbolicName: org.openhab.binding.enigma2
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.enigma2.internal.Enigma2Activator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Enigma2 binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.enigma2/pom.xml
+++ b/bundles/binding/org.openhab.binding.enigma2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.enocean.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.enocean.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the EnOcean binding
 Bundle-SymbolicName: org.openhab.binding.enocean.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.binding.enocean
 Require-Bundle: org.junit;bundle-version="4.8.1"

--- a/bundles/binding/org.openhab.binding.enocean.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.enocean.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.enocean/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.enocean/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB enocean Binding
 Bundle-SymbolicName: org.openhab.binding.enocean
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.enocean.internal.EnoceanActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the enocean binding of the open Home Automation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.enocean/pom.xml
+++ b/bundles/binding/org.openhab.binding.enocean/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB EnOcean Binding</name>

--- a/bundles/binding/org.openhab.binding.enphaseenergy/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.enphaseenergy/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Enphase Energy Binding
 Bundle-SymbolicName: org.openhab.binding.enphaseenergy
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.enphaseenergy.internal.EnphaseenergyActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Enphase Energy binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.enphaseenergy/pom.xml
+++ b/bundles/binding/org.openhab.binding.enphaseenergy/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Enphase Energy Binding</name>

--- a/bundles/binding/org.openhab.binding.epsonprojector/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.epsonprojector/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Epson projector Binding
 Bundle-SymbolicName: org.openhab.binding.epsonprojector
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.epsonprojector.internal.EpsonProjectorActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Epson projector binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.epsonprojector/pom.xml
+++ b/bundles/binding/org.openhab.binding.epsonprojector/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Epson projector Binding</name>

--- a/bundles/binding/org.openhab.binding.exec.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.exec.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Exec binding
 Bundle-SymbolicName: org.openhab.binding.exec.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.binding.exec
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.exec.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.exec.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.exec/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.exec/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.exec.internal
 Ignore-Package: org.openhab.binding.exec.internal
 Bundle-Name: openHAB Exec Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.exec.internal.ExecActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.exec/pom.xml
+++ b/bundles/binding/org.openhab.binding.exec/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Exec Binding</name>

--- a/bundles/binding/org.openhab.binding.fht/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.fht/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB FHT Binding
 Bundle-SymbolicName: org.openhab.binding.fht
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.fht.internal.FHTActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the FHT binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.fht/pom.xml
+++ b/bundles/binding/org.openhab.binding.fht/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB FHT Binding</name>

--- a/bundles/binding/org.openhab.binding.freebox/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.freebox/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Freebox Binding
 Bundle-SymbolicName: org.openhab.binding.freebox
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.freebox.internal.FreeboxActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Freebox binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.freebox/pom.xml
+++ b/bundles/binding/org.openhab.binding.freebox/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.freeswitch/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.freeswitch/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Freeswitch Binding
 Bundle-SymbolicName: org.openhab.binding.freeswitch
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.freeswitch.internal.FreeswitchActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Freeswitch binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.freeswitch/pom.xml
+++ b/bundles/binding/org.openhab.binding.freeswitch/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.fritzbox/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.fritzbox/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Fritzbox Binding
 Bundle-SymbolicName: org.openhab.binding.fritzbox
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.fritzbox.internal.FritzboxActivator
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.fritzbox/pom.xml
+++ b/bundles/binding/org.openhab.binding.fritzbox/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Fritzbox Binding</name>

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB FritzboxTr064 Binding
 Bundle-SymbolicName: org.openhab.binding.fritzboxtr064
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.8.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the FritzboxTr064 binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.fritzboxtr064/pom.xml
+++ b/bundles/binding/org.openhab.binding.fritzboxtr064/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB FrontierSiliconRadio Binding
 Bundle-SymbolicName: org.openhab.binding.frontiersiliconradio
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.frontiersiliconradio.internal.FrontierSiliconRadioActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the FrontierSiliconRadio binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.frontiersiliconradio/pom.xml
+++ b/bundles/binding/org.openhab.binding.frontiersiliconradio/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.fs20/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.fs20/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB FS20 Binding
 Bundle-SymbolicName: org.openhab.binding.fs20
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.fs20.internal.FS20Activator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the FS20 binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.fs20/pom.xml
+++ b/bundles/binding/org.openhab.binding.fs20/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB FS20 Binding</name>

--- a/bundles/binding/org.openhab.binding.garadget/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.garadget/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Garadget Binding
 Bundle-SymbolicName: org.openhab.binding.garadget
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Garadget binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.garadget/pom.xml
+++ b/bundles/binding/org.openhab.binding.garadget/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.gc100ir/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.gc100ir/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB GC100IR Binding
 Bundle-SymbolicName: org.openhab.binding.gc100ir
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.gc100ir.internal.GC100IRActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the GC100IR binding of the open Home Automation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.gc100ir/pom.xml
+++ b/bundles/binding/org.openhab.binding.gc100ir/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB GC100IR Binding</name>

--- a/bundles/binding/org.openhab.binding.gpio/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.gpio/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB GPIO Binding
 Bundle-SymbolicName: org.openhab.binding.gpio
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: Dancho Penev
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.apache.commons.collections,

--- a/bundles/binding/org.openhab.binding.gpio/pom.xml
+++ b/bundles/binding/org.openhab.binding.gpio/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.harmonyhub/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.harmonyhub/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB HarmonyHub Binding
 Bundle-SymbolicName: org.openhab.binding.harmonyhub
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the HarmonyHub binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.harmonyhub/pom.xml
+++ b/bundles/binding/org.openhab.binding.harmonyhub/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.hdanywhere/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.hdanywhere/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: HDanywhere
 Bundle-SymbolicName: org.openhab.binding.hdanywhere
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.hdanywhere.internal.HDanywhereActivator
 Bundle-Vendor: openHAB
 Bundle-DocURL: http://www.openhab.org

--- a/bundles/binding/org.openhab.binding.hdanywhere/pom.xml
+++ b/bundles/binding/org.openhab.binding.hdanywhere/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.heatmiser/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.heatmiser/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.gnu.org/licenses/gpl.html
 Bundle-Name: openHAB Heatmiser Binding
 Bundle-SymbolicName: org.openhab.binding.heatmiser
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.heatmiser.internal.HeatmiserActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Heatmiser binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.heatmiser/pom.xml
+++ b/bundles/binding/org.openhab.binding.heatmiser/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Heatmiser Binding</name>

--- a/bundles/binding/org.openhab.binding.hms/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.hms/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB HMS Binding
 Bundle-SymbolicName: org.openhab.binding.hms
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.hms.internal.HMSActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the HMS binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.hms/pom.xml
+++ b/bundles/binding/org.openhab.binding.hms/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.homematic.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.homematic.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Homematic binding
 Bundle-SymbolicName: org.openhab.binding.homematic.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.binding.homematic
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.homematic.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.homematic.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.homematic/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.homematic/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB homematic Binding
 Bundle-SymbolicName: org.openhab.binding.homematic
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.homematic.internal.bus.HomematicActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the homematic binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.homematic/pom.xml
+++ b/bundles/binding/org.openhab.binding.homematic/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Homematic Binding</name>

--- a/bundles/binding/org.openhab.binding.http.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.http.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the HTTP binding
 Bundle-SymbolicName: org.openhab.binding.http.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.binding.http
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.http.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.http.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.http/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.http/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.http.internal
 Ignore-Package: org.openhab.binding.http.internal
 Bundle-Name: openHAB HTTP Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.http.internal.HttpActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.http/pom.xml
+++ b/bundles/binding/org.openhab.binding.http/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB HTTP Binding</name>

--- a/bundles/binding/org.openhab.binding.hue/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.hue/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.hue.internal
 Ignore-Package: org.openhab.binding.hue.internal
 Bundle-Name: openHAB Hue Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.hue.internal.HueActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.hue/pom.xml
+++ b/bundles/binding/org.openhab.binding.hue/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Hue Binding</name>

--- a/bundles/binding/org.openhab.binding.iec6205621meter/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.iec6205621meter/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB IEC 62056-21 Meter Binding
 Bundle-SymbolicName: org.openhab.binding.iec6205621meter
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.iec6205621meter.internal.Iec6205621MeterActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the IEC 62056-21 Meter binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.iec6205621meter/pom.xml
+++ b/bundles/binding/org.openhab.binding.iec6205621meter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.ihc/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.ihc/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.ihc.internal
 Ignore-Package: org.openhab.binding.ihc.internal
 Bundle-Name: openHAB IHC/ELKO LS Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.ihc.internal.IhcActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.ihc/pom.xml
+++ b/bundles/binding/org.openhab.binding.ihc/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB IHC / ELKO LS Binding</name>

--- a/bundles/binding/org.openhab.binding.insteonhub/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.insteonhub/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Insteon Hub Binding
 Bundle-SymbolicName: org.openhab.binding.insteonhub
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ClassPath: .
 Bundle-Activator: org.openhab.binding.insteonhub.internal.InsteonHubActivator
 Bundle-Vendor: openHAB.org

--- a/bundles/binding/org.openhab.binding.insteonhub/pom.xml
+++ b/bundles/binding/org.openhab.binding.insteonhub/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB InsteonHub Binding</name>

--- a/bundles/binding/org.openhab.binding.insteonplm/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.insteonplm/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Insteon PLM Binding
 Bundle-SymbolicName: org.openhab.binding.insteonplm
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.insteonplm.InsteonPLMActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Insteon PLM binding of the open Home Automation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.insteonplm/pom.xml
+++ b/bundles/binding/org.openhab.binding.insteonplm/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.intertechno/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.intertechno/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB CULIntertechno Binding
 Bundle-SymbolicName: org.openhab.binding.intertechno
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.intertechno.internal.CULIntertechnoActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the CULIntertechno binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.intertechno/pom.xml
+++ b/bundles/binding/org.openhab.binding.intertechno/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB CULIntertechno Binding</name>

--- a/bundles/binding/org.openhab.binding.ipx800/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.ipx800/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Ipx800 Binding
 Bundle-SymbolicName: org.openhab.binding.ipx800
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.ipx800.internal.Ipx800Activator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Ipx800 binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.ipx800/pom.xml
+++ b/bundles/binding/org.openhab.binding.ipx800/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.irtrans/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.irtrans/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.irtrans.internal
 Ignore-Package: org.openhab.binding.irtrans.internal
 Bundle-Name: openHAB irTrans Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.irtrans.internal.IRtransActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.irtrans/pom.xml
+++ b/bundles/binding/org.openhab.binding.irtrans/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.jointspace/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.jointspace/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB JointSpace Binding
 Bundle-SymbolicName: org.openhab.binding.jointspace
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.jointspace.internal.JointSpaceActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the JointSpace binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.jointspace/pom.xml
+++ b/bundles/binding/org.openhab.binding.jointspace/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.k8055/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.k8055/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB k8055 Binding
 Bundle-SymbolicName: org.openhab.binding.k8055
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.k8055.internal.k8055Activator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the k8055 binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.k8055/pom.xml
+++ b/bundles/binding/org.openhab.binding.k8055/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.knx.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.knx.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the KNX binding
 Bundle-SymbolicName: org.openhab.binding.knx.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.binding.knx
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.knx.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.knx.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.knx/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.knx/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.knx.internal
 Ignore-Package: org.openhab.binding.knx.internal
 Bundle-Name: openHAB KNX Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.knx.internal.KNXActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.knx/pom.xml
+++ b/bundles/binding/org.openhab.binding.knx/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB KNX Binding</name>

--- a/bundles/binding/org.openhab.binding.koubachi/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.koubachi/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Koubachi Binding
 Bundle-SymbolicName: org.openhab.binding.koubachi
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.koubachi.internal.KoubachiActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Koubachi binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.koubachi/pom.xml
+++ b/bundles/binding/org.openhab.binding.koubachi/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Koubachi Binding</name>

--- a/bundles/binding/org.openhab.binding.lcn/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.lcn/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB LCN Binding
 Bundle-SymbolicName: org.openhab.binding.lcn
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.lcn.internal.LcnBindingActivator
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.lcn/pom.xml
+++ b/bundles/binding/org.openhab.binding.lcn/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB LCN Binding</name>

--- a/bundles/binding/org.openhab.binding.lgtv/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.lgtv/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Lgtv Binding
 Bundle-SymbolicName: org.openhab.binding.lgtv
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.lgtv.internal.LgtvActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Lgtv binding of the open Home Automation Bus

--- a/bundles/binding/org.openhab.binding.lgtv/pom.xml
+++ b/bundles/binding/org.openhab.binding.lgtv/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.lightwaverf.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.lightwaverf.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the LightwaveRf binding
 Bundle-SymbolicName: org.openhab.binding.lightwaverf.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.binding.lightwaverf
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.lightwaverf.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.lightwaverf.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.lightwaverf/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.lightwaverf/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB LightwaveRf Binding
 Bundle-SymbolicName: org.openhab.binding.lightwaverf
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the LightwaveRf binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.lightwaverf/pom.xml
+++ b/bundles/binding/org.openhab.binding.lightwaverf/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.mailcontrol/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.mailcontrol/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB MailControl Binding
 Bundle-SymbolicName: org.openhab.binding.mailcontrol
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.mailcontrol.internal.MailControlActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the MailControl binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.mailcontrol/pom.xml
+++ b/bundles/binding/org.openhab.binding.mailcontrol/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.maxcube.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.maxcube.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the MAX!Cube binding
 Bundle-SymbolicName: org.openhab.binding.maxcube.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.binding.maxcube
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.maxcube.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.maxcube.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.maxcube/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.maxcube/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.maxcube.internal
 Ignore-Package: org.openhab.binding.maxcube.internal
 Bundle-Name: openHAB MAX!Cube Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.maxcube.internal.MaxCubeActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.maxcube/pom.xml
+++ b/bundles/binding/org.openhab.binding.maxcube/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB MaxCube Binding</name>

--- a/bundles/binding/org.openhab.binding.maxcul/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.maxcul/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB MaxCul Binding
 Bundle-SymbolicName: org.openhab.binding.maxcul
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.maxcul.internal.MaxCulActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the MaxCul binding of the open Home Automation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.maxcul/pom.xml
+++ b/bundles/binding/org.openhab.binding.maxcul/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.milight/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.milight/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Milight Binding
 Bundle-SymbolicName: org.openhab.binding.milight
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.milight.internal.MilightActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Milight binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.milight/pom.xml
+++ b/bundles/binding/org.openhab.binding.milight/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Milight Binding</name>

--- a/bundles/binding/org.openhab.binding.mios/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.mios/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB MiOS Binding
 Bundle-SymbolicName: org.openhab.binding.mios
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.mios.internal.MiosActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the MiOS binding of the open Home Automation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.mios/pom.xml
+++ b/bundles/binding/org.openhab.binding.mios/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB MiOS Binding</name>

--- a/bundles/binding/org.openhab.binding.mochadx10/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.mochadx10/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.mochadx10.internal
 Ignore-Package: org.openhab.binding.mochadx10.internal
 Bundle-Name: openHAB Mochad X10 Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.mochadx10.internal.MochadX10Activator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.mochadx10/pom.xml
+++ b/bundles/binding/org.openhab.binding.mochadx10/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Mochad X10 Binding</name>

--- a/bundles/binding/org.openhab.binding.modbus.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.modbus.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for Modbus Binding
 Bundle-SymbolicName: org.openhab.binding.modbus.test
-Bundle-Version: 1.8.0.qualifier
+Bundle-Version: 1.9.0.b3
 Fragment-Host: org.openhab.binding.modbus
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.junit

--- a/bundles/binding/org.openhab.binding.modbus.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.modbus.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Modbus Binding Tests</name>

--- a/bundles/binding/org.openhab.binding.modbus/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.modbus/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB ModbusTCP Master Binding
 Bundle-SymbolicName: org.openhab.binding.modbus
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.modbus.internal.ModbusActivator
 Bundle-Vendor: openHAB.org
 Import-Package: org.apache.commons.collections,

--- a/bundles/binding/org.openhab.binding.modbus/pom.xml
+++ b/bundles/binding/org.openhab.binding.modbus/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Modbus Binding</name>

--- a/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
+++ b/bundles/binding/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/ModbusBinding.java
@@ -607,6 +607,11 @@ public class ModbusBinding extends AbstractActiveBinding<ModbusBindingProvider>i
                 return inner.hasNext();
             }
 
+            @Override
+            public void remove() {
+                inner.remove();
+            }
+
         };
         return settingIterator;
     }

--- a/bundles/binding/org.openhab.binding.mpd/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.mpd/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.mpd.internal
 Ignore-Package: org.openhab.binding.mpd.internal
 Bundle-Name: openHAB MPD Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.mpd.internal.MpdActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.mpd/pom.xml
+++ b/bundles/binding/org.openhab.binding.mpd/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB MPD Binding</name>

--- a/bundles/binding/org.openhab.binding.mqtt/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.mqtt/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.mqtt.internal
 Ignore-Package: org.openhab.binding.mqtt.internal
 Bundle-Name: openHAB MQTT Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the MQTT binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.mqtt/pom.xml
+++ b/bundles/binding/org.openhab.binding.mqtt/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB MQTT Binding</name>

--- a/bundles/binding/org.openhab.binding.mqttitude/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.mqttitude/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.gnu.org/licenses/gpl.html
 Bundle-Name: openHAB Mqttitude Binding
 Bundle-SymbolicName: org.openhab.binding.mqttitude
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.mqttitude.internal.MqttitudeActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Mqttitude binding of the open Home Automation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.mqttitude/pom.xml
+++ b/bundles/binding/org.openhab.binding.mqttitude/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Mqttitude Binding</name>

--- a/bundles/binding/org.openhab.binding.myq/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.myq/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB myq Binding
 Bundle-SymbolicName: org.openhab.binding.myq
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the myq binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.myq/pom.xml
+++ b/bundles/binding/org.openhab.binding.myq/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.mystromecopower/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.mystromecopower/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB MyStromEcoPower Binding
 Bundle-SymbolicName: org.openhab.binding.mystromecopower
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.mystromecopower.internal.MyStromEcoPowerActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the MyStromEcoPower binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.mystromecopower/pom.xml
+++ b/bundles/binding/org.openhab.binding.mystromecopower/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.neohub/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.neohub/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB neohub Binding
 Bundle-SymbolicName: org.openhab.binding.neohub
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.neohub.internal.NeoHubActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the neohub binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.neohub/pom.xml
+++ b/bundles/binding/org.openhab.binding.neohub/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB neohub Binding</name>

--- a/bundles/binding/org.openhab.binding.nest/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.nest/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Nest Binding
 Bundle-SymbolicName: org.openhab.binding.nest
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.nest.internal.NestActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Nest binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.nest/pom.xml
+++ b/bundles/binding/org.openhab.binding.nest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.netatmo.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.netatmo.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Netatmo binding
 Bundle-SymbolicName: org.openhab.binding.netatmo.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.binding.netatmo
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.netatmo.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.netatmo.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.netatmo/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.netatmo/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Netatmo Binding
 Bundle-SymbolicName: org.openhab.binding.netatmo
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.netatmo.internal.NetatmoActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Netatmo binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.netatmo/pom.xml
+++ b/bundles/binding/org.openhab.binding.netatmo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Netatmo Binding</name>

--- a/bundles/binding/org.openhab.binding.networkhealth/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.networkhealth/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.networkhealth.internal
 Ignore-Package: org.openhab.binding.networkhealth.internal
 Bundle-Name: openHAB NetworkHealth Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.networkhealth.internal.NetworkHealthActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.networkhealth/pom.xml
+++ b/bundles/binding/org.openhab.binding.networkhealth/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB NetworkHealth Binding</name>

--- a/bundles/binding/org.openhab.binding.networkupstools/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.networkupstools/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB NetworkUpsTools Binding
 Bundle-SymbolicName: org.openhab.binding.networkupstools
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.networkupstools.internal.NetworkUpsToolsActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the NetworkUpsTools binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.networkupstools/pom.xml
+++ b/bundles/binding/org.openhab.binding.networkupstools/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.nibeheatpump/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.nibeheatpump/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB nibeheatpump Binding
 Bundle-SymbolicName: org.openhab.binding.nibeheatpump
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.nibeheatpump.internal.NibeHeatPumpActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the nibeheatpump binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.nibeheatpump/pom.xml
+++ b/bundles/binding/org.openhab.binding.nibeheatpump/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Nibe heat pump Binding</name>

--- a/bundles/binding/org.openhab.binding.nikobus.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.nikobus.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for Nikobus Binding
 Bundle-SymbolicName: org.openhab.binding.nikobus.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Fragment-Host: org.openhab.binding.nikobus;bundle-version="1.3.0"
 Bundle-Vendor: openHAB.org
 Require-Bundle: org.junit;bundle-version="4.8.1",org.openhab.io.transport.serial;bundle-version="1.3.0"

--- a/bundles/binding/org.openhab.binding.nikobus.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.nikobus.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.nikobus/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.nikobus/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Ignore-Package: org.openhab.binding.nikobus.internal
 Bundle-Name: openHAB nikobus Binding
 Bundle-SymbolicName: org.openhab.binding.nikobus
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the nikobus binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.nikobus/pom.xml
+++ b/bundles/binding/org.openhab.binding.nikobus/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Nikobus Binding</name>

--- a/bundles/binding/org.openhab.binding.novelanheatpump/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Novelan Heatpump Binding
 Bundle-SymbolicName: org.openhab.binding.novelanheatpump
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.novelanheatpump.internal.HeatPumpActivator
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.novelanheatpump/pom.xml
+++ b/bundles/binding/org.openhab.binding.novelanheatpump/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 	<name>openHAB Novelan Heatpump Binding</name>
 

--- a/bundles/binding/org.openhab.binding.ntp/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.ntp/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.ntp.internal
 Ignore-Package: org.openhab.binding.ntp.internal
 Bundle-Name: openHAB NTP Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.ntp.internal.NtpActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.ntp/pom.xml
+++ b/bundles/binding/org.openhab.binding.ntp/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB NTP Binding</name>

--- a/bundles/binding/org.openhab.binding.oceanic/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.oceanic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Oceanic Binding
 Bundle-SymbolicName: org.openhab.binding.oceanic
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.oceanic.internal.OceanicActivator
 Bundle-Vendor: openhab.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.oceanic/pom.xml
+++ b/bundles/binding/org.openhab.binding.oceanic/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Oceanic Binding</name>

--- a/bundles/binding/org.openhab.binding.octoller/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.octoller/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB octoller Binding
 Bundle-SymbolicName: org.openhab.binding.octoller
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.octoller.internal.OctollerActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the octoller binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.octoller/pom.xml
+++ b/bundles/binding/org.openhab.binding.octoller/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.omnilink/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.omnilink/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB OmniLink Binding
 Bundle-SymbolicName: org.openhab.binding.omnilink
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.omnilink.internal.OmniLinkActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the OmniLink binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.omnilink/pom.xml
+++ b/bundles/binding/org.openhab.binding.omnilink/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.onewire/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.onewire/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.onewire.internal
 Ignore-Package: org.openhab.binding.onewire.internal
 Bundle-Name: openHAB OneWire Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.onewire.internal.OneWireActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.onewire/pom.xml
+++ b/bundles/binding/org.openhab.binding.onewire/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB 1-Wire Binding</name>

--- a/bundles/binding/org.openhab.binding.onkyo/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.onkyo/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Onkyo Binding
 Bundle-SymbolicName: org.openhab.binding.onkyo
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.onkyo.internal.OnkyoActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Onkyo binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.onkyo/pom.xml
+++ b/bundles/binding/org.openhab.binding.onkyo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Onkyo Binding</name>

--- a/bundles/binding/org.openhab.binding.openenergymonitor/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.openenergymonitor/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Open Energy Monitor Binding
 Bundle-SymbolicName: org.openhab.binding.openenergymonitor
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.openenergymonitor.internal.OpenEnergyMonitorActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Open Energy Monitor binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.openenergymonitor/pom.xml
+++ b/bundles/binding/org.openhab.binding.openenergymonitor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Open Energy Monitor Binding</name>

--- a/bundles/binding/org.openhab.binding.openpaths/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.openpaths/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.gnu.org/licenses/gpl.html
 Bundle-Name: openHAB OpenPaths Binding
 Bundle-SymbolicName: org.openhab.binding.openpaths
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.openpaths.internal.OpenPathsActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the OpenPaths binding of the open Home Automation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.openpaths/pom.xml
+++ b/bundles/binding/org.openhab.binding.openpaths/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB OpenPaths Binding</name>

--- a/bundles/binding/org.openhab.binding.opensprinkler/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.opensprinkler/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB OpenSprinkler Binding
 Bundle-SymbolicName: org.openhab.binding.opensprinkler
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.opensprinkler.internal.OpenSprinklerActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the OpenSprinkler binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.opensprinkler/pom.xml
+++ b/bundles/binding/org.openhab.binding.opensprinkler/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB OpenSprinkler Binding</name>

--- a/bundles/binding/org.openhab.binding.owserver/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.owserver/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.owserver.internal
 Ignore-Package: org.openhab.binding.owserver.internal
 Bundle-Name: openHAB OWServer Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.owserver.internal.OWServerActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.owserver/pom.xml
+++ b/bundles/binding/org.openhab.binding.owserver/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB OWServer Binding</name>

--- a/bundles/binding/org.openhab.binding.panasonictv/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.panasonictv/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB PanasonicTV Binding
 Bundle-SymbolicName: org.openhab.binding.panasonictv
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.panasonictv.internal.PanasonicTVActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the PanasonicTV binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.panasonictv/pom.xml
+++ b/bundles/binding/org.openhab.binding.panasonictv/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.panstamp/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.panstamp/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB PanStamp Binding
 Bundle-SymbolicName: org.openhab.binding.panstamp
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the PanStamp binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.panstamp/pom.xml
+++ b/bundles/binding/org.openhab.binding.panstamp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.piface/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.piface/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.piface.internal
 Ignore-Package: org.openhab.binding.piface.internal
 Bundle-Name: openHAB Piface Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.piface.internal.PifaceActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.piface/pom.xml
+++ b/bundles/binding/org.openhab.binding.piface/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Piface Binding</name>

--- a/bundles/binding/org.openhab.binding.pilight.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.pilight.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the pilight binding
 Bundle-SymbolicName: org.openhab.binding.pilight.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.binding.pilight
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.pilight.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.pilight.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.pilight/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.pilight/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB pilight Binding
 Bundle-SymbolicName: org.openhab.binding.pilight
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.pilight.internal.PilightActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the pilight binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.pilight/pom.xml
+++ b/bundles/binding/org.openhab.binding.pilight/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.pioneeravr/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.pioneeravr/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Pioneer AVR Binding
 Bundle-SymbolicName: org.openhab.binding.pioneeravr
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.pioneeravr.internal.PioneerAvrActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Pioneer AVR Binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.pioneeravr/pom.xml
+++ b/bundles/binding/org.openhab.binding.pioneeravr/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Pioneer AVR Binding</name>

--- a/bundles/binding/org.openhab.binding.plcbus/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.plcbus/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB PLCBus Binding
 Bundle-SymbolicName: org.openhab.binding.plcbus
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.plcbus.internal.PLCBusActivator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: gnu.io,

--- a/bundles/binding/org.openhab.binding.plcbus/pom.xml
+++ b/bundles/binding/org.openhab.binding.plcbus/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB PLCBus Binding</name>

--- a/bundles/binding/org.openhab.binding.plex/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.plex/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Plex Binding
 Bundle-SymbolicName: org.openhab.binding.plex
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.plex.internal.PlexActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Plex binding of the open Home Automation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.plex/pom.xml
+++ b/bundles/binding/org.openhab.binding.plex/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.plugwise/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.plugwise/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Plugwise
 Bundle-SymbolicName: org.openhab.binding.plugwise
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.plugwise.internal.PlugwiseActivator
 Bundle-Vendor: openHAB
 Bundle-DocURL: http://www.openhab.org

--- a/bundles/binding/org.openhab.binding.plugwise/pom.xml
+++ b/bundles/binding/org.openhab.binding.plugwise/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Plugwise Binding</name>

--- a/bundles/binding/org.openhab.binding.powermax/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.powermax/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB PowerMax Binding
 Bundle-SymbolicName: org.openhab.binding.powermax
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the PowerMax binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.powermax/pom.xml
+++ b/bundles/binding/org.openhab.binding.powermax/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.primare/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.primare/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Primare Binding
 Bundle-SymbolicName: org.openhab.binding.primare
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.primare.internal.PrimareActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Primare binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.primare/pom.xml
+++ b/bundles/binding/org.openhab.binding.primare/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Primare Binding</name>

--- a/bundles/binding/org.openhab.binding.pulseaudio/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.pulseaudio/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: openHAB Pulseaudio Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.pulseaudio.internal.PulseaudioActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.pulseaudio/pom.xml
+++ b/bundles/binding/org.openhab.binding.pulseaudio/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Pulseaudio Binding</name>

--- a/bundles/binding/org.openhab.binding.rfxcom/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.rfxcom/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB RFXCOM Binding
 Bundle-SymbolicName: org.openhab.binding.rfxcom
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.rfxcom.internal.RFXComActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the RFXCOM binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.rfxcom/pom.xml
+++ b/bundles/binding/org.openhab.binding.rfxcom/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB RFXCOM Binding</name>

--- a/bundles/binding/org.openhab.binding.rme/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.rme/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB RME Binding
 Bundle-SymbolicName: org.openhab.binding.rme
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.rme.internal.RMEActivator
 Bundle-Vendor: openhab.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.rme/pom.xml
+++ b/bundles/binding/org.openhab.binding.rme/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB RME Binding</name>

--- a/bundles/binding/org.openhab.binding.rpircswitch/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.rpircswitch/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Raspberry Pi RC Switch Binding
 Bundle-SymbolicName: org.openhab.binding.rpircswitch
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.rpircswitch.internal.RPiRcSwitchActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the RC Switch binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.rpircswitch/pom.xml
+++ b/bundles/binding/org.openhab.binding.rpircswitch/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Raspberry Pi RC Switch Binding</name>

--- a/bundles/binding/org.openhab.binding.rwesmarthome/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.rwesmarthome/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB RWE Smarthome Binding
 Bundle-SymbolicName: org.openhab.binding.rwesmarthome
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the RWE Smarthome binding of the open Home Automation Bus (openHAB)
 Import-Package: com.google.common.base,

--- a/bundles/binding/org.openhab.binding.rwesmarthome/pom.xml
+++ b/bundles/binding/org.openhab.binding.rwesmarthome/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.s300th.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.s300th.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the S300TH binding
 Bundle-SymbolicName: org.openhab.binding.s300th.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.binding.s300th;bundle-version="1.4.0"
 Require-Bundle: org.junit;bundle-version="4.8.1"

--- a/bundles/binding/org.openhab.binding.s300th.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.s300th.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.s300th/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.s300th/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB S300TH Binding
 Bundle-SymbolicName: org.openhab.binding.s300th
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.s300th.internal.S300THActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the S300TH binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.s300th/pom.xml
+++ b/bundles/binding/org.openhab.binding.s300th/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB S300TH Binding</name>

--- a/bundles/binding/org.openhab.binding.sallegra/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.sallegra/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Sallegra Binding
 Bundle-SymbolicName: org.openhab.binding.sallegra
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Sallegra binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.sallegra/pom.xml
+++ b/bundles/binding/org.openhab.binding.sallegra/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.samsungac.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.samsungac.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Samsung Air Conditioner binding
 Bundle-SymbolicName: org.openhab.binding.samsungac.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.binding.samsungac
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.samsungac.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.samsungac.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.samsungac/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.samsungac/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Samsung AC Binding
 Bundle-SymbolicName: org.openhab.binding.samsungac
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.samsungac.internal.SamsungAcActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Samsung AC binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.samsungac/pom.xml
+++ b/bundles/binding/org.openhab.binding.samsungac/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Samsung Air Conditioner Binding</name>

--- a/bundles/binding/org.openhab.binding.samsungtv/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.samsungtv/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Samsung TV Binding
 Bundle-SymbolicName: org.openhab.binding.samsungtv
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.samsungtv.internal.SamsungTvActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Samsung TV binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.samsungtv/pom.xml
+++ b/bundles/binding/org.openhab.binding.samsungtv/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Samsung TV Binding</name>

--- a/bundles/binding/org.openhab.binding.sapp/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.sapp/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Sapp Binding
 Bundle-SymbolicName: org.openhab.binding.sapp
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Sapp binding of the open Home Automation Bus (openHAB)
 Import-Package: org.apache.commons.lang,

--- a/bundles/binding/org.openhab.binding.sapp/pom.xml
+++ b/bundles/binding/org.openhab.binding.sapp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.satel/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.satel/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Satel Binding
 Bundle-SymbolicName: org.openhab.binding.satel
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.satel.internal.SatelActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Satel binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.satel/pom.xml
+++ b/bundles/binding/org.openhab.binding.satel/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Satel Binding</name>

--- a/bundles/binding/org.openhab.binding.serial/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.serial/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Serial Binding
 Bundle-SymbolicName: org.openhab.binding.serial
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: gnu.io,

--- a/bundles/binding/org.openhab.binding.serial/pom.xml
+++ b/bundles/binding/org.openhab.binding.serial/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Serial Binding</name>

--- a/bundles/binding/org.openhab.binding.smarthomatic/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.smarthomatic/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Smarthomatic Binding
 Bundle-SymbolicName: org.openhab.binding.smarthomatic
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.smarthomatic.internal.SmarthomaticActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Smarthomatic binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.smarthomatic/pom.xml
+++ b/bundles/binding/org.openhab.binding.smarthomatic/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.smarthomatic/src-gen/main/java/readme.txt
+++ b/bundles/binding/org.openhab.binding.smarthomatic/src-gen/main/java/readme.txt
@@ -1,1 +1,0 @@
-Bundle resources go in here!

--- a/bundles/binding/org.openhab.binding.snmp/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.snmp/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.snmp.internal
 Ignore-Package: org.openhab.binding.snmp.internal
 Bundle-Name: openHAB SNMP Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.snmp.internal.SnmpActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.snmp/pom.xml
+++ b/bundles/binding/org.openhab.binding.snmp/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB SNMP Binding</name>

--- a/bundles/binding/org.openhab.binding.sonance/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.sonance/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Sonance Binding
 Bundle-SymbolicName: org.openhab.binding.sonance
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Sonance binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.sonance/pom.xml
+++ b/bundles/binding/org.openhab.binding.sonance/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.sonos/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.sonos/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Sonos Binding
 Bundle-SymbolicName: org.openhab.binding.sonos
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.sonos.internal.SonosActivator
 Bundle-Vendor: openhab.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.sonos/pom.xml
+++ b/bundles/binding/org.openhab.binding.sonos/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Sonos Binding</name>

--- a/bundles/binding/org.openhab.binding.souliss/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.souliss/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: Souliss - Arduino based SmartHome Binding
 Bundle-SymbolicName: org.openhab.binding.souliss
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.souliss.internal.SoulissActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the souliss binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.souliss/pom.xml
+++ b/bundles/binding/org.openhab.binding.souliss/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>Souliss - Arduino based SmartHome - openHAB Binding</name>

--- a/bundles/binding/org.openhab.binding.squeezebox/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.squeezebox/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.gnu.org/licenses/gpl.html
 Bundle-Name: openHAB Squeezebox Binding
 Bundle-SymbolicName: org.openhab.binding.squeezebox
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.squeezebox.internal.SqueezeboxActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Squeezebox binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.squeezebox/pom.xml
+++ b/bundles/binding/org.openhab.binding.squeezebox/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Squeezebox Binding</name>

--- a/bundles/binding/org.openhab.binding.stiebelheatpump.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.stiebelheatpump.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Stiebel Heat Pump binding
 Bundle-SymbolicName: org.openhab.binding.stiebelheatpump.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.binding.stiebelheatpump
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.stiebelheatpump.test/pom.xml
+++ b/bundles/binding/org.openhab.binding.stiebelheatpump.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.stiebelheatpump/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.stiebelheatpump/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB stiebel heat pump Binding
 Bundle-SymbolicName: org.openhab.binding.stiebelheatpump
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.stiebelheatpump.internal.StiebelHeatPumpActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the stiebel heat poump binding of the open Home Automation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.stiebelheatpump/pom.xml
+++ b/bundles/binding/org.openhab.binding.stiebelheatpump/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.swegonventilation/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.swegonventilation/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Ignore-Package: org.openhab.binding.swegonventilation.internal
 Bundle-Name: openHAB Swegon ventilation Binding
 Bundle-SymbolicName: org.openhab.binding.swegonventilation
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.swegonventilation.internal.SwegonVentilationActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Swegon ventilation binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.swegonventilation/pom.xml
+++ b/bundles/binding/org.openhab.binding.swegonventilation/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Swegon ventilation Binding</name>

--- a/bundles/binding/org.openhab.binding.systeminfo/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.systeminfo/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Systeminfo Binding
 Bundle-SymbolicName: org.openhab.binding.systeminfo
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.systeminfo.internal.SysteminfoActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Systeminfo Binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.systeminfo/pom.xml
+++ b/bundles/binding/org.openhab.binding.systeminfo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Systeminfo Binding</name>

--- a/bundles/binding/org.openhab.binding.tacmi/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.tacmi/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB TACmi Binding
 Bundle-SymbolicName: org.openhab.binding.tacmi
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the TACmi binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.tacmi/pom.xml
+++ b/bundles/binding/org.openhab.binding.tacmi/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.tcp/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.tcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB TCP-UDP Binding
 Bundle-SymbolicName: org.openhab.binding.tcp
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.tcp.internal.TCPActivator
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.tcp/pom.xml
+++ b/bundles/binding/org.openhab.binding.tcp/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB TCP/UDP Binding</name>

--- a/bundles/binding/org.openhab.binding.tellstick/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.tellstick/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Tellstick Binding
 Bundle-SymbolicName: org.openhab.binding.tellstick
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.tellstick.internal.TellstickActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Tellstick binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.tellstick/pom.xml
+++ b/bundles/binding/org.openhab.binding.tellstick/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.tinkerforge/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.tinkerforge/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Tinkerforge Binding
 Bundle-SymbolicName: org.openhab.binding.tinkerforge;singleton:=true
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.tinkerforge.internal.TinkerforgeActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Tinkerforge binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.tinkerforge/pom.xml
+++ b/bundles/binding/org.openhab.binding.tinkerforge/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Tinkerforge Binding</name>

--- a/bundles/binding/org.openhab.binding.tivo/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.tivo/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB tivo Binding
 Bundle-SymbolicName: org.openhab.binding.tivo
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.tivo.internal.TivoActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the tivo binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.tivo/pom.xml
+++ b/bundles/binding/org.openhab.binding.tivo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB TiVo Binding</name>

--- a/bundles/binding/org.openhab.binding.ucprelayboard/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.ucprelayboard/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB UCProjects.eu RelayBoard Binding
 Bundle-SymbolicName: org.openhab.binding.ucprelayboard
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: gnu.io,

--- a/bundles/binding/org.openhab.binding.ucprelayboard/pom.xml
+++ b/bundles/binding/org.openhab.binding.ucprelayboard/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB UCProjects.eu RelayBoard Binding</name>

--- a/bundles/binding/org.openhab.binding.urtsi/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.urtsi/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Somfy URTSI II Binding
 Bundle-SymbolicName: org.openhab.binding.urtsi
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.base,

--- a/bundles/binding/org.openhab.binding.urtsi/pom.xml
+++ b/bundles/binding/org.openhab.binding.urtsi/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Somfy URTSI II Binding</name>

--- a/bundles/binding/org.openhab.binding.vdr/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.vdr/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB VDR Binding
 Bundle-SymbolicName: org.openhab.binding.vdr
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.vdr.internal.VDRActivator
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.vdr/pom.xml
+++ b/bundles/binding/org.openhab.binding.vdr/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB VDR Binding</name>

--- a/bundles/binding/org.openhab.binding.wago/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.wago/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Wago Binding
 Bundle-SymbolicName: org.openhab.binding.wago
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.wago.internal.WagoActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Wago binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.wago/pom.xml
+++ b/bundles/binding/org.openhab.binding.wago/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.weather/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.weather/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.weather.internal
 Ignore-Package: org.openhab.binding.weather.internal
 Bundle-Name: openHAB Weather Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.weather.internal.bus.WeatherActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.weather/pom.xml
+++ b/bundles/binding/org.openhab.binding.weather/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.bundles</groupId>
     <artifactId>binding</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <name>openHAB Weather Binding</name>

--- a/bundles/binding/org.openhab.binding.wemo/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.wemo/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Wemo Binding
 Bundle-SymbolicName: org.openhab.binding.wemo
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.wemo.internal.WemoActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Wemo binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.wemo/pom.xml
+++ b/bundles/binding/org.openhab.binding.wemo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.withings/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.withings/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB Withings Binding
 Bundle-SymbolicName: org.openhab.binding.withings
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the Withings binding of the open Home Aut
  omation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.withings/pom.xml
+++ b/bundles/binding/org.openhab.binding.withings/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.wol/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.wol/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.binding.wol.internal
 Ignore-Package: org.openhab.binding.wol.internal
 Bundle-Name: openHAB WoL Binding
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.wol.internal.WolActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/binding/org.openhab.binding.wol/pom.xml
+++ b/bundles/binding/org.openhab.binding.wol/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Wake-on-LAN binding</name>

--- a/bundles/binding/org.openhab.binding.xbmc/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.xbmc/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB XBMC Binding
 Bundle-SymbolicName: org.openhab.binding.xbmc
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.xbmc.internal.XbmcActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the XBMC binding of the open Home Automation Bus (openHAB)

--- a/bundles/binding/org.openhab.binding.xbmc/pom.xml
+++ b/bundles/binding/org.openhab.binding.xbmc/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB XBMC Binding</name>

--- a/bundles/binding/org.openhab.binding.xpl/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.xpl/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB xPL Binding
 Bundle-SymbolicName: org.openhab.binding.xpl
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.xpl.internal.XplActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the xPL binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.xpl/pom.xml
+++ b/bundles/binding/org.openhab.binding.xpl/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.yamahareceiver/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.yamahareceiver/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB YamahaReceiver Binding
 Bundle-SymbolicName: org.openhab.binding.yamahareceiver
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-ClassPath: .
 Bundle-Activator: org.openhab.binding.yamahareceiver.internal.YamahaReceiverActivator
 Bundle-Vendor: openHAB.org

--- a/bundles/binding/org.openhab.binding.yamahareceiver/pom.xml
+++ b/bundles/binding/org.openhab.binding.yamahareceiver/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB YamahaReceiver Binding</name>

--- a/bundles/binding/org.openhab.binding.zibase/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.zibase/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB zibase Binding
 Bundle-SymbolicName: org.openhab.binding.zibase
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.zibase.internal.ZibaseActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the zibase binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.zibase/pom.xml
+++ b/bundles/binding/org.openhab.binding.zibase/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/binding/org.openhab.binding.zwave/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.zwave/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB ZWave Binding
 Bundle-SymbolicName: org.openhab.binding.zwave
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.binding.zwave.internal.ZWaveActivator
 Bundle-ManifestVersion: 2
 Bundle-Description: This is the ZWave binding of the open Home Aut

--- a/bundles/binding/org.openhab.binding.zwave/pom.xml
+++ b/bundles/binding/org.openhab.binding.zwave/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>binding</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB ZWave Binding</name>

--- a/bundles/binding/pom.xml
+++ b/bundles/binding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab</groupId>
     <artifactId>bundles</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/io/org.openhab.io.caldav/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.caldav/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.io.caldav.internal
 Ignore-Package: org.openhab.io.caldav.internal
 Bundle-Name: openHAB CalDav Calendar
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.io.caldav.internal.CalDavActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/io/org.openhab.io.caldav/pom.xml
+++ b/bundles/io/org.openhab.io.caldav/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.openhab.io.dropbox/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.dropbox/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Ignore-Package: org.openhab.io.dropbox.internal
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Dropbox IO Bundle
 Bundle-SymbolicName: org.openhab.io.dropbox
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.io.dropbox.internal.DropboxActivator
 Bundle-Vendor: openHAB.org
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/io/org.openhab.io.dropbox/pom.xml
+++ b/bundles/io/org.openhab.io.dropbox/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>io</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Dropbox Connector</name>

--- a/bundles/io/org.openhab.io.gcal.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.gcal.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Description: This is the Test-Bundle for the Google Calendar enhancement
  of the open Home Automation Bus (openHAB)
 Bundle-SymbolicName: org.openhab.io.gcal.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Fragment-Host: org.openhab.io.gcal
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.8.2"

--- a/bundles/io/org.openhab.io.gcal.test/pom.xml
+++ b/bundles/io/org.openhab.io.gcal.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.openhab.io.gcal/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.gcal/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.openhab.io.gcal.internal
 Ignore-Package: org.openhab.io.gcal.internal
 Bundle-Name: openHAB Google Calendar
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.io.gcal.internal.GCalActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/io/org.openhab.io.gcal/pom.xml
+++ b/bundles/io/org.openhab.io.gcal/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.openhab.io.gpio/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.gpio/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB GPIO IO Module
 Bundle-SymbolicName: org.openhab.io.gpio
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: Dancho Penev
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.openhab.io.gpio

--- a/bundles/io/org.openhab.io.gpio/pom.xml
+++ b/bundles/io/org.openhab.io.gpio/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.openhab.io.harmonyhub/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.harmonyhub/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB HarmonyHub IO Bundle
 Bundle-SymbolicName: org.openhab.io.harmonyhub
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.openhab.io.harmonyhub, 

--- a/bundles/io/org.openhab.io.harmonyhub/pom.xml
+++ b/bundles/io/org.openhab.io.harmonyhub/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <name>openHAB Harmony Client IO</name>

--- a/bundles/io/org.openhab.io.multimedia.tts.freetts/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.multimedia.tts.freetts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Multimedia FreeTTS
 Bundle-SymbolicName: org.openhab.io.multimedia.tts.freetts
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .,

--- a/bundles/io/org.openhab.io.multimedia.tts.freetts/pom.xml
+++ b/bundles/io/org.openhab.io.multimedia.tts.freetts/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>io</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Multimedia FreeTTS</name>

--- a/bundles/io/org.openhab.io.multimedia.tts.googletts.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.multimedia.tts.googletts.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Description: This is the Test-Bundle for the GoogleTTS enhancement
  of the open Home Automation Bus (openHAB)
 Bundle-SymbolicName: org.openhab.io.multimedia.tts.googletts.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Fragment-Host: org.openhab.io.multimedia.tts.googletts
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.8.2"

--- a/bundles/io/org.openhab.io.multimedia.tts.googletts.test/pom.xml
+++ b/bundles/io/org.openhab.io.multimedia.tts.googletts.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>io</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/io/org.openhab.io.multimedia.tts.googletts/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.multimedia.tts.googletts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Multimedia GoogleTTS
 Bundle-SymbolicName: org.openhab.io.multimedia.tts.googletts
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .,

--- a/bundles/io/org.openhab.io.multimedia.tts.googletts/pom.xml
+++ b/bundles/io/org.openhab.io.multimedia.tts.googletts/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>io</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Multimedia GoogleTTS</name>

--- a/bundles/io/org.openhab.io.multimedia.tts.macintalk/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.multimedia.tts.macintalk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Multimedia MacinTalk
 Bundle-SymbolicName: org.openhab.io.multimedia.tts.macintalk
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .

--- a/bundles/io/org.openhab.io.multimedia.tts.macintalk/pom.xml
+++ b/bundles/io/org.openhab.io.multimedia.tts.macintalk/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>io</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Multimedia MacinTalk</name>

--- a/bundles/io/org.openhab.io.multimedia.tts.marytts/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.multimedia.tts.marytts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Multimedia MaryTTS
 Bundle-SymbolicName: org.openhab.io.multimedia.tts.marytts
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .,

--- a/bundles/io/org.openhab.io.multimedia.tts.marytts/pom.xml
+++ b/bundles/io/org.openhab.io.multimedia.tts.marytts/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>io</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Multimedia MaryTTS</name>

--- a/bundles/io/org.openhab.io.multimedia.tts.speechdispatcher/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.multimedia.tts.speechdispatcher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Multimedia SpeechDispatcher
 Bundle-SymbolicName: org.openhab.io.multimedia.tts.speechdispatcher
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .,

--- a/bundles/io/org.openhab.io.multimedia.tts.speechdispatcher/pom.xml
+++ b/bundles/io/org.openhab.io.multimedia.tts.speechdispatcher/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>io</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Multimedia SpeechDispatcher</name>

--- a/bundles/io/org.openhab.io.squeezeserver/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.squeezeserver/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Squeeze Server Bundle
 Bundle-SymbolicName: org.openhab.io.squeezeserver
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.openhab.io.squeezeserver

--- a/bundles/io/org.openhab.io.squeezeserver/pom.xml
+++ b/bundles/io/org.openhab.io.squeezeserver/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>io</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Squeeze Server</name>

--- a/bundles/io/org.openhab.io.transport.cul.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.transport.cul.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the CUL I/O bundle
 Bundle-SymbolicName: org.openhab.io.transport.cul.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.io.transport.cul
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/io/org.openhab.io.transport.cul.test/pom.xml
+++ b/bundles/io/org.openhab.io.transport.cul.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.openhab.io.transport.cul/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.transport.cul/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB CUL Transport Bundle
 Bundle-SymbolicName: org.openhab.io.transport.cul
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: gnu.io,

--- a/bundles/io/org.openhab.io.transport.cul/pom.xml
+++ b/bundles/io/org.openhab.io.transport.cul/pom.xml
@@ -5,7 +5,7 @@
   <parent>
   	<groupId>org.openhab.bundles</groupId>
   	<artifactId>io</artifactId>
-  	<version>1.9.0-SNAPSHOT</version>
+  	<version>1.9.0.b3</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.openhab.io.transport.mqtt/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.transport.mqtt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB MQTT Transport Bundle
 Bundle-SymbolicName: org.openhab.io.transport.mqtt
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.paho.client.mqttv3,org.eclipse.paho.client

--- a/bundles/io/org.openhab.io.transport.mqtt/pom.xml
+++ b/bundles/io/org.openhab.io.transport.mqtt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
   	<groupId>org.openhab.bundles</groupId>
   	<artifactId>io</artifactId>
-  	<version>1.9.0-SNAPSHOT</version>
+  	<version>1.9.0.b3</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.openhab.io.transport.xpl/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.transport.xpl/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-Name: openHAB xPL Transport Bundle
 Bundle-SymbolicName: org.openhab.io.transport.xpl
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.cdp1802.xpl,

--- a/bundles/io/org.openhab.io.transport.xpl/pom.xml
+++ b/bundles/io/org.openhab.io.transport.xpl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
   	<groupId>org.openhab.bundles</groupId>
   	<artifactId>io</artifactId>
-  	<version>1.9.0-SNAPSHOT</version>
+  	<version>1.9.0.b3</version>
   </parent>
 
   <properties>

--- a/bundles/io/pom.xml
+++ b/bundles/io/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab</groupId>
     <artifactId>bundles</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/persistence/org.openhab.persistence.caldav/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.caldav/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Service-Component: OSGI-INF/caldav.xml, OSGI-INF/configuration.xml
 Bundle-Name: openHAB calDAV Persistence
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.persistence.caldav.internal.CaldavActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/persistence/org.openhab.persistence.caldav/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.caldav/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB calDAV Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.cosm/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.cosm/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Cosm Persistence Bundle
 Bundle-SymbolicName: org.openhab.persistence.cosm
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.apache.commons.httpclient;version="3.1.0",

--- a/bundles/persistence/org.openhab.persistence.cosm/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.cosm/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Cosm Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.db4o.test/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.db4o.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the db4o Persistence Bundle
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-SymbolicName: org.openhab.persistence.db4o.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.persistence.db4o
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/persistence/org.openhab.persistence.db4o.test/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.db4o.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/persistence/org.openhab.persistence.db4o/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.db4o/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Service-Component: OSGI-INF/database-db4o.xml, OSGI-INF/configuration.xml
 Bundle-Name: openHAB db4o Persistence
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.persistence.db4o.internal.Db4oActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/persistence/org.openhab.persistence.db4o/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.db4o/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB db4o Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.exec.test/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.exec.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Exec Persistence Bundle
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-SymbolicName: org.openhab.persistence.exec.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Fragment-Host: org.openhab.persistence.exec
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/persistence/org.openhab.persistence.exec.test/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.exec.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<properties>

--- a/bundles/persistence/org.openhab.persistence.exec/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.exec/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Exec Persistence Bundle
 Bundle-SymbolicName: org.openhab.persistence.exec
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 DynamicImport-Package: *

--- a/bundles/persistence/org.openhab.persistence.exec/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.exec/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Exec Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.gcal/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.gcal/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB GCal Persistence Bundle
 Bundle-SymbolicName: org.openhab.persistence.gcal
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: ch.qos.logback.classic,

--- a/bundles/persistence/org.openhab.persistence.gcal/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.gcal/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Google Calendar Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.influxdb/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.influxdb/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB InfluxDB Persistence bundle
 Bundle-SymbolicName: org.openhab.persistence.influxdb
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.apache.commons.lang,

--- a/bundles/persistence/org.openhab.persistence.influxdb/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.influxdb/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB InfluxDB Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.influxdb08/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.influxdb08/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB InfluxDB 0.8 Persistence bundle
 Bundle-SymbolicName: org.openhab.persistence.influxdb08;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Import-Package: org.apache.commons.lang,

--- a/bundles/persistence/org.openhab.persistence.influxdb08/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.influxdb08/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB InfluxDB 0.8 Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.jdbc/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.jdbc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB JDBC SQL Persistence bundle
 Bundle-SymbolicName: org.openhab.persistence.jdbc
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.mysql.jdbc;resolution:=optional,

--- a/bundles/persistence/org.openhab.persistence.jdbc/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB JDBC SQL Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.jpa/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.jpa/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB JPA Persistence bundle
 Bundle-SymbolicName: org.openhab.persistence.jpa
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 DynamicImport-Package: *

--- a/bundles/persistence/org.openhab.persistence.jpa/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.jpa/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.openhab.bundles</groupId>
         <artifactId>persistence</artifactId>
-        <version>1.9.0-SNAPSHOT</version>
+        <version>1.9.0.b3</version>
     </parent>
 
     <name>openHAB JPA Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.logging/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.logging/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Logging Persistence Bundle
 Bundle-SymbolicName: org.openhab.persistence.logging
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: ch.qos.logback.classic,

--- a/bundles/persistence/org.openhab.persistence.logging/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.logging/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Logging Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.mapdb/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.mapdb/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB MapDB Persistence Bundle
 Bundle-SymbolicName: org.openhab.persistence.mapdb
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.apache.commons.io,

--- a/bundles/persistence/org.openhab.persistence.mapdb/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.mapdb/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB MapDB Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.mongodb/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.mongodb/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB mongodb Persistence bundle
 Bundle-SymbolicName: org.openhab.persistence.mongodb
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 DynamicImport-Package: *

--- a/bundles/persistence/org.openhab.persistence.mongodb/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.mongodb/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB mongodb Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.mqtt/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.mqtt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB MQTT Persistence Bundle
 Bundle-SymbolicName: org.openhab.persistence.mqtt
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.apache.commons.io,

--- a/bundles/persistence/org.openhab.persistence.mqtt/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.mqtt/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB MQTT Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.mysql/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.mysql/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB mySQL Persistence bundle
 Bundle-SymbolicName: org.openhab.persistence.mysql
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 DynamicImport-Package: *

--- a/bundles/persistence/org.openhab.persistence.mysql/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.mysql/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB mySQL Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.rrd4j/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB RRD4j Persistence Bundle
 Bundle-SymbolicName: org.openhab.persistence.rrd4j
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: javax.servlet,

--- a/bundles/persistence/org.openhab.persistence.rrd4j/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.rrd4j/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB RRD4j Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.sense/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.sense/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Sense Persistence Bundle
 Bundle-SymbolicName: org.openhab.persistence.sense
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.apache.commons.io,

--- a/bundles/persistence/org.openhab.persistence.sense/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.sense/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB Open.Sen.se Persistence</name>

--- a/bundles/persistence/org.openhab.persistence.sitewhere/META-INF/MANIFEST.MF
+++ b/bundles/persistence/org.openhab.persistence.sitewhere/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Service-Component: OSGI-INF/persistence.xml
 Bundle-Name: openHAB SiteWhere Persistence
 Bundle-Vendor: openHAB.org
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.0.b3
 Bundle-Activator: org.openhab.persistence.sitewhere.internal.SiteWhereActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/persistence/org.openhab.persistence.sitewhere/pom.xml
+++ b/bundles/persistence/org.openhab.persistence.sitewhere/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openhab.bundles</groupId>
 		<artifactId>persistence</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.0.b3</version>
 	</parent>
 
 	<name>openHAB SiteWhere Persistence</name>

--- a/bundles/persistence/pom.xml
+++ b/bundles/persistence/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab</groupId>
     <artifactId>bundles</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab</groupId>
     <artifactId>openhab</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/openhab-addons-external/pom.xml
+++ b/features/openhab-addons-external/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.openhab</groupId>
         <artifactId>features</artifactId>
-        <version>1.9.0-SNAPSHOT</version>
+        <version>1.9.0.b3</version>
     </parent>
 
     <groupId>org.openhab.addons</groupId>

--- a/features/openhab-addons-legacy/pom.xml
+++ b/features/openhab-addons-legacy/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.openhab</groupId>
         <artifactId>features</artifactId>
-        <version>1.9.0-SNAPSHOT</version>
+        <version>1.9.0.b3</version>
     </parent>
 
     <groupId>org.openhab.addons</groupId>

--- a/features/openhab-addons-verify/pom.xml
+++ b/features/openhab-addons-verify/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.openhab</groupId>
         <artifactId>features</artifactId>
-        <version>1.9.0-SNAPSHOT</version>
+        <version>1.9.0.b3</version>
     </parent>
 
     <groupId>org.openhab.addons</groupId>

--- a/features/openhab-addons/pom.xml
+++ b/features/openhab-addons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.openhab</groupId>
         <artifactId>features</artifactId>
-        <version>1.9.0-SNAPSHOT</version>
+        <version>1.9.0.b3</version>
     </parent>
 
     <groupId>org.openhab.addons</groupId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.openhab</groupId>
     <artifactId>openhab</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>org.openhab</groupId>
     <artifactId>openhab</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.0.b3</version>
     <name>openHAB</name>
 
     <organization>
@@ -37,8 +37,8 @@
     <description>This is the open Home Automation Bus (openHAB)</description>
 
     <properties>
-        <ohdr.version>1.0.0</ohdr.version>
-        <ohc.version>2.0.0.x</ohc.version>
+        <ohdr.version>1.0.6</ohdr.version>
+        <ohc.version>2.0.0.b3</ohc.version>
         <jdeb-version>1.4</jdeb-version>
 
         <tycho-version>0.24.0</tycho-version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,17 @@
         <system>Github</system>
     </issueManagement>
 
+    <distributionManagement>
+        <repository>
+            <id>bintray</id>
+            <url>https://api.bintray.com/maven/openhab/mvn/openhab/;publish=1</url>
+        </repository>
+        <snapshotRepository>
+            <id>jfrog</id>
+            <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <description>This is the open Home Automation Bus (openHAB)</description>
 
     <properties>


### PR DESCRIPTION
Can somebody add the extra following Colormodes in the epson projector binding?
In the file EpsonProjectorDevice.java

My beamer support the following extra colormodes 
	
	CINEMANIGHT(0x05),
	VIVID(0x06),
	HD(0x09),
	SILVER(0x0A),
        CINEMADAY(0x0C),


These are the current colormodes available in the file:
        DYNAMIC(0x06),
        NATURAL(0x07),
        XVCOLOR(0x0B),
        LIVINGROOM(0x0C),
        CINEMA(0x15),
        ERROR(0xFF);
