### PR TITLE
[satel] Added ability to revert user code

### DIFF
--- a/bundles/action/org.openhab.action.satel/src/main/java/org/openhab/action/satel/internal/Satel.java
+++ b/bundles/action/org.openhab.action.satel/src/main/java/org/openhab/action/satel/internal/Satel.java
@@ -165,6 +165,15 @@ public class Satel {
         }
     }
 
+    @ActionDoc(text = "Reverts user code to the one configured in settings.")
+    public static void satelResetUserCode() {
+        if (SatelActionService.satelCommModule == null) {
+            logger.debug("Satel communication module not available - execution aborted!");
+        } else {
+            SatelActionService.satelCommModule.resetUserCode();
+        }
+    }
+
     private static class EventDescription {
         String eventText;
         int descKind;

--- a/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/SatelCommModule.java
+++ b/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/SatelCommModule.java
@@ -49,9 +49,14 @@ public interface SatelCommModule {
 
     /**
      * Overrides user code configured in settings.
-     * 
+     *
      * @param userCode user code to set
      */
     void setUserCode(String userCode);
+
+    /**
+     * Reverts user code to the value configured in settings.
+     */
+    void resetUserCode();
 
 }

--- a/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelBinding.java
+++ b/bundles/binding/org.openhab.binding.satel/src/main/java/org/openhab/binding/satel/internal/SatelBinding.java
@@ -54,6 +54,7 @@ public class SatelBinding extends AbstractActiveBinding<SatelBindingProvider>
     private SatelModule satelModule = null;
     private boolean forceRefresh = false;
     private String textEncoding;
+    private String userCodeOverride = null;
 
     /**
      * {@inheritDoc}
@@ -146,12 +147,20 @@ public class SatelBinding extends AbstractActiveBinding<SatelBindingProvider>
             if (itemConfig != null) {
                 logger.trace("Sending internal command for item {}: {}", itemName, command);
                 SatelCommand satelCmd = itemConfig.convertCommand(command, this.satelModule.getIntegraType(),
-                        this.userCode);
+                        getUserCode());
                 if (satelCmd != null) {
                     this.satelModule.sendCommand(satelCmd);
                 }
                 break;
             }
+        }
+    }
+
+    private String getUserCode() {
+        if (StringUtils.isNotEmpty(this.userCodeOverride)) {
+            return this.userCodeOverride;
+        } else {
+            return this.userCode;
         }
     }
 
@@ -318,7 +327,15 @@ public class SatelBinding extends AbstractActiveBinding<SatelBindingProvider>
      */
     @Override
     public void setUserCode(String userCode) {
-        this.userCode = userCode;
+        this.userCodeOverride = userCode;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void resetUserCode() {
+        this.userCodeOverride = null;
     }
 
 }


### PR DESCRIPTION
This PR adds new action method `satelResetUserCode()` which reverts user code set by `satelSetUserCode(String)` to the value configured in *openhab.cfg*.