### PR TITLE
updated dependency reference

### DIFF
--- a/bundles/binding/org.openhab.binding.iec6205621meter/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.iec6205621meter/META-INF/MANIFEST.MF
@@ -22,11 +22,11 @@ Import-Package: org.apache.commons.lang,
  org.osgi.service.cm,
  org.osgi.service.component,
  org.osgi.service.event,
- org.slf4j
+ org.slf4j,
+ gnu.io
 Export-Package: org.openhab.binding.iec6205621meter;uses:="org.openhab
  .core.binding"
 Bundle-DocURL: http://www.openhab.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/binding.xml, OSGI-INF/genericbindingprovider.xml
 Bundle-ClassPath: .
-Require-Bundle: org.openhab.io.transport.serial;bundle-version="1.4.0"

--- a/bundles/binding/org.openhab.binding.modbus/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.modbus/META-INF/MANIFEST.MF
@@ -29,10 +29,10 @@ Import-Package: org.apache.commons.collections,
  org.quartz.impl,
  org.quartz.impl.matchers,
  org.quartz.utils,
- org.slf4j
+ org.slf4j,
+ gnu.io
 Export-Package: org.openhab.binding.modbus
 Service-Component: OSGI-INF/*.xml
 Bundle-ClassPath: .,
  lib/commons-pool2-2.4.2.jar
-Require-Bundle: org.openhab.io.transport.serial;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/binding/org.openhab.binding.nikobus.test/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.nikobus.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.openhab.binding.nikobus.test
 Bundle-Version: 1.9.0.qualifier
 Fragment-Host: org.openhab.binding.nikobus;bundle-version="1.3.0"
 Bundle-Vendor: openHAB.org
-Require-Bundle: org.junit;bundle-version="4.8.1",org.openhab.io.transport.serial;bundle-version="1.3.0"
+Require-Bundle: org.junit;bundle-version="4.8.1"
 Bundle-ClassPath: lib/mockito-all-1.9.5.jar,
  lib/slf4j-jdk14-1.6.4.jar,
  .

--- a/bundles/binding/org.openhab.binding.nikobus/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.nikobus/META-INF/MANIFEST.MF
@@ -21,10 +21,10 @@ Import-Package: org.apache.commons.lang,
  org.osgi.service.cm,
  org.osgi.service.component,
  org.osgi.service.event,
- org.slf4j
+ org.slf4j,
+ gnu.io
 Export-Package: org.openhab.binding.nikobus
 Bundle-DocURL: http://www.openhab.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/*.xml
 Bundle-ClassPath: .
-Require-Bundle: org.openhab.io.transport.serial;bundle-version="1.3.0"

--- a/bundles/binding/org.openhab.binding.stiebelheatpump/META-INF/MANIFEST.MF
+++ b/bundles/binding/org.openhab.binding.stiebelheatpump/META-INF/MANIFEST.MF
@@ -23,11 +23,11 @@ Import-Package: org.apache.commons.lang,
  org.osgi.service.cm,
  org.osgi.service.component,
  org.osgi.service.event,
- org.slf4j
+ org.slf4j,
+ gnu.io
 Export-Package: org.openhab.binding.stiebelheatpump;uses:="org.openhab.core.binding",
  org.openhab.binding.stiebelheatpump.internal
 Bundle-DocURL: http://www.openhab.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/binding.xml, OSGI-INF/genericbindingprovider.xml
 Bundle-ClassPath: . 
-Require-Bundle: org.openhab.io.transport.serial;bundle-version="1.4.0"

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <description>This is the open Home Automation Bus (openHAB)</description>
 
     <properties>
-        <ohdr.version>1.0.0</ohdr.version>
+        <ohdr.version>1.0.10</ohdr.version>
         <ohc.version>2.0.0.x</ohc.version>
         <jdeb-version>1.4</jdeb-version>
 


### PR DESCRIPTION
brings back gnu.io to fix the build

Signed-off-by: Kai Kreuzer <kai@openhab.org>