### PR TITLE
Add new device ID for ZWN-RSM2 (0101:5606)

### DIFF
--- a/bundles/binding/org.openhab.binding.zwave/database/enerwave/zwnrsm2.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/enerwave/zwnrsm2.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product>
+  <Model>ZWN-RSM2</Model>
+  <Label lang="en">Smart Dual Relay Switch Module</Label>
+
+  <CommandClasses>
+    <Class>
+      <id>0x00</id>
+      <!-- NO_OPERATION -->
+    </Class>
+    <Class>
+      <id>0x20</id>
+      <!-- BASIC -->
+    </Class>
+    <Class>
+      <id>0x25</id>
+      <!-- SWITCH_BINARY -->
+    </Class>
+    <Class>
+      <id>0x27</id>
+      <!-- SWITCH_ALL -->
+    </Class>
+    <Class>
+      <id>0x60</id>
+      <!-- MULTI_INSTANCE -->
+    </Class>
+    <Class>
+      <id>0x70</id>
+      <!-- CONFIGURATION -->
+    </Class>
+    <Class>
+      <id>0x72</id>
+      <!-- MANUFACTURER_SPECIFIC -->
+    </Class>
+    <Class>
+      <id>0x85</id>
+      <!-- ASSOCIATION -->
+    </Class>
+    <Class>
+      <id>0x86</id>
+      <!-- VERSION -->
+    </Class>
+    <Class>
+      <id>0x8E</id>
+      <!-- MULTI_INSTANCE_ASSOCIATION -->
+    </Class>
+  </CommandClasses>
+
+  <Configuration>
+
+    <Parameter>
+      <Index>3</Index>
+      <Label lang="en">Unsolicited Report Configuration</Label>
+      <Type>short</Type>
+      <Default>0</Default>
+      <Minimum>0</Minimum>
+      <Maximum>255</Maximum>
+      <Size>1</Size>
+      <Help>
+        <![CDATA[ZWN-RSM2 can send unsolicited status report to primary controller (Node ID 0X01) when switch toggled due to some controllers designed as gateway. If your controller is not a gateway or does not need the status or you think it could confuse your Z-Wave net
+            ]]>
+      </Help>
+    </Parameter>
+
+  </Configuration>
+
+</Product>

--- a/bundles/binding/org.openhab.binding.zwave/database/products.xml
+++ b/bundles/binding/org.openhab.binding.zwave/database/products.xml
@@ -2720,6 +2720,15 @@
             <Label lang="en">Scene Controller</Label>
             <ConfigFile>enerwave/zwn-sc7.xml</ConfigFile>
         </Product>
+        <Product>
+            <Reference>
+                <Type>0101</Type>
+                <Id>5606</Id>
+            </Reference>
+            <Model>ZWN-RSM2</Model>
+            <Label lang="en">Smart Dual Relay Switch Module</Label>
+            <ConfigFile>enerwave/zwnrsm2.xml</ConfigFile>
+        </Product>
     </Manufacturer>
     <Manufacturer>
         <Id>0001</Id>


### PR DESCRIPTION
Related to https://github.com/openhab/org.openhab.binding.zwave/issues/229, but for OH1. I exported the device from the database at www.cd-jackson.com. I added zwmrsm2.xml because the existing zwn-rsm2.xml in the same folder doesn't seem to match what was exported from the device database.