### PR TITLE
KNX-Binding: Changed warn to debug in log message 'Ignoring local events...'

### DIFF
--- a/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBinding.java
+++ b/bundles/binding/org.openhab.binding.knx/src/main/java/org/openhab/binding/knx/internal/bus/KNXBinding.java
@@ -186,7 +186,7 @@ public class KNXBinding extends AbstractBinding<KNXBindingProvider> implements P
                 && e.getSourceAddr().toString().equalsIgnoreCase(KNXConnection.getLocalSourceAddr()))) {
             readFromKNX(e);
         } else {
-            logger.warn("Ignoring local Event, received from my local Source address {} for Group address {}.",
+            logger.debug("Ignoring local Event, received from my local Source address {} for Group address {}.",
                     e.getSourceAddr().toString(), e.getDestination().toString());
         }
     }


### PR DESCRIPTION
Ignoring local events is the correct behaviour of the binding. This message only blows up my and probably logfiles of other users.

Signed-off-by: Sebastian Kutschbach <sebastian.kutschbach@freenet.de>